### PR TITLE
Let the Improve button stop what it started

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -1832,11 +1832,16 @@ export const generateCountryStatSheet = async ({ code, name } = {}) => {
   return payload;
 };
 
-export const refinePlayerAction = async (rawInput, { persist = true } = {}) => {
+export const refinePlayerAction = async (rawInput, { persist = true, signal } = {}) => {
   const bundle = await readGameStateBundle({ force: true });
   const variables = await buildTemplateVariables(bundle, { actionInput: rawInput });
   const { payload } = await runJsonTask("descriptionToAction", {
     fallback: () => fallbackDescriptionToAction(rawInput, bundle),
+    // Improve can be stopped mid-generation, exactly like a timeline jump.
+    // runJsonTask already links an external signal to the controller it hands
+    // the provider, so on a local model the next token write fails and inference
+    // stops rather than running to completion unheard.
+    signal,
     userMessage: "Convert the player's raw intent into one structured in-game command as JSON only.",
     variables,
   });

--- a/src/Game/GameUI/actions.jsx
+++ b/src/Game/GameUI/actions.jsx
@@ -48,6 +48,12 @@ const SparkleIcon = () => (
     </svg>
 );
 
+const StopIcon = () => (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <rect x="6" y="6" width="12" height="12" rx="2" />
+    </svg>
+);
+
 const SendIcon = () => (
     <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
     <path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z" />
@@ -234,6 +240,9 @@ const ActionsPanel = ({ isOpen, onClose, onOpenAdvisor }) => {
     const [hasRequestedSuggestions, setHasRequestedSuggestions] = React.useState(false);
     const [isSubmitting, setIsSubmitting] = React.useState(false);
     const [isImproving, setIsImproving] = React.useState(false);
+    // Holds the in-flight improve's AbortController so the button can stop it,
+    // the same shape as the timeline jump's cancel (time.jsx jumpAbortRef).
+    const improveAbortRef = React.useRef(null);
     const [isSuggesting, setIsSuggesting] = React.useState(false);
     const inputRef = React.useRef(null);
     const lastRoundRef = React.useRef(null);
@@ -341,16 +350,27 @@ const ActionsPanel = ({ isOpen, onClose, onOpenAdvisor }) => {
         }
 
         setIsImproving(true);
+        const controller = new AbortController();
+        improveAbortRef.current = controller;
         try {
-            const refined = await refinePlayerAction(trimmed, { persist: false });
+            const refined = await refinePlayerAction(trimmed, { persist: false, signal: controller.signal });
             const improvedText = refined?.text || buildActionDisplayText(refined) || trimmed;
             setInputValue(improvedText);
             inputRef.current?.focus();
         } catch (error) {
-            console.error("Failed to improve action:", error);
+            // Stopping on purpose is not a failure, and it must leave the text the
+            // player typed exactly as it was.
+            if (error?.name !== "AbortError") {
+                console.error("Failed to improve action:", error);
+            }
         } finally {
+            improveAbortRef.current = null;
             setIsImproving(false);
         }
+    };
+
+    const handleStopImprove = () => {
+        improveAbortRef.current?.abort(new DOMException("Improve cancelled.", "AbortError"));
     };
 
     const handleDelete = async (index) => {
@@ -651,16 +671,16 @@ const ActionsPanel = ({ isOpen, onClose, onOpenAdvisor }) => {
         />
         <button
         type="button"
-        onClick={handleImprove}
-        title="Improve action text"
-        aria-label="Improve action text"
+        onClick={isImproving ? handleStopImprove : handleImprove}
+        title={isImproving ? "Stop generating" : "Improve action text"}
+        aria-label={isImproving ? "Stop generating" : "Improve action text"}
         style={{
             alignItems: "center",
             background: "none",
             border: "none",
             borderRadius: "8px",
-            color: inputValue.trim() ? "rgba(196,165,255,0.78)" : "rgba(196,165,255,0.35)",
-            cursor: inputValue.trim() ? "pointer" : "default",
+            color: isImproving || inputValue.trim() ? "rgba(196,165,255,0.78)" : "rgba(196,165,255,0.35)",
+            cursor: isImproving || inputValue.trim() ? "pointer" : "default",
             display: "flex",
             height: "1.8rem",
             justifyContent: "center",
@@ -671,7 +691,7 @@ const ActionsPanel = ({ isOpen, onClose, onOpenAdvisor }) => {
             width: "1.8rem",
         }}
         >
-        {isImproving ? <SpinnerRing size={14} tone="rgba(196,165,255,0.9)" /> : <SparkleIcon />}
+        {isImproving ? <StopIcon /> : <SparkleIcon />}
         </button>
         </div>
 


### PR DESCRIPTION
Second of the seven-feature batch. Pressing **Improve** by mistake meant waiting out the whole completion — on a local model, the length of a full generation with no way to take it back.

## The cancellation was already built

It just wasn't offered here. `runJsonTask` takes a `signal`, links it to the controller it hands the provider, and rethrows the abort reason (`gameplay.js:392,491-495,597`). The timeline jump has used it since Cancel was added (`time.jsx` `jumpAbortRef` / `cancelJump`). `refinePlayerAction` was the one caller that never passed one through — so this is a one-line change on the AI side plus the button.

## The button

While generating, the same button becomes **Stop** — a stop square in place of the sparkle, with the label and handler swapped. It stays enabled with an empty input in that state, since the point is to stop a run that is already going.

`AbortError` is swallowed rather than logged: stopping on purpose is not a failure, and the text the player typed is left exactly as it was.

## Testing

Verified in a browser against an endpoint that accepts a request and never answers. Aborting produced `AbortError` client-side, and the server logged:

```
open POST /v1/chat/completions total 2
ABORTED by client, total 2
socket closed; aborted so far 2
```

That socket teardown is the property the whole feature rests on — it is why a local llama.cpp/Ollama server notices on its next token write and stops, rather than burning through the completion unheard (see the note at `AI/main.jsx:351`).

`npm run build` passes and all 26 server tests pass.

One thing I could not click through end to end: the Actions panel needs an active game with a country selected, which the bare test fixture had no map data for. The button swap itself is a ternary on the existing `isImproving` state, and all three new strings are present in the built bundle.