### PR TITLE
Point the website's APK download at open-historia.apk

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -347,7 +347,7 @@
         <h3>Android app</h3>
         <div class="meta">Thin client · ~6 MB</div>
         <p>A lightweight client that connects to a game server (a desktop on your network, or Termux on the same phone).</p>
-        <a class="btn btn-ghost" href="https://github.com/Open-Historia/open-historia/releases/download/android/pax-historia.apk">⬇ Download APK</a>
+        <a class="btn btn-ghost" href="https://github.com/Open-Historia/open-historia/releases/download/android/open-historia.apk">⬇ Download APK</a>
       </div>
     </div>
     <p class="hero-note" style="text-align:center;margin-top:22px">Already installed? Run the <b>Update Open Historia</b> script to grab the latest — your saves and scenarios are kept. · <a href="https://github.com/Open-Historia/open-historia/releases" target="_blank" rel="noopener">All releases</a></p>
@@ -450,7 +450,7 @@
   else if (/Linux/i.test(ua)) os = "linux";
 
   var STABLE = "https://github.com/Open-Historia/open-historia/releases/download/app-stable/Open-Historia.zip";
-  var APK = "https://github.com/Open-Historia/open-historia/releases/download/android/pax-historia.apk";
+  var APK = "https://github.com/Open-Historia/open-historia/releases/download/android/open-historia.apk";
 
   var label = { windows:"Download for Windows", mac:"Download for macOS", linux:"Download for Linux",
                 android:"Download the Android app", ios:"Download the Desktop app", desktop:"Download for Desktop" }[os];


### PR DESCRIPTION
Both APK download links on the site — the Android card and the OS-detecting hero button — now point at `open-historia.apk`.

**The asset already exists.** I published the same bytes under the new name on the `android` release first, so nothing 404s at any point:

```
open-historia.apk  6357157   sha256 0228c4b1bd6bd2604cbc…
pax-historia.apk   6357157   sha256 0228c4b1bd6bd2604cbc…
```

Verified by downloading the new URL and comparing hashes.

## Why pax-historia.apk stays published

`docs/delivery-and-deploy.md:74` says the name is contractual because the installed app self-updates from a fixed asset URL. That is now **stale for the code in the tree** — no application code resolves the APK by name any more; the boot-time check was removed when the in-app banner shipped (#503-505), and the banner reads whatever URL `latest.json` gives it.

But installs **in the wild** from before that change did poll the old filename, and removing it would strand them with no signal. Keeping both names costs 6 MB and removes the risk entirely.

## Not changed, deliberately

The Android **`appId`** (`io.github.arkniem.paxhistoria`) is untouched. Changing it makes Android treat the app as a different package — existing users can't update over the top, they'd have to uninstall and lose their data. Nothing about renaming the download requires it.

## Still outstanding

The workflows that build the APK (`android-apk.yml`, `android-apk-beta.yml`) still emit only `pax-historia.apk`, so the next build would publish the old name and leave `open-historia.apk` frozen at today's bytes. Fixing that needs a `workflow`-scoped push, which this token doesn't have — handed over separately as a patch.

Separately worth knowing: the `android` release has **no `latest.json`**, so the in-app update banner is inert on Android regardless of naming. The site's "download the newest build and run it over the top" line is currently the only Android update path.