### PR TITLE
Archive games instead of deleting them

### DIFF
--- a/server/libraryStore.js
+++ b/server/libraryStore.js
@@ -656,6 +656,9 @@ const readGameMeta = (gameId) => {
 
   return {
     accentColor: String(raw?.accentColor ?? "").trim() || DEFAULT_GAME_META.accentColor,
+    // Hidden from the library but fully intact on disk — the "I want it out of
+    // the way, not gone" case that delete cannot serve.
+    archived: raw?.archived === true,
     coverImageContentType: readStoredImageContentType(raw?.coverImageContentType),
     createdAt: raw?.createdAt ?? new Date().toISOString(),
     description,
@@ -1709,6 +1712,7 @@ const updateGame = (
   gameId,
   {
     accentColor,
+    archived,
     description,
     eyebrow,
     game,
@@ -1734,6 +1738,7 @@ const updateGame = (
   const currentMeta = readGameMeta(gameId);
   writeGameMeta(gameId, {
     accentColor: String(accentColor ?? currentMeta.accentColor).trim() || currentMeta.accentColor,
+                archived: typeof archived === "boolean" ? archived : currentMeta.archived,
                 description: String(description ?? currentMeta.description).trim() || currentMeta.description,
                 eyebrow: String(eyebrow ?? currentMeta.eyebrow).trim() || currentMeta.eyebrow,
                 heroSubtitle:
@@ -1742,6 +1747,29 @@ const updateGame = (
                 name: String(name ?? currentMeta.name).trim() || currentMeta.name,
                 subtitle: String(subtitle ?? currentMeta.subtitle).trim() || currentMeta.subtitle,
   });
+
+  // Archiving the game you are currently IN would hide it from the library while
+  // leaving it active: the player is dropped into a session they can no longer
+  // see, or switch away from, because switching happens from the list it just
+  // left. Hand the active slot to the most recently played game that is still
+  // visible. Enforced here rather than in the UI so a direct API call cannot
+  // skip it, and only on the archive transition so unarchiving stays inert.
+  if (archived === true && !currentMeta.archived) {
+    const manifest = getGameManifest();
+    if (manifest.activeGameId === gameId) {
+      const fallback = resolveOrderedIds(manifest.order, GAMES_DIR, DEFAULT_GAME_ID)
+        .filter((id) => id !== gameId && fs.existsSync(getGameMetaPath(id)))
+        .map((id) => readGameMeta(id))
+        .filter((meta) => !meta.archived)
+        .sort((left, right) => String(right.lastPlayedAt ?? "").localeCompare(String(left.lastPlayedAt ?? "")))[0];
+      // Only reassign when there is somewhere to go. Archiving the LAST visible
+      // game leaves it active on purpose: you have to be in some game, and it is
+      // still reachable and marked Current on the Archived shelf. Blanking the id
+      // instead would just make buildGameCatalog re-elect games[0] anyway, which
+      // is the same outcome reached by accident.
+      if (fallback) saveGameManifest({ ...manifest, activeGameId: fallback.id });
+    }
+  }
 
   // See the note in updateScenario: game.country is an owner reference and needs
   // the world to resolve a preset's polity.

--- a/src/Game/GameUI/libraryBar.jsx
+++ b/src/Game/GameUI/libraryBar.jsx
@@ -516,7 +516,7 @@ const ScenarioCard = ({ onClone, onEdit, onPlay, onSelect, onUpdate, scenario, s
   );
 };
 
-const GameCard = ({ active, game, onActivate, onClone, onEdit }) => {
+const GameCard = ({ active, game, onActivate, onArchive, onClone, onEdit }) => {
   const cardImageUrl = game.coverImageUrl || "/loading_screen.jpg";
 
   return (
@@ -610,8 +610,19 @@ const GameCard = ({ active, game, onActivate, onClone, onEdit }) => {
             <button onClick={() => onEdit(game.id)} style={{ ...actionButtonStyle, flex: 1 }} type="button">
               Edit
             </button>
-            <button onClick={() => onClone(game)} style={{ ...actionButtonStyle, flexBasis: "100%" }} type="button">
-              Clone Game
+            <button onClick={() => onClone(game)} style={{ ...actionButtonStyle, flex: 1 }} type="button">
+              Clone
+            </button>
+            {/* Hide a finished or abandoned run without destroying it — the case
+                Delete cannot serve. Archiving the ACTIVE game is allowed: the
+                server hands the active slot to another game first. */}
+            <button
+              onClick={() => onArchive(game)}
+              style={{ ...actionButtonStyle, flexBasis: "100%" }}
+              title={game.archived ? "Move back into your library" : "Hide from the library without deleting"}
+              type="button"
+            >
+              {game.archived ? "Unarchive" : "Archive"}
             </button>
           </div>
         </div>
@@ -1395,6 +1406,15 @@ const LibraryTopBar = () => {
 
   // Play an existing game from the menu: close the menu (module flag first —
   // the activation remounts the UI) and activate. Reopen only on failure.
+  const handleGameArchive = async (game) => {
+    setEditorError(null);
+    try {
+      await saveGame(game.id, { archived: !game.archived });
+    } catch (nextError) {
+      setEditorError(nextError.message);
+    }
+  };
+
   const handleGameActivate = async (gameId) => {
     setMenuOpen(false);
     try {
@@ -1962,13 +1982,22 @@ const LibraryTopBar = () => {
   // The catalog's game order is already activation recency (activating unshifts),
   // so games without a lastPlayedAt stamp (pre-feature saves) keep a sensible
   // relative order behind the stamped ones.
-  const lastPlayedGames = useMemo(
-    () => [...games].sort((a, b) => String(b.lastPlayedAt ?? "").localeCompare(String(a.lastPlayedAt ?? ""))),
+  // Archived games stay in the catalog (and keep their playCount and events) but
+  // leave the normal shelves, so a long library is the games you actually play.
+  const visibleGames = useMemo(() => games.filter((game) => !game.archived), [games]);
+  const archivedGames = useMemo(
+    () => games
+      .filter((game) => game.archived)
+      .sort((a, b) => String(b.lastPlayedAt ?? "").localeCompare(String(a.lastPlayedAt ?? ""))),
     [games],
   );
+  const lastPlayedGames = useMemo(
+    () => [...visibleGames].sort((a, b) => String(b.lastPlayedAt ?? "").localeCompare(String(a.lastPlayedAt ?? ""))),
+    [visibleGames],
+  );
   const mostPlayedGames = useMemo(
-    () => [...games].sort((a, b) => (b.playCount ?? 0) - (a.playCount ?? 0) || (b.round ?? 0) - (a.round ?? 0)),
-    [games],
+    () => [...visibleGames].sort((a, b) => (b.playCount ?? 0) - (a.playCount ?? 0) || (b.round ?? 0) - (a.round ?? 0)),
+    [visibleGames],
   );
   const mostPlayedScenarios = useMemo(
     () => [...scenarios].sort((a, b) => (b.playCount ?? 0) - (a.playCount ?? 0) || (b.gameCount ?? 0) - (a.gameCount ?? 0)),
@@ -2404,7 +2433,7 @@ const LibraryTopBar = () => {
                 <CommunityPanel fullPage onImported={() => setActiveTab("scenarios")} />
               </Suspense>
             ) : activeTab === "games" ? (
-              loaded && games.length === 0 ? (
+              loaded && visibleGames.length === 0 && archivedGames.length === 0 ? (
                 <div style={{ alignItems: "center", display: "flex", flexDirection: "column", justifyContent: "center", minHeight: "60vh", textAlign: "center" }}>
                   <img alt="" src="/logo.png" style={{ height: "5rem", marginBottom: "1.2rem", opacity: 0.9, width: "5rem" }} />
                   <div style={{ fontSize: "1.5rem", fontWeight: 800, letterSpacing: "-0.02em" }}>No games yet</div>
@@ -2437,6 +2466,7 @@ const LibraryTopBar = () => {
                         active={game.id === activeGameId}
                         game={game}
                         onActivate={handleGameActivate}
+                        onArchive={handleGameArchive}
                         onClone={handleGameClone}
                         onEdit={openGameEditor}
                       />
@@ -2449,11 +2479,27 @@ const LibraryTopBar = () => {
                         active={game.id === activeGameId}
                         game={game}
                         onActivate={handleGameActivate}
+                        onArchive={handleGameArchive}
                         onClone={handleGameClone}
                         onEdit={openGameEditor}
                       />
                     ))}
                   </MenuRow>
+                  {archivedGames.length > 0 && (
+                    <MenuRow title={`🗄️ Archived (${archivedGames.length})`}>
+                      {archivedGames.map((game) => (
+                        <GameCard
+                          key={game.id}
+                          active={game.id === activeGameId}
+                          game={game}
+                          onActivate={handleGameActivate}
+                          onArchive={handleGameArchive}
+                          onClone={handleGameClone}
+                          onEdit={openGameEditor}
+                        />
+                      ))}
+                    </MenuRow>
+                  )}
                 </>
               )
             ) : (


### PR DESCRIPTION
First of the seven-feature batch. A finished or abandoned run has only ever had one exit: **Delete**. Archiving hides it from the library while leaving the save, its events and its `playCount` fully intact.

## Server

Game meta gains an `archived` flag. `buildGameCatalog` spreads `...meta`, so the catalog picks it up for free — but `updateGame`'s parameter list is an explicit **allow-list**, and a field not named there is silently ignored, so it has to be declared to be settable at all.

**Archiving the game you are currently in** is allowed and handled server-side: the active slot moves to the most recently played game that is still visible. Enforced in `updateGame` rather than in the UI so a direct API call cannot skip it, and only on the archive transition so unarchiving stays inert.

Archiving the **last visible** game deliberately leaves it active — you have to be in some game, and it stays reachable and marked *Current* on the Archived shelf. Blanking the id instead would just make `buildGameCatalog` re-elect `games[0]` anyway, which is the same outcome reached by accident.

## Client

The library shelves now read from the unarchived set, with an **Archived (n)** shelf that only appears once something is in it. The "No games yet" empty state counts both sets, so archiving everything does not replace the menu with three empty rows and no way forward.

## Testing

`npm run build` passes and all 26 server tests pass. Verified in a browser against a two-game fixture:

- archive → leaves the shelves, appears under Archived with an **Unarchive** button
- archiving the **active** game → active slot moves to the other game
- archiving the **last visible** game → slot stays, game still reachable and marked Current
- rename after archiving → `archived` is not clobbered
- values persist to `game-instance.json` across a server restart

## Unrelated note

`dist-site/` is not in `.gitignore` (only `dist`, `dist-web`, `dist-ssr` are), so `npm run build:site` leaves an untracked build directory that is easy to commit by accident. Worth a one-line addition, separately.