### PR TITLE
Take back the last point while drawing a region

### DIFF
--- a/src/Editor/OlMap.jsx
+++ b/src/Editor/OlMap.jsx
@@ -185,6 +185,12 @@ const OlMap = ({
   const interactionsRef = useRef([]);
   const undoStackRef = useRef([]);
   const redoStackRef = useRef([]);
+  // The live Draw interaction and the points the map-maker has actually CLICKED
+  // during the current sketch. Tracked here rather than read off the sketch
+  // geometry because trace mode appends a run of vertices per click: "the point
+  // you just placed" means the click, not each traced vertex.
+  const activeDrawRef = useRef(null);
+  const placedPointsRef = useRef([]);
   const onFeatureCreateRef = useRef(onFeatureCreate);
   onFeatureCreateRef.current = onFeatureCreate;
   const onFeatureEditRef = useRef(onFeatureEdit);
@@ -548,7 +554,19 @@ const OlMap = ({
       // Ctrl/Cmd+Z undo, Ctrl/Cmd+Shift+Z or Ctrl+Y redo
       if ((e.ctrlKey || e.metaKey) && !typing) {
         const k = e.key.toLowerCase();
-        if (k === "z" && !e.shiftKey) { e.preventDefault(); doUndo(); return; }
+        if (k === "z" && !e.shiftKey) {
+          e.preventDefault();
+          // Mid-sketch, Ctrl+Z belongs to the sketch. Undoing a whole region
+          // operation out from under an unfinished outline is never what the
+          // map-maker meant, and there is no way back to the half-drawn shape.
+          if (activeDrawRef.current && placedPointsRef.current.length > 0) {
+            activeDrawRef.current.removeLastPoint();
+            placedPointsRef.current.pop();
+            return;
+          }
+          doUndo();
+          return;
+        }
         if ((k === "z" && e.shiftKey) || k === "y") { e.preventDefault(); doRedo(); return; }
       }
       // Delete / Backspace removes the current selection
@@ -885,8 +903,58 @@ const OlMap = ({
       // and shares their exact vertices — which is what keeps borders gap-free.
       // Snap is still added below: trace follows a border once you are ON it,
       // Snap is what gets you onto it.
-      const draw = new Draw({ source, type: "Polygon", trace: true, traceSource: source });
+      // Clicking the point you just placed takes it back, rather than finishing
+      // the polygon on it (OL's default). Overshooting a corner is the common
+      // mistake and it had no cheap fix — the shape had to be finished wrong and
+      // redrawn. Finishing still works by clicking the FIRST point or by
+      // double-clicking, so there are two ways out.
+      const CLICK_SLOP_PX = 12;
+      const atLastPlaced = (event) => {
+        const placed = placedPointsRef.current;
+        // Needs at least two points: taking back the only point would leave a
+        // sketch with nothing in it, which OL has no state for.
+        if (placed.length < 2 || !event.map) return false;
+        const lastPixel = event.map.getPixelFromCoordinate(placed[placed.length - 1]);
+        if (!lastPixel || !event.pixel) return false;
+        return Math.hypot(event.pixel[0] - lastPixel[0], event.pixel[1] - lastPixel[1]) <= CLICK_SLOP_PX;
+      };
+
+      const draw = new Draw({
+        source,
+        type: "Polygon",
+        trace: true,
+        traceSource: source,
+        condition: (event) => {
+          // Modifier-clicks stay OL's business (this mirrors its default
+          // noModifierKeys) so ctrl-click never silently drops a point.
+          const oe = event.originalEvent;
+          if (oe && (oe.ctrlKey || oe.metaKey || oe.altKey || oe.shiftKey)) return false;
+          if (atLastPlaced(event)) {
+            draw.removeLastPoint();
+            placedPointsRef.current.pop();
+            return false; // consumed: take the point back instead of adding one
+          }
+          placedPointsRef.current.push(event.coordinate);
+          return true;
+        },
+        // No finishCondition on purpose. OL evaluates condition on pointerdown
+        // and only reaches the finish check if it returned TRUE, so a click that
+        // takes the last point back can never also finish the polygon — the
+        // remove already short-circuits it. Adding one here actively broke
+        // closing: condition pushes the clicked coordinate, and a finishCondition
+        // recomputed in the same event then sees that point as "the last placed"
+        // and refuses to close on the first vertex.
+      });
+      activeDrawRef.current = draw;
+      draw.on("drawstart", () => {
+        // The click that starts a sketch already went through condition above,
+        // so the first point is recorded; anything left from an aborted sketch
+        // is not.
+        placedPointsRef.current = placedPointsRef.current.slice(-1);
+      });
+      draw.on("drawabort", () => { placedPointsRef.current = []; });
       draw.on("drawend", (e) => {
+        placedPointsRef.current = [];
         const f = e.feature;
         f.setId(newId());
         if (f.get("typeId") == null) f.set("typeId", defaultTypeIdRef.current || "land");
@@ -986,6 +1054,11 @@ const OlMap = ({
     return () => {
       added.forEach((i) => map.removeInteraction(i));
       interactionsRef.current = [];
+      // Switching tools abandons any half-drawn sketch, so Ctrl+Z has to go back
+      // to meaning "undo the last region operation" rather than calling into a
+      // Draw the map no longer owns.
+      activeDrawRef.current = null;
+      placedPointsRef.current = [];
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTool]);


### PR DESCRIPTION
Third of the seven-feature batch. Overshooting a corner mid-outline had no cheap fix — the shape had to be finished wrong and redrawn. Two ways to take a point back now: **Ctrl/Cmd+Z**, and **clicking the point you just placed**.

## Ctrl+Z is guarded on an open sketch

Without the guard it popped the region-level undo stack instead, undoing a whole finished operation out from under a half-drawn outline — with no way back to the sketch. Mid-draw, the key belongs to the draw.

## Clicking the last placed point removes it

Rather than finishing the polygon on it, which was OL's default. Closing still works on the **first** point, so there is still a way out.

Points are tracked as **clicks**, not read off the sketch geometry: trace mode appends a run of vertices per click, and "the point you just placed" means the click.

## No finishCondition, deliberately

OL evaluates `condition` on pointerdown and only reaches the finish check if it returned `true` — so a click that takes a point back can never also finish; the remove already short-circuits it.

Adding one actively **broke closing**: `condition` pushes the clicked coordinate, and a `finishCondition` recomputed in the same event then sees that point as "the last placed" and refuses to close on the first vertex. I only found this by drawing in a browser — it reads fine.

## Testing

Verified in the real editor against the 3,661-region world seed, in open ocean where trace mode does not engage:

| case | result |
| --- | --- |
| 4 clicks, closed on the first point | clean **5-vertex** square — drawing and closing still work |
| same 4 clicks, 4th clicked again before closing | **4-vertex** shape — that point was removed |
| Ctrl+Z mid-sketch, with a region already drawn | region count held at **3662** rather than dropping to 3661 |

That last one is the case the guard exists for. `npm run build` passes and all 26 server tests pass.

One behaviour worth knowing: in **trace** mode a click can append many vertices, and `removeLastPoint()` takes back one vertex, not the whole traced run. That is OL's granularity rather than something this can control.