### PR TITLE
Log what happens, so a bug report can carry more than "it broke"

### DIFF
--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -29,6 +29,41 @@ const ASSETS_DIR = path.join(USER_ROOT, "public", "assets");
 process.env.OH_DATA_DIR = DATA_DIR;
 process.env.OH_ASSETS_DIR = ASSETS_DIR;
 
+// Main-process crashes are the ones that reach the player as a bare "A
+// JavaScript error occurred in the main process" dialog with nothing to act on —
+// the EADDRINUSE port clash was exactly that. They also happen BEFORE the server
+// exists, so this writes the same JSONL directly rather than POSTing to /api/log
+// like the page does. Same file, same shape; logStore.js owns rotation and
+// redaction for everything written later.
+const LOG_FILE = path.join(DATA_DIR, "logs", "app.log");
+const logMain = (level, event, message, data) => {
+  try {
+    fs.mkdirSync(path.dirname(LOG_FILE), { recursive: true });
+    fs.appendFileSync(LOG_FILE, JSON.stringify({
+      at: new Date().toISOString(),
+      level,
+      source: "main",
+      event,
+      message: String(message ?? "").slice(0, 8000),
+      ...(data === undefined ? {} : { data }),
+    }) + "\n", "utf8");
+  } catch {
+    // Diagnostics must never become the failure they were meant to explain.
+  }
+};
+
+process.on("uncaughtException", (error) => {
+  logMain("error", "main.uncaughtException", error && error.message, {
+    stack: error && error.stack ? String(error.stack).slice(0, 8000) : undefined,
+    code: error && error.code,
+  });
+});
+process.on("unhandledRejection", (reason) => {
+  logMain("error", "main.unhandledRejection", reason && (reason.message || String(reason)), {
+    stack: reason && reason.stack ? String(reason.stack).slice(0, 8000) : undefined,
+  });
+});
+
 // The build id the release workflow stamped in. The server passes it to the page so
 // the update banner can compare it against the published one. Deliberately routed
 // this way rather than through a preload: attaching a preload to the game window is
@@ -173,6 +208,7 @@ const startServer = async () => {
   const port = await findFreePort(requested);
   if (port !== requested) {
     console.log(`Port ${requested} is in use — starting Open Historia on ${port} instead.`);
+    logMain("warn", "server.portInUse", `Port ${requested} is in use; using ${port} instead.`);
   }
   // Both server.js and the loadURL below read this, so they cannot disagree.
   process.env.PORT = String(port);

--- a/server/logStore.js
+++ b/server/logStore.js
@@ -1,0 +1,115 @@
+/*! Open Historia — diagnostic log store © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// One append-only JSONL file the whole app writes to: the Electron main process,
+// this server, the page, and the AI layer. Bug reports arrive as "it broke" with
+// nothing to go on, and the interesting state — which prompt was sent, what the
+// model answered, which impacts were dropped — only ever existed in a console
+// nobody had open.
+//
+// Lives under the writable data dir (server/dataDir.js), so it lands beside the
+// saves in every build: server/data/logs for the zip, the Electron userData dir
+// for the installed app, and the sandbox path on Android.
+
+import fs from "fs";
+import path from "path";
+import { DATA_DIR } from "./dataDir.js";
+
+const LOG_DIR = path.join(DATA_DIR, "logs");
+const LOG_FILE = path.join(LOG_DIR, "app.log");
+// Five files of five megabytes. Big enough to hold a long session with full
+// prompts, small enough that the whole set can be attached to a bug report.
+const MAX_BYTES = 5 * 1024 * 1024;
+const MAX_FILES = 5;
+
+const LEVELS = new Set(["debug", "info", "warn", "error"]);
+const SOURCES = new Set(["main", "server", "client", "ai"]);
+
+// Redaction happens HERE rather than at each caller. A key can reach this file
+// from the page's provider settings, an AI request header, a relayed URL or a
+// pasted error message, and a redactor placed at any one of those eventually
+// misses a path. One choke point is the only version that stays true.
+//
+// Ordered widest-first: a bearer header wrapping a key must not be half-matched.
+const REDACTIONS = [
+  [/\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/gi, "$1 [redacted]"],
+  [/\b(sk|pk|rk)-[A-Za-z0-9_-]{8,}/g, "$1-[redacted]"],
+  [/\bAIza[A-Za-z0-9_-]{10,}/g, "[redacted-google-key]"],
+  [/\bgh[pousr]_[A-Za-z0-9]{16,}/g, "[redacted-github-token]"],
+  // key-ish assignments in JSON, query strings or prose
+  [/("?\b(?:api[_-]?key|apikey|access[_-]?token|authorization|password|secret)"?\s*[:=]\s*"?)([^"\s,&}]{6,})/gi, "$1[redacted]"],
+];
+
+export const redact = (value) => {
+  let text = typeof value === "string" ? value : JSON.stringify(value ?? null);
+  if (typeof text !== "string") return text;
+  for (const [pattern, replacement] of REDACTIONS) text = text.replace(pattern, replacement);
+  return text;
+};
+
+const rotate = () => {
+  try {
+    if (!fs.existsSync(LOG_FILE) || fs.statSync(LOG_FILE).size < MAX_BYTES) return;
+    // Drop the oldest, shuffle the rest down, then move the live file aside.
+    const oldest = `${LOG_FILE}.${MAX_FILES - 1}`;
+    if (fs.existsSync(oldest)) fs.rmSync(oldest, { force: true });
+    for (let index = MAX_FILES - 2; index >= 1; index -= 1) {
+      const from = `${LOG_FILE}.${index}`;
+      if (fs.existsSync(from)) fs.renameSync(from, `${LOG_FILE}.${index + 1}`);
+    }
+    fs.renameSync(LOG_FILE, `${LOG_FILE}.1`);
+  } catch {
+    // A failed rotation must never take the app down; the next append just
+    // grows the current file a little further.
+  }
+};
+
+// Never throws. Logging is diagnostics — a broken log must not become the
+// failure it was meant to explain.
+export const appendLog = (entry) => {
+  try {
+    const level = LEVELS.has(entry?.level) ? entry.level : "info";
+    const source = SOURCES.has(entry?.source) ? entry.source : "client";
+    const line = JSON.stringify({
+      at: new Date().toISOString(),
+      level,
+      source,
+      event: String(entry?.event ?? "").slice(0, 120),
+      message: redact(String(entry?.message ?? "")).slice(0, 8000),
+      // Free-form context: AI prompt/response bodies, request metadata, stacks.
+      // Redacted as a whole so a key nested anywhere inside is caught too.
+      ...(entry?.data === undefined ? {} : { data: redact(entry.data).slice(0, 200000) }),
+    });
+    fs.mkdirSync(LOG_DIR, { recursive: true });
+    rotate();
+    fs.appendFileSync(LOG_FILE, `${line}\n`, "utf8");
+  } catch {
+    // swallow: see above
+  }
+};
+
+export const appendLogBatch = (entries) => {
+  if (!Array.isArray(entries)) return 0;
+  // Bounded so one bad client cannot write a gigabyte in a single request.
+  const capped = entries.slice(0, 200);
+  for (const entry of capped) appendLog(entry);
+  return capped.length;
+};
+
+// Newest-last tail, for the in-app viewer. Reads only the live file: the
+// rotated ones are for attaching to a report, not for browsing.
+export const readLogTail = (limit = 500) => {
+  try {
+    if (!fs.existsSync(LOG_FILE)) return [];
+    const lines = fs.readFileSync(LOG_FILE, "utf8").split("\n").filter(Boolean);
+    return lines.slice(-Math.max(1, Math.min(5000, limit))).map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return { at: "", level: "warn", source: "server", event: "unparseable", message: line.slice(0, 500) };
+      }
+    });
+  } catch {
+    return [];
+  }
+};
+
+export const logFilePath = () => LOG_FILE;

--- a/server/server.js
+++ b/server/server.js
@@ -54,6 +54,7 @@ import {
   isAllowedHubUrl,
   parseByteRange,
 } from "./security.js";
+import { appendLog, appendLogBatch, readLogTail, logFilePath } from "./logStore.js";
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 import { DATA_DIR } from "./dataDir.js";
@@ -95,6 +96,15 @@ ensureBasemapStore();
 
 const sendError = (res, statusCode, error) => {
   const message = error instanceof Error ? error.message : String(error);
+  // Single choke point for every API failure, which is what makes logging them
+  // one line rather than forty.
+  appendLog({
+    level: statusCode >= 500 ? "error" : "warn",
+    source: "server",
+    event: `http.${statusCode}`,
+    message,
+    data: error instanceof Error && error.stack ? { stack: error.stack } : undefined,
+  });
   res.status(statusCode).json({ error: message });
 };
 
@@ -247,6 +257,33 @@ app.put("/api/ui-settings", jsonParser, (req, res) => {
     fs.mkdirSync(path.dirname(uiSettingsFile), { recursive: true });
     fs.writeFileSync(uiSettingsFile, JSON.stringify(next, null, 2));
     res.json(next);
+  } catch (error) {
+    sendError(res, 500, error);
+  }
+});
+
+// ---- Diagnostics log ------------------------------------------------------
+// The page, the AI layer and the Electron main process all write here, so a bug
+// report can carry what actually happened instead of "it broke". Redaction and
+// rotation live in logStore.js. This sits behind the same cross-origin write
+// guard as every other POST, so a random page cannot stuff the player's log.
+app.post("/api/log", largeJsonParser, (req, res) => {
+  try {
+    const body = req.body ?? {};
+    const written = Array.isArray(body.entries)
+      ? appendLogBatch(body.entries)
+      : (appendLog(body), 1);
+    res.json({ ok: true, written });
+  } catch (error) {
+    sendError(res, 400, error);
+  }
+});
+
+app.get("/api/log", (req, res) => {
+  try {
+    const limit = Number.parseInt(String(req.query.limit ?? "500"), 10);
+    res.setHeader("Cache-Control", "no-store");
+    res.json({ file: logFilePath(), entries: readLogTail(Number.isFinite(limit) ? limit : 500) });
   } catch (error) {
     sendError(res, 500, error);
   }

--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -1,5 +1,6 @@
 /*! Open Historia — portions (briefing dossiers + timeout/fallback hardening) © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
 import { callAI } from "./main.jsx";
+import { logAi } from "../../runtime/logClient.js";
 import { normalizePromptPack } from "./gameplayPrompts.js";
 import { getGameplayTool, validateGameplayPayload } from "./gameplaySchemas.js";
 import { toCountryName } from "../../runtime/ownerNames.js";
@@ -503,6 +504,15 @@ const runJsonTask = async (taskKey, {
 
   try {
     for (let outputAttempt = 1; outputAttempt <= 2; outputAttempt += 1) {
+      logAi("ai.request", `${taskKey} attempt ${outputAttempt}`, {
+        task: taskKey,
+        attempt: outputAttempt,
+        promptChars: systemPrompt.length,
+        historyMessages: Array.isArray(history) ? history.length : 0,
+        // The whole context, so "what does the AI actually know here" is
+        // answerable from the log rather than by re-deriving it.
+        systemPrompt,
+      });
       const response = await callAI(systemPrompt, history, {
         // No output-token cap. A long/action-heavy turn's JSON must not be truncated
         // mid-response — a cut-off response won't parse, so runJsonTask fell back to
@@ -587,6 +597,11 @@ const runJsonTask = async (taskKey, {
   } catch (error) {
     const actualError = controller.signal.aborted ? controller.signal.reason : error;
     failureReason = normalizeString(actualError?.message || actualError) || failureReason;
+    logAi("ai.failed", `${taskKey}: ${failureReason}`, {
+      task: taskKey,
+      aborted: controller.signal.aborted,
+      stack: actualError?.stack ? String(actualError.stack).slice(0, 4000) : undefined,
+    }, "error");
   } finally {
     if (timeoutId) clearTimeout(timeoutId);
   }

--- a/src/Game/GameUI/cheats.jsx
+++ b/src/Game/GameUI/cheats.jsx
@@ -37,6 +37,7 @@ const TOOLS = [
     { id: "add-feature", title: "Add Map Feature", subtitle: "Create new map features with custom properties" },
     { id: "clear-features", title: "Clear Map Features", subtitle: "Clean up old and irrelevant features" },
     { id: "events", title: "Events", subtitle: "Edit historical events and their descriptions" },
+    { id: "logs", title: "Diagnostics Log", subtitle: "Errors, API failures and the context the AI was given" },
 ];
 
 const inputStyle = {
@@ -332,6 +333,79 @@ const CheatsPanel = ({ open, onClose, onOpenForces }) => {
     );
 };
 
+// Reads the shared diagnostics log. Newest first, because the thing that just
+// went wrong is what the reporter is looking at.
+const LEVEL_TONE = { error: "#ff6b6b", warn: "#ffc861", info: "rgba(255,255,255,0.72)", debug: "rgba(255,255,255,0.45)" };
+
+const LogsPanel = ({ header }) => {
+    const [entries, setEntries] = React.useState([]);
+    const [file, setFile] = React.useState("");
+    const [onlyProblems, setOnlyProblems] = React.useState(false);
+    const [expanded, setExpanded] = React.useState(null);
+    const [note, setNote] = React.useState("");
+
+    const load = React.useCallback(async () => {
+        try {
+            const response = await fetch("/api/log?limit=500", { cache: "no-store" });
+            const data = await response.json();
+            setEntries(Array.isArray(data.entries) ? data.entries.slice().reverse() : []);
+            setFile(String(data.file || ""));
+        } catch (error) {
+            setNote(`Could not read the log: ${error.message}`);
+        }
+    }, []);
+
+    React.useEffect(() => { load(); }, [load]);
+
+    const shown = onlyProblems ? entries.filter((e) => e.level === "error" || e.level === "warn") : entries;
+
+    const copyAll = async () => {
+        try {
+            await navigator.clipboard.writeText(shown.map((e) => JSON.stringify(e)).join("\n"));
+            setNote(`Copied ${shown.length} entr${shown.length === 1 ? "y" : "ies"}.`);
+        } catch {
+            setNote("Clipboard blocked — the file path is shown above.");
+        }
+    };
+
+    return (
+        <>
+        {header}
+        <div style={{ display: "flex", flexWrap: "wrap", gap: "0.4rem", marginBottom: "0.6rem" }}>
+        <button type="button" style={buttonStyle} onClick={load}>Refresh</button>
+        <button type="button" style={buttonStyle} onClick={() => setOnlyProblems((v) => !v)}>
+        {onlyProblems ? "Showing problems" : "Showing everything"}
+        </button>
+        <button type="button" style={buttonStyle} onClick={copyAll}>Copy for a bug report</button>
+        </div>
+        {file && <div style={{ ...labelStyle, wordBreak: "break-all", marginBottom: "0.5rem" }}>{file}</div>}
+        {note && <div style={{ ...labelStyle, marginBottom: "0.5rem" }}>{note}</div>}
+        {shown.length === 0 && <div style={labelStyle}>Nothing logged yet.</div>}
+        {shown.map((entry, index) => (
+            <div key={index} style={{ borderBottom: "1px solid rgba(255,255,255,0.08)", padding: "0.4rem 0" }}>
+            <div
+            onClick={() => setExpanded(expanded === index ? null : index)}
+            style={{ cursor: entry.data ? "pointer" : "default", display: "flex", gap: "0.5rem", fontSize: "0.78rem" }}
+            >
+            <span style={{ color: "rgba(255,255,255,0.4)", whiteSpace: "nowrap" }}>{String(entry.at || "").slice(11, 19)}</span>
+            <span style={{ color: LEVEL_TONE[entry.level] || LEVEL_TONE.info, fontWeight: 700, whiteSpace: "nowrap" }}>{entry.source}</span>
+            <span style={{ color: "rgba(255,255,255,0.55)", whiteSpace: "nowrap" }}>{entry.event}</span>
+            <span style={{ color: "#fff", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{entry.message}</span>
+            {entry.data && <span style={{ color: "rgba(255,255,255,0.35)" }}>{expanded === index ? "▾" : "▸"}</span>}
+            </div>
+            {expanded === index && entry.data && (
+                <pre style={{
+                    background: "rgba(0,0,0,0.35)", borderRadius: 6, color: "rgba(255,255,255,0.8)",
+                    fontSize: "0.72rem", margin: "0.4rem 0 0", maxHeight: "18rem", overflow: "auto", padding: "0.5rem",
+                    whiteSpace: "pre-wrap", wordBreak: "break-word",
+                }}>{typeof entry.data === "string" ? entry.data : JSON.stringify(entry.data, null, 2)}</pre>
+            )}
+            </div>
+        ))}
+        </>
+    );
+};
+
 const ToolView = ({ tool, header, busy, status, game, polities, refresh, runBusy, beginClickMode, endClickMode, setStatus }) => {
     const meta = TOOLS.find((entry) => entry.id === tool);
     const [text, setText] = useState("");
@@ -373,6 +447,10 @@ const ToolView = ({ tool, header, busy, status, game, polities, refresh, runBusy
     const nameOf = (code) => politiesByCode.get(code)?.name || code || "unclaimed land";
 
     // ----- individual tools -----
+
+    if (tool === "logs") {
+        return <LogsPanel header={header} />;
+    }
 
     if (tool === "master-ai") {
         return (

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,6 +1,7 @@
 import { createRoot } from "react-dom/client";
 import { configureMapRuntime } from "./runtime/assets.js";
 import { startTranslator } from "./runtime/translator.js";
+import { installLogClient } from "./runtime/logClient.js";
 import App from "./App.jsx";
 import "maplibre-gl/dist/maplibre-gl.css";
 import "./styles.css";
@@ -16,6 +17,9 @@ const registerServiceWorker = () => {
 };
 
 const mount = () => {
+    // First, so a throw anywhere below is captured rather than lost to a console
+    // nobody had open.
+    installLogClient();
     configureMapRuntime();
     createRoot(document.getElementById("root")).render(
         <App />,

--- a/src/runtime/ErrorBoundary.jsx
+++ b/src/runtime/ErrorBoundary.jsx
@@ -1,5 +1,6 @@
 /*! Open Historia — React error boundary (recoverable render-crash fallback) © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
 import React from "react";
+import { logEvent } from "./logClient.js";
 
 // Catches render/lifecycle/constructor throws in the map, game UI and panels so a
 // crash shows a recoverable fallback (with a Reload) instead of React unmounting the
@@ -20,6 +21,12 @@ class ErrorBoundary extends React.Component {
 
   componentDidCatch(error, info) {
     console.error("Render crash caught by ErrorBoundary:", error, info?.componentStack);
+    logEvent({
+      level: "error",
+      event: "render.crash",
+      message: String(error?.message ?? error),
+      data: { stack: String(error?.stack ?? "").slice(0, 8000), componentStack: info?.componentStack },
+    });
   }
 
   handleReload = () => {

--- a/src/runtime/logClient.js
+++ b/src/runtime/logClient.js
@@ -1,0 +1,109 @@
+/*! Open Historia — client-side diagnostic logging © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// Ships page-side events to the server's log file (server/logStore.js), which is
+// the one place the whole app writes to.
+//
+// Deliberately routed through the server rather than an Electron preload: the
+// game window has no preload on purpose — attaching one is what broke the app
+// last time (see electron/main.cjs, which routes the build id the same way).
+// Going through the API also means the zip build, Termux and the website all log
+// the same way, with no per-platform branch.
+
+const ENDPOINT = "/api/log";
+// Batched because a render loop that throws can produce hundreds of identical
+// errors a second, and one request per error would turn a bug into an outage.
+const FLUSH_MS = 2000;
+const MAX_QUEUE = 200;
+
+let queue = [];
+let timer = null;
+let installed = false;
+// Set false after a failed POST so a server that is gone (or a website build with
+// no local server) stops retrying every two seconds forever.
+let enabled = true;
+
+const flush = async () => {
+  timer = null;
+  if (!enabled || queue.length === 0) return;
+  const entries = queue;
+  queue = [];
+  try {
+    await fetch(ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ entries }),
+      keepalive: true, // survives the page being closed mid-flush
+    });
+  } catch {
+    // Never re-queue: the failure is usually "no server", and holding the
+    // entries would grow the queue without bound for the rest of the session.
+    enabled = false;
+  }
+};
+
+const schedule = () => {
+  if (timer || !enabled) return;
+  timer = setTimeout(flush, FLUSH_MS);
+};
+
+export const logEvent = (entry) => {
+  if (!enabled) return;
+  if (queue.length >= MAX_QUEUE) {
+    // Drop the oldest rather than the newest: whatever is happening NOW is what
+    // the reporter is looking at.
+    queue.shift();
+  }
+  queue.push({ source: "client", level: "info", ...entry });
+  // Errors go out promptly — a crash that takes the tab with it should not lose
+  // the entry that explains it.
+  if (entry?.level === "error") flush();
+  else schedule();
+};
+
+// Convenience wrapper for the AI layer, which has the most useful context and the
+// least visibility today.
+export const logAi = (event, message, data, level = "info") =>
+  logEvent({ source: "ai", level, event, message, data });
+
+const describe = (error) => ({
+  message: String(error?.message ?? error ?? "unknown error"),
+  data: error?.stack ? { stack: String(error.stack).slice(0, 8000) } : undefined,
+});
+
+export const installLogClient = () => {
+  if (installed || typeof window === "undefined") return;
+  installed = true;
+
+  window.addEventListener("error", (event) => {
+    const described = describe(event.error ?? event.message);
+    logEvent({
+      level: "error",
+      event: "window.error",
+      message: described.message,
+      data: {
+        ...(described.data ?? {}),
+        source: `${event.filename ?? ""}:${event.lineno ?? 0}:${event.colno ?? 0}`,
+      },
+    });
+  });
+
+  window.addEventListener("unhandledrejection", (event) => {
+    const described = describe(event.reason);
+    logEvent({ level: "error", event: "unhandled.rejection", ...described });
+  });
+
+  // Page identity, so a report's log says which build and which browser it came
+  // from without the reporter having to know.
+  logEvent({
+    event: "session.start",
+    message: "Page loaded",
+    data: {
+      build: import.meta.env.VITE_APP_BUILD || "dev",
+      userAgent: navigator.userAgent,
+      href: location.href,
+    },
+  });
+
+  // A close mid-batch would otherwise lose the last two seconds, which is
+  // exactly the window a crash lands in.
+  window.addEventListener("pagehide", flush);
+};


### PR DESCRIPTION
Fifth of the seven-feature batch. One append-only JSONL file everything writes to, under the writable data dir — so it lands beside the saves in every build: `server/data/logs` for the zip, the Electron userData dir for the installed app, the sandbox path on Android.

## Sources

- **Electron main process** — writes **directly**, not through the API, because these crashes happen *before* the server exists. The EADDRINUSE port clash reached players as a bare *"A JavaScript error occurred in the main process"* with nothing to act on.
- **Server** — `sendError` is already the single choke point for every API failure, so it is one line.
- **Page** — `window.onerror`, `unhandledrejection` and the existing `ErrorBoundary`, batched (a render loop that throws can produce hundreds of identical errors a second).
- **AI layer** — see below.

## Deliberately not an Electron preload

The game window has no preload **on purpose** — attaching one is what broke the app last time, and `main.cjs` already routes the build id through the server for exactly that reason. Going through the API also means the zip build, Termux and the website log identically, with no per-platform branch.

## Redaction lives in the store, not at the callers

A key can arrive from provider settings, a request header, a relayed URL or a pasted error message. A redactor placed at any one of those eventually misses a path — one choke point is the only version that stays true. Covers `Bearer`/`Basic` headers, `sk-`/`pk-`/`rk-` keys, Google and GitHub tokens, and key-ish assignments in JSON or query strings.

Five files of 5 MB, rotated, so a long session with full prompts still fits in a report.

## "What the AI knows"

The assembled system prompt — region catalog, stat sheets, ownership list, directives — logged per attempt alongside the task, prompt size and failure reason. That context previously existed only in a console nobody had open.

## Viewer

A **Diagnostics Log** tool in the cheats panel: newest first, filter to problems, expand an entry for its data, copy the lot for a report. This also answers the earlier "a console where people can see errors" request.

## Testing

| check | result |
| --- | --- |
| six secret shapes fed through redaction | **zero** present on disk afterwards |
| a real server 404 | self-logs via `sendError` |
| browser: page boot | `client/info/session.start` with build + user agent |
| browser: `window.error` | captured |
| browser: `unhandledrejection` | captured |

`npm run build` passes and all 26 server tests pass.