### PR TITLE
Community bar at the top of the site; hero button says "Demo in your browser"

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -187,6 +187,7 @@
   .btn-ghost{background:var(--marble);border-color:var(--line2);color:var(--ink)}
   .btn-ghost:hover{background:var(--marble2)}
   .hero-note{font-size:.96rem;color:var(--sepia2);margin-top:8px;font-style:italic}
+  #heroNote{max-width:640px;margin-left:auto;margin-right:auto}
   .hero-note a{color:var(--bronze);border-bottom:1px solid rgba(154,107,47,.4)}
 
   .shot{margin:50px auto 0;max-width:940px;position:relative}
@@ -310,7 +311,7 @@
         <span>⬇</span> <span id="primaryLabel">Download for Desktop</span>
       </a>
     </div>
-    <p class="hero-note" id="heroNote">Play instantly in your browser — no install, nothing to download. Or <a href="#download">get the desktop app</a> for offline play.</p>
+    <p class="hero-note" id="heroNote">The browser version is a demo — it streams the world map over the network, so expect lag. The <a href="#download">desktop app</a> runs locally and is how the game is meant to be played.</p>
     <div class="shot">
       <img src="https://raw.githubusercontent.com/Open-Historia/open-historia/main/public/screenshot.png" alt="Open Historia gameplay — a strategic world map with events and nations" loading="lazy" />
     </div>
@@ -508,7 +509,7 @@
   var bd = document.getElementById("bandDownload"); if (bd) bd.href = href;
   if (os === "ios"){
     var n = document.getElementById("heroNote");
-    if (n) n.innerHTML = "On iPhone &amp; iPad, tap <b>Play</b> to run it in Safari — add it to your Home Screen for fullscreen.";
+    if (n) n.innerHTML = "On iPhone &amp; iPad, tap <b>Demo</b> to try it in Safari — expect lag, and add it to your Home Screen for fullscreen.";
   }
 
   var tabs = Array.prototype.slice.call(document.querySelectorAll(".tab"));

--- a/site/index.html
+++ b/site/index.html
@@ -135,6 +135,26 @@
   .col .plinth{position:absolute;bottom:0;left:-8px;right:-8px;height:15px;border-radius:2px;border:1px solid var(--line2);
     background:linear-gradient(90deg,#b3a37e,#f7f0d8 50%,#b3a37e);box-shadow:0 -2px 6px rgba(52,36,12,.22)}
 
+  /* ---------- community bar ---------- */
+  /* Above the sticky header, so it scrolls away once someone is reading and the
+     nav keeps the top of the screen. Dark bronze against the parchment: the page
+     is otherwise all light, so a strip that matched it would not be seen. */
+  .community{position:relative;z-index:60;color:#f2e4c4;font-size:.95rem;
+    background:linear-gradient(100deg,#4a3316 0%,#6d4a1c 52%,#4a3316 100%);
+    border-bottom:1px solid rgba(255,225,160,.22)}
+  .community-in{display:flex;flex-wrap:wrap;align-items:center;justify-content:center;
+    gap:8px 16px;min-height:46px;padding:8px 24px;text-align:center}
+  .community-in b{color:#fff3d6;font-weight:600}
+  .community-links{display:flex;flex-wrap:wrap;align-items:center;justify-content:center;gap:9px}
+  .community-btn{display:inline-flex;align-items:center;gap:7px;padding:6px 15px;border-radius:999px;
+    font-family:var(--display);font-size:.76rem;letter-spacing:.08em;text-transform:uppercase;font-weight:700;
+    white-space:nowrap;color:#f7eccf;border:1px solid rgba(255,225,160,.34);background:rgba(255,235,190,.10);
+    transition:background .15s,border-color .15s,transform .12s}
+  .community-btn:hover{background:rgba(255,235,190,.2);border-color:rgba(255,225,160,.62);transform:translateY(-1px)}
+  /* On a narrow screen the two buttons ARE the message — the sentence is what goes. */
+  @media(max-width:560px){.community-in{gap:8px;padding:7px 12px;min-height:42px}.community-say{display:none}
+    .community-btn{font-size:.7rem;letter-spacing:.05em;padding:6px 12px}}
+
   /* ---------- header ---------- */
   header{position:sticky;top:0;z-index:50;backdrop-filter:blur(8px);
     background:color-mix(in srgb,var(--parch) 82%,transparent);border-bottom:1px solid var(--line)}
@@ -253,6 +273,16 @@
   <div class="col r"><div class="cap"><span class="abacus"></span><span class="echinus"></span></div><div class="shaft"><span class="necking"></span></div><div class="base"><span class="torus"></span><span class="plinth"></span></div></div>
 </div>
 
+<div class="community">
+  <div class="community-in">
+    <span class="community-say">Ask questions, share scenarios, and hear about updates &mdash; <b>come say hello.</b></span>
+    <span class="community-links">
+      <a class="community-btn" href="https://discord.gg/QaqAK7fQAg" target="_blank" rel="noopener">Join the Discord</a>
+      <a class="community-btn" href="https://www.reddit.com/r/OpenHistoria" target="_blank" rel="noopener">r/OpenHistoria</a>
+    </span>
+  </div>
+</div>
+
 <header>
   <div class="wrap nav">
     <a class="brand" href="#top"><span class="globe">🏛️</span> Open Historia</a>
@@ -275,7 +305,7 @@
     <h1>Rewrite history,<br><span class="grad">one decision at a time.</span></h1>
     <p class="sub">Open Historia is an AI-driven turn-based strategy game. Lead any nation on a living world map, act in plain language, and watch an AI simulate the consequences — wars, diplomacy, and borders that actually shift.</p>
     <div class="cta-row">
-      <a class="btn btn-primary" href="/play/"><span>▶</span> Play in your browser</a>
+      <a class="btn btn-primary" href="/play/"><span>▶</span> Demo in your browser</a>
       <a id="primaryDownload" class="btn btn-ghost" href="#download">
         <span>⬇</span> <span id="primaryLabel">Download for Desktop</span>
       </a>


### PR DESCRIPTION
## Community bar

Discord and Reddit only existed in the footer, where nobody arriving for the first time sees them. A slim bar now sits at the very top of the landing page with both.

It goes **above** the sticky header rather than inside it, so it scrolls away once someone starts reading and the nav keeps the top of the screen. Dark bronze against the parchment — the page is otherwise all light, so a strip that matched it would not register as anything.

On a phone the sentence drops and the two buttons carry it on their own. Checked at 375px and 1280px: no horizontal overflow, both pills on one row at equal height (they were wrapping to different heights before `white-space:nowrap`).

## The browser build is called a demo, before the click

- **The hero button**: "Play in your browser" → **"Demo in your browser"**.
- **The line under it**: was *"Play instantly in your browser — no install, nothing to download. Or get the desktop app for offline play"*, which sold the browser build as the equal and easier of the two. It now reads *"The browser version is a demo — it streams the world map over the network, so expect lag. The desktop app runs locally and is how the game is meant to be played."*
- **The iOS variant** of that line (swapped in by the UA script) named a button called Play, which no longer exists, and dropped the demo framing entirely. It now carries both.

The web build already says all this — but only in the notice that appears *after* someone clicks through. This says it first.

One layout fix came with it: `.hero-note` has no width of its own, so the longer text ran the full 1040px wrap, far wider than the hero column above it. Constrained to the 640px the hero paragraph already uses, scoped to the hero's own note — the two other `.hero-note` paragraphs further down the page are full-width on purpose.

Landing page only (`site/index.html`); nothing in the game build changed.
