### PR TITLE
Fix captured regions reporting their old owner, and one fuzzy name moving a whole nation

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -1047,6 +1047,12 @@ const resolveRegionTransfers = async (containers, world) => {
     return "";
   };
 
+  // How many regions an UNFLAGGED transfer may move by being reinterpreted as a
+  // polity name. A real whole-country handover is dozens of regions and should say
+  // so with wholeCountry:true; a handful is the plausible size of a region/polity
+  // name collision, which is the case this fallback exists for.
+  const IMPLICIT_WHOLE_COUNTRY_LIMIT = 3;
+
   const unresolved = [];
   for (const { impacts, path } of containers) {
     const transfers = normalizeArray(impacts?.regionTransfers);
@@ -1073,16 +1079,35 @@ const resolveRegionTransfers = async (containers, world) => {
         resolved.push(transfer);
         continue;
       }
-      // Not a region the map knows — but it may be a POLITY the model meant wholesale
-      // ("Austria-Hungary is partitioned"). Expanding beats dropping the change.
+      // Not a region the map knows — it MAY be a POLITY the model meant wholesale
+      // ("Austria-Hungary is partitioned"). But the prompt also tells the model to
+      // put a plain REGION name in regionId whenever it does not know the id, so an
+      // unmatched name is the ROUTINE case here, not an exceptional one. Expanding
+      // every one of them meant a single fuzzy name could hand over an entire
+      // nation's territory in a turn whose events never mentioned it — reported as
+      // "captured one region and it reverted all of Ukraine".
+      //
+      // An explicit wholeCountry:true still expands without limit (handled above);
+      // that is the model saying it means a whole nation. Without the flag, accept
+      // an expansion only while it is small enough to be a genuine name collision.
+      // Anything larger goes to the retry, which names the exact region that failed
+      // to match — and if the retry runs out, dropping one transfer is a far smaller
+      // failure than silently moving a country.
       const expanded = expandWholeCountry(transfer);
-      if (expanded.length) {
+      if (expanded.length && expanded.length <= IMPLICIT_WHOLE_COUNTRY_LIMIT) {
         console.info(
           `[ai] ${path}.regionTransfers treated "${normalizeString(transfer?.regionId)}" as a whole ` +
             `country -> ${normalizeString(transfer?.toCode)}: ${expanded.length} region(s).`,
         );
         resolved.push(...expanded);
         continue;
+      }
+      if (expanded.length) {
+        console.warn(
+          `[ai] ${path}.regionTransfers REFUSED to treat "${normalizeString(transfer?.regionId)}" as a ` +
+            `whole country -> ${normalizeString(transfer?.toCode)}: it would move ${expanded.length} ` +
+            `regions and the transfer did not set wholeCountry. Asking for an exact region id instead.`,
+        );
       }
       unresolved.push({
         label: normalizeString(transfer?.regionName) || normalizeString(transfer?.regionId),

--- a/src/Game/Selection/Regions.jsx
+++ b/src/Game/Selection/Regions.jsx
@@ -177,15 +177,27 @@ const RegionPopup = () => {
     };
 
     // Era-aware display name for the selected owner (polity name > overrides > modern).
-    const resolveSelectionName = (sel) =>
-        polities[sel?.GID_0]?.name || resolveCountryDisplayName(sel?.COUNTRY, sel?.GID_0);
+    // Who holds this region NOW. GID_0 is the country baked into the PMTiles and
+    // never changes, so keying the panel on it left a captured region showing its
+    // previous owner's name, flag and stat sheet — and opening diplomacy with the
+    // nation that just lost it. The click handler already resolves the live owner
+    // (Nations.jsx: props.owner, else the ownership lookup); this just uses it.
+    // Falls back to GID_0 so an unclaimed region reads exactly as it did before.
+    const selectionOwner = (sel) => String(sel?.owner ?? "").trim() || sel?.GID_0 || "";
+
+    const resolveSelectionName = (sel) => {
+        const owner = selectionOwner(sel);
+        return polities[owner]?.name
+            || resolveCountryDisplayName(sel?.COUNTRY, owner)
+            || owner;
+    };
 
     // Open a diplomatic chat with the selected country (via the chat panel bridge).
     const handleOpenChat = () => {
         if (!_currentSelection) return;
         requestDiplomaticChat({
             name: resolveSelectionName(_currentSelection),
-            code: _currentSelection.GID_0,
+            code: selectionOwner(_currentSelection),
         });
         _dismiss?.();
     };
@@ -195,9 +207,10 @@ const RegionPopup = () => {
     const handleToggleStats = () => {
         const sel = _currentSelection;
         if (!sel) return;
-        const flagInfo = resolveEraFlagInfo(sel.GID_0, polities[sel.GID_0], customFlags);
+        const owner = selectionOwner(sel);
+        const flagInfo = resolveEraFlagInfo(owner, polities[owner], customFlags);
         openCountryPanel({
-            code: sel.GID_0,
+            code: owner,
             name: resolveSelectionName(sel),
             flagUrl: flagInfo?.imageUrl || null,
             flagEmoji: flagInfo?.emoji || null,
@@ -229,7 +242,8 @@ const RegionPopup = () => {
         // Era-correct flag only: the polity's own flag, else the owner's ISO flag.
         // Deliberately NO modern-country fallback — an era polity without a flag
         // shows "No flag available" rather than an anachronistic modern flag.
-        const flagInfo = resolveEraFlagInfo(selection.GID_0, polities[selection.GID_0], customFlags);
+        const owner = selectionOwner(selection);
+        const flagInfo = resolveEraFlagInfo(owner, polities[owner], customFlags);
         setFlagState(
             flagInfo
                 ? createFlagState("ready", flagInfo.imageUrl, flagInfo.emoji)


### PR DESCRIPTION
Closes the report: *"invaded Ukraine, sometimes would capture a region and it would revert all of Ukraine's states back to its control, even if the event only said i captured one"*.

That report contains **two unrelated bugs**. The reporter's hypothesis — that ownership never changes internally, and the stale flag confuses the AI — is not the cause: ownership does persist, and the AI never reads the UI. But both of their observations are real.

## 1. A captured region still reports its previous owner

`Regions.jsx` keyed the whole panel on `GID_0`, the country baked into the PMTiles, which never changes when land does. On a captured region that meant:

- the **flag** stayed the old nation's
- so did the **name** and the **stat sheet**
- and **Open chat** started diplomacy with the nation that had just lost it

The click handler already resolves the live owner (`Nations.jsx`: `props.owner`, else the ownership lookup), and the popup effect even lists `selection.owner` in its deps — the value was simply never used. Everything now routes through one `selectionOwner()` helper, falling back to `GID_0` so an unclaimed region reads exactly as before.

This also fixes era polities as a side effect: `gidToAlpha2` matches on country **name** before code, and `polityOverrides` has been name-keyed since the owner migration, so a `GID_0` code missed both lookups.

## 2. One unmatched name could hand over an entire country

This is what actually moves the map, and it is not a display problem. Ownership persists correctly — `applyEventImpactsToWorld` writes the override, and `toCountryName` passes unknown polity names through untouched, so nothing is silently dropped.

The cause is the resolver's fallback in `gameplay.js`: when a `regionTransfers` entry names no known region, it reinterpreted that name as a **polity** and handed over **every region that polity owned**.

The prompt tells the model to put a plain region name in `regionId` whenever it does not know the id — so an unmatched name is the **routine** case here, not an exceptional one. Any of them could move a nation in a turn whose events never mentioned it, which is exactly what was reported.

An explicit `wholeCountry: true` still expands without limit; that is the model stating it means a whole nation. Without the flag, an implicit expansion is now capped at **3 regions** — the plausible size of a region/polity name collision, which is the case this fallback exists for. Anything larger is refused, logged loudly, and sent back through the existing retry, which names the exact region that failed to match. If the retry runs out, dropping one transfer is a far smaller failure than silently moving a country.

## Verifying against a report

This path already logs itself, so an affected save can be confirmed from the console:

```
[ai] ....regionTransfers treated "<name>" as a whole country -> <toCode>: N region(s).
```

After this change, the dangerous case instead logs:

```
[ai] ....regionTransfers REFUSED to treat "<name>" as a whole country -> <toCode>: it would move N regions and the transfer did not set wholeCountry.
```

## Testing

`npm run build` passes and all 26 server tests pass. The two changes are independent — #1 is presentation only, #2 does not touch how transfers are applied, only which ones are accepted.