### PR TITLE
Desktop app installs its own updates instead of downloading an installer

### DIFF
--- a/.github/workflows/desktop-installer.yml
+++ b/.github/workflows/desktop-installer.yml
@@ -64,9 +64,23 @@ jobs:
           echo "{\"build\":\"${{ github.run_id }}\"}" > electron/build-id.json
           cat electron/build-id.json
 
+      # package.json ships 0.0.0 and electron-updater decides whether an update
+      # exists by comparing SEMVER — so without a real, increasing version here
+      # every build would look identical to the one already installed and the app
+      # would never update itself. run_number increments per run and is shared by
+      # all three jobs in it, so one release is one version on every platform.
+      - name: Stamp the app version
+        shell: bash
+        run: |
+          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.version='0.0.${{ github.run_number }}';fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
+          node -p "'version: '+require('./package.json').version"
+
       - name: Build the client
         run: npm run build
 
+      # --publish never still WRITES the latest*.yml feed files (the publish block
+      # in package.json is what produces them); it only declines to upload them,
+      # which the release step below does itself.
       - name: Build the installer
         run: npx electron-builder ${{ matrix.args }} --publish never
         env:
@@ -100,7 +114,11 @@ jobs:
               --notes "Windows, macOS and Linux downloads. The world map downloads on first launch." \
             || true
           shopt -s nullglob
-          files=(release/*.exe release/*-mac-*.zip release/*.AppImage)
+          # The latest*.yml files ARE the update feed: electron-updater fetches
+          # latest.yml (win) / latest-mac.yml / latest-linux.yml from this release
+          # and compares the version in it against the running app. One per
+          # platform, so the three jobs cannot overwrite each other's.
+          files=(release/*.exe release/*-mac-*.zip release/*.AppImage release/latest*.yml)
           # Only the Windows job writes latest.json, so three racing jobs cannot
           # each publish a different view of the same release.
           if [ "${{ matrix.os }}" = "windows-latest" ]; then

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -41,6 +41,87 @@ try {
   /* dev build: unstamped, so no update is ever offered */
 }
 
+// --- automatic updates ------------------------------------------------------
+
+// The app used to answer "a new version exists" by opening the installer's
+// download URL in the player's browser and leaving them to run it. It now
+// downloads and applies the update itself; the download link stays only as the
+// fallback for the cases below.
+//
+// This is reachable from the page WITHOUT a preload and without IPC, because
+// startServer() imports server.js into THIS process — the Express routes and the
+// updater are the same process, so the server can call straight into it through
+// the handle published on globalThis at the bottom of this block. That matters:
+// attaching a preload to the game window is what broke the app last time.
+//
+// macOS is excluded. Squirrel.Mac validates the running app's code signature
+// before applying anything, and the release workflow builds unsigned
+// (CSC_IDENTITY_AUTO_DISCOVERY: false) because there is no Developer ID
+// certificate yet. Attempting it there produces an error and nothing else, so mac
+// keeps the manual download until there is a certificate to sign with.
+const AUTO_UPDATE_SUPPORTED = process.platform !== "darwin";
+
+// What the banner polls. One object, replaced rather than mutated, so a read is
+// always internally consistent.
+let updateState = { state: "idle", percent: 0, version: "", error: "" };
+const setUpdateState = (patch) => { updateState = { ...updateState, ...patch }; };
+
+const setupAutoUpdater = () => {
+  // A dev run has no app-update.yml inside it, so electron-updater would only
+  // ever error; an unpackaged app also cannot be replaced by an installer.
+  if (!AUTO_UPDATE_SUPPORTED || !app.isPackaged) return null;
+  let autoUpdater;
+  try {
+    ({ autoUpdater } = require("electron-updater"));
+  } catch {
+    return null; // not packaged with the app: fall back to the download link
+  }
+  // The banner decides when to download — a player on a metered connection
+  // should not have ~100MB pulled out from under them by opening the game.
+  autoUpdater.autoDownload = false;
+  // If they download but never press Restart, it installs on the next quit
+  // instead of being thrown away.
+  autoUpdater.autoInstallOnAppQuit = true;
+  autoUpdater.on("checking-for-update", () => setUpdateState({ state: "checking", error: "" }));
+  autoUpdater.on("update-available", (info) => setUpdateState({ state: "available", percent: 0, version: String(info?.version || ""), error: "" }));
+  autoUpdater.on("update-not-available", () => setUpdateState({ state: "none", percent: 0 }));
+  autoUpdater.on("download-progress", (progress) => setUpdateState({ state: "downloading", percent: Math.max(0, Math.min(100, Math.round(progress?.percent || 0))) }));
+  autoUpdater.on("update-downloaded", (info) => setUpdateState({ state: "ready", percent: 100, version: String(info?.version || ""), error: "" }));
+  // Every failure lands here — no signature, no latest.yml, offline mid-download.
+  // The banner reads it and offers the installer download instead, so a broken
+  // updater degrades to exactly the behaviour this replaced.
+  autoUpdater.on("error", (error) => setUpdateState({ state: "error", error: String(error?.message || error || "Update failed.") }));
+  return autoUpdater;
+};
+
+// Published on globalThis for server.js, which is imported into THIS process and
+// serves /api/app-update/{status,download,restart} straight off it. Called from
+// boot() before the server starts, so the routes are never live without it.
+const installAutoUpdater = () => {
+  const autoUpdater = setupAutoUpdater();
+  if (!autoUpdater) return;
+  globalThis.__ohAutoUpdate = {
+    status: () => updateState,
+    download: () => {
+      // checkForUpdates has to have run first — downloadUpdate with nothing found
+      // rejects. Chaining them here means the page needs one call, not two.
+      setUpdateState({ state: "checking", error: "" });
+      autoUpdater
+        .checkForUpdates()
+        .then((result) => (result?.updateInfo ? autoUpdater.downloadUpdate() : null))
+        .catch((error) => setUpdateState({ state: "error", error: String(error?.message || error) }));
+    },
+    // isSilent: the whole point is that the player does not meet an installer.
+    // The NSIS build is assisted (oneClick: false) and per-user (perMachine:
+    // false), so a silent update rewrites the existing install with no wizard and
+    // no elevation prompt. isForceRunAfter reopens the game once it is done.
+    //
+    // Deferred: the HTTP response for this request still has to be written, and
+    // quitAndInstall tears the process down immediately.
+    restart: () => { setTimeout(() => autoUpdater.quitAndInstall(true, true), 400); },
+  };
+};
+
 const APP_ROOT = path.join(__dirname, "..");
 // asarUnpack keeps scripts/ outside the archive so a child process can run it.
 const unpacked = (p) => p.replace(`app.asar${path.sep}`, `app.asar.unpacked${path.sep}`);
@@ -180,6 +261,7 @@ const startServer = async () => {
 };
 
 const boot = async () => {
+  installAutoUpdater();
   const pending = missingAssets();
   if (pending.length) {
     setupWindow = createSetupWindow();

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "chart.js": "^4.5.1",
         "d3-geo": "^3.1.1",
         "dayjs": "^1.11.19",
+        "electron-updater": "^6.8.9",
         "eslint": "^9.39.3",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.26",
@@ -3408,7 +3409,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "devOptional": true,
       "license": "Python-2.0"
     },
     "node_modules/arr-union": {
@@ -5143,6 +5143,82 @@
       "integrity": "sha512-7zt9Aw+SrmxLWLN0zhaTWZQiCdryLVrYTq5R7iZakLvi2UQPYMMsROYV/2qVCzMeCiSXHwKOU+sZ4zOVVlrtKA==",
       "license": "ISC"
     },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/builder-util-runtime": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
+      "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-updater/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/electron-updater/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -6227,8 +6303,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "license": "ISC",
-      "optional": true
+      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -6899,7 +6974,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
       "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -7026,8 +7100,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/lazystream": {
       "version": "1.0.1",
@@ -7111,6 +7184,12 @@
       "optional": true,
       "peer": true
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
@@ -7118,6 +7197,13 @@
       "license": "MIT",
       "optional": true,
       "peer": true
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -9476,7 +9562,6 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
       "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
       "license": "BlueOak-1.0.0",
-      "optional": true,
       "engines": {
         "node": ">=11.0.0"
       }
@@ -10249,6 +10334,12 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.15",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,6 @@
   },
   "dependencies": {
     "@noble/ed25519": "^2.3.0",
-    "@vitejs/plugin-react": "^5.1.4",
-    "babel-plugin-react-compiler": "^1.0.0",
     "@turf/area": "^7.3.5",
     "@turf/boolean-point-in-polygon": "^7.3.5",
     "@turf/centroid": "^7.3.5",
@@ -33,9 +31,12 @@
     "@turf/line-split": "^7.3.5",
     "@turf/polygon-to-line": "^7.3.5",
     "@turf/simplify": "^7.3.5",
+    "@vitejs/plugin-react": "^5.1.4",
+    "babel-plugin-react-compiler": "^1.0.0",
     "chart.js": "^4.5.1",
     "d3-geo": "^3.1.1",
     "dayjs": "^1.11.19",
+    "electron-updater": "^6.8.9",
     "eslint": "^9.39.3",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.26",
@@ -90,6 +91,13 @@
     ],
     "asarUnpack": [
       "scripts/**"
+    ],
+    "publish": [
+      {
+        "provider": "generic",
+        "url": "https://github.com/Open-Historia/open-historia/releases/download/desktop-stable",
+        "channel": "latest"
+      }
     ],
     "directories": {
       "output": "release",

--- a/server/appUpdate.test.js
+++ b/server/appUpdate.test.js
@@ -1,0 +1,117 @@
+/*! Open Historia — desktop self-update route tests © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// The desktop app updates itself through these three routes. They read the updater
+// off globalThis, which the Electron main process publishes and nothing else does —
+// so the same server binary is inert in the zip build and live inside the app, and
+// both halves of that are what this checks.
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test, { after, before } from "node:test";
+
+const DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "oh-update-test-"));
+process.env.OH_DATA_DIR = DATA_DIR;
+process.env.PORT = "39517";
+
+let httpServer;
+let base;
+
+// A stand-in for electron-updater. The real one is only reachable from a packaged
+// Electron main process, so what is under test here is the wiring, not Squirrel.
+const fake = () => {
+  const calls = [];
+  let state = { state: "idle", percent: 0, version: "", error: "" };
+  return {
+    calls,
+    setState: (next) => { state = { ...state, ...next }; },
+    handle: {
+      status: () => state,
+      check: () => calls.push("check"),
+      download: () => calls.push("download"),
+      restart: () => calls.push("restart"),
+    },
+  };
+};
+
+before(async () => {
+  ({ httpServer } = await import("./server.js"));
+  base = `http://127.0.0.1:${process.env.PORT}`;
+});
+
+after(() => {
+  httpServer?.close();
+  fs.rmSync(DATA_DIR, { recursive: true, force: true });
+});
+
+test("without an updater the routes report unsupported and refuse to act", async () => {
+  delete globalThis.__ohAutoUpdate;
+
+  const status = await fetch(`${base}/api/app-update/status`);
+  assert.equal(status.status, 200);
+  assert.deepEqual(await status.json(), { supported: false });
+
+  // 404 rather than 500: this build genuinely has no such capability, and the
+  // banner reads the failure as "fall back to the installer download".
+  for (const route of ["download", "restart"]) {
+    const res = await fetch(`${base}/api/app-update/${route}`, { method: "POST" });
+    assert.equal(res.status, 404, `${route} must 404 without an updater`);
+  }
+});
+
+test("status passes the updater's own state through", async () => {
+  const updater = fake();
+  globalThis.__ohAutoUpdate = updater.handle;
+  updater.setState({ state: "downloading", percent: 42, version: "0.0.7" });
+
+  const res = await fetch(`${base}/api/app-update/status`);
+  assert.deepEqual(await res.json(), {
+    supported: true,
+    state: "downloading",
+    percent: 42,
+    version: "0.0.7",
+    error: "",
+  });
+});
+
+test("download starts the updater and returns immediately", async () => {
+  const updater = fake();
+  globalThis.__ohAutoUpdate = updater.handle;
+
+  const res = await fetch(`${base}/api/app-update/download`, { method: "POST" });
+  assert.equal(res.status, 200);
+  assert.deepEqual(await res.json(), { started: true });
+  // The point of the route: it must NOT hold the request open for the length of a
+  // ~100MB download — the page follows it through /status instead.
+  assert.deepEqual(updater.calls, ["download"]);
+});
+
+test("restart only installs an update that finished downloading", async () => {
+  const updater = fake();
+  globalThis.__ohAutoUpdate = updater.handle;
+
+  updater.setState({ state: "downloading", percent: 61 });
+  const early = await fetch(`${base}/api/app-update/restart`, { method: "POST" });
+  assert.equal(early.status, 409, "restarting mid-download would lose the download");
+  assert.deepEqual(updater.calls, []);
+
+  updater.setState({ state: "ready", percent: 100 });
+  const ready = await fetch(`${base}/api/app-update/restart`, { method: "POST" });
+  assert.equal(ready.status, 200);
+  assert.deepEqual(await ready.json(), { restarting: true });
+  assert.deepEqual(updater.calls, ["restart"]);
+});
+
+test("the manifest tells the page which of the two updates it can offer", async () => {
+  // autoUpdate is what the banner branches on: true installs in place, false keeps
+  // opening the installer download. It is answered from this process, so it holds
+  // even when the GitHub fetch behind the rest of the payload fails.
+  globalThis.__ohAutoUpdate = fake().handle;
+  const on = await (await fetch(`${base}/api/app-update?track=desktop`)).json();
+  assert.equal(on.autoUpdate, true);
+
+  delete globalThis.__ohAutoUpdate;
+  // The reply is cached for three minutes, so ask on a track that has not been hit.
+  const off = await (await fetch(`${base}/api/app-update?track=stable`)).json();
+  assert.equal(off.autoUpdate ?? false, false);
+});

--- a/server/server.js
+++ b/server/server.js
@@ -281,6 +281,13 @@ const APP_UPDATE_MANIFESTS = {
   // reason the Android tracks are served this way.
   desktop: "https://github.com/Open-Historia/open-historia/releases/download/desktop-stable/latest.json",
 };
+// The desktop app imports this server into its Electron main process
+// (electron/main.cjs startServer), so the updater living there is reachable
+// straight through globalThis — no IPC, and no preload on the game window. It is
+// absent everywhere else, which is what makes these routes inert in the zip build
+// and on the website.
+const desktopUpdater = () => globalThis.__ohAutoUpdate || null;
+
 const APP_UPDATE_TTL_MS = 3 * 60 * 1000;
 const appUpdateCache = new Map(); // track -> { at, data }
 
@@ -316,12 +323,47 @@ app.get("/api/app-update", async (req, res) => {
       // localhost page — and it is absent everywhere else, so no banner appears.
       current: String(process.env.OH_DESKTOP_BUILD || ""),
       download: str(raw && raw[{ win32: "windows", darwin: "mac", linux: "linux" }[process.platform]]),
+      // True when this app can install the update itself. False on a build that
+      // cannot (unsigned macOS, an unpackaged dev run), and the banner then offers
+      // the download link exactly as it did before.
+      autoUpdate: Boolean(desktopUpdater()),
     };
     appUpdateCache.set(track, { at: Date.now(), data });
     res.json(data);
   } catch {
     res.json(cached ? cached.data : {}); // offline / timeout -> fail-open
   }
+});
+
+app.get("/api/app-update/status", (req, res) => {
+  const updater = desktopUpdater();
+  res.json(updater ? { supported: true, ...updater.status() } : { supported: false });
+});
+
+app.post("/api/app-update/download", (req, res) => {
+  const updater = desktopUpdater();
+  if (!updater) {
+    res.status(404).json({ error: "This build cannot update itself." });
+    return;
+  }
+  // Fire-and-forget: the download takes as long as it takes, and the page follows
+  // it through /status rather than holding a request open for minutes.
+  updater.download();
+  res.json({ started: true });
+});
+
+app.post("/api/app-update/restart", (req, res) => {
+  const updater = desktopUpdater();
+  if (!updater) {
+    res.status(404).json({ error: "This build cannot update itself." });
+    return;
+  }
+  if (updater.status().state !== "ready") {
+    res.status(409).json({ error: "No downloaded update is ready to install." });
+    return;
+  }
+  res.json({ restarting: true });
+  updater.restart();
 });
 
 app.get("/api/scenarios/:scenarioId", (req, res) => {
@@ -903,7 +945,9 @@ app.get("*splat", (_req, res) => {
   res.sendFile(path.join(distDir, "index.html"));
 });
 
-const httpServer = app.listen(PORT, () => {
+// Exported so a test can shut the listener down; nothing else imports it (the
+// app and the launchers import this module purely for its side effects).
+export const httpServer = app.listen(PORT, () => {
   console.log(`Server running at http://localhost:${PORT}`);
 });
 

--- a/src/runtime/AppUpdateBanner.jsx
+++ b/src/runtime/AppUpdateBanner.jsx
@@ -85,7 +85,36 @@ export default function AppUpdateBanner() {
     }
   });
   const [updating, setUpdating] = useState(false);
+  // The main process's updater state, polled while an update is actually running.
+  // Null until the player asks for one — the banner is otherwise the same as it
+  // was, and a build that cannot update itself never sets this at all.
+  const [progress, setProgress] = useState(null);
   const lastRefocusRef = useRef(0);
+
+  // A second-by-second poll, but only between pressing Update and the update being
+  // ready (or failing) — never while the banner is merely sitting there.
+  const running = progress?.state === "checking" || progress?.state === "downloading";
+  useEffect(() => {
+    if (!running) return undefined;
+    let stopped = false;
+    const tick = async () => {
+      try {
+        const res = await fetch("/api/app-update/status", { cache: "no-store" });
+        if (!res.ok) return;
+        const data = await res.json();
+        if (stopped || !data?.supported) return;
+        setProgress(data);
+        // A failure mid-download hands the player back to the installer link, so
+        // the button has to become pressable again — otherwise it sits disabled
+        // reading "Opening…" while nothing is opening.
+        if (data.state === "error") setUpdating(false);
+      } catch {
+        /* a missed poll changes nothing: the next one has the same answer */
+      }
+    };
+    const timer = setInterval(tick, 1000);
+    return () => { stopped = true; clearInterval(timer); };
+  }, [running]);
 
   useEffect(() => {
     if (isApp || isWeb) return undefined;
@@ -99,7 +128,7 @@ export default function AppUpdateBanner() {
         // the ids are opaque, so a rollback counts just as much as a newer build.
         if (dropped || !data?.current || !data?.buildId || !data?.download) return;
         if (data.buildId === data.current) return;
-        setDesktop({ build: data.buildId, notes: data.notes || "", url: data.download });
+        setDesktop({ auto: Boolean(data.autoUpdate), build: data.buildId, notes: data.notes || "", url: data.download });
       } catch {
         /* fail open: no banner */
       }
@@ -161,10 +190,25 @@ export default function AppUpdateBanner() {
 
   const onUpdate = async () => {
     if (desktop) {
+      setUpdating(true);
+      // The app installs the update itself: the main process downloads it and
+      // swaps the installation on restart, so there is nothing for the player to
+      // find in a downloads folder and run.
+      if (desktop.auto && progress?.state !== "error") {
+        setProgress({ state: "checking", percent: 0 });
+        try {
+          const res = await fetch("/api/app-update/download", { method: "POST" });
+          if (res.ok) return;
+        } catch {
+          /* fall through to the download link below */
+        }
+        // The route is gone or refused — never leave the player with a button that
+        // did nothing. This is the behaviour that used to be the only one.
+        setProgress({ state: "error", error: "" });
+      }
       // window.open goes through the main process's window-open handler, which sends
       // it to the real browser — so the installer downloads where the player can see
       // it, and no extra bridge is needed to do it.
-      setUpdating(true);
       window.open(desktop.url, "_blank", "noopener");
       return;
     }
@@ -195,6 +239,17 @@ export default function AppUpdateBanner() {
     // Downloads the new APK; Android then prompts to install it and reopen the app.
     window.location.href = latest.apk;
   };
+  const onRestart = async () => {
+    try {
+      // The app quits and reopens on the new version; the response comes back
+      // before it goes, so a refusal is still visible.
+      const res = await fetch("/api/app-update/restart", { method: "POST" });
+      if (!res.ok) setProgress({ state: "error", error: "" });
+    } catch {
+      /* the app is already going down — nothing left to report to */
+    }
+  };
+
   const onDismiss = () => {
     setDismissed(info.build);
     try {
@@ -204,13 +259,28 @@ export default function AppUpdateBanner() {
     }
   };
 
+  // What the desktop line says depends on how far along the app's own update is.
+  // "error" is not shown as a failure: the button falls back to the installer
+  // download, so the honest thing to say is what the player can still do.
+  const desktopStatus = () => {
+    if (!desktop.auto || progress?.state === "error") {
+      return updating ? "Opening the download…" : "Download the new version and run it — your games are kept.";
+    }
+    if (progress?.state === "ready") return "Downloaded. Restart to finish — your games are kept.";
+    if (progress?.state === "downloading") return `Downloading the update… ${progress.percent || 0}%`;
+    if (progress?.state === "checking") return "Fetching the update…";
+    return "Installs itself in the background — your games are kept.";
+  };
+  const ready = Boolean(desktop && desktop.auto && progress?.state === "ready");
+  const busy = Boolean(desktop && desktop.auto && (progress?.state === "checking" || progress?.state === "downloading"));
+
   return (
     <div style={bar} role="status" aria-live="polite">
       <div style={text}>
         A new version of Open Historia is ready.
         <span style={sub}>
           {desktop
-            ? (updating ? "Opening the download…" : "Download the new version and run it — your games are kept.")
+            ? desktopStatus()
             : isWeb
             ? (updating ? "Reloading…" : "Reload to get the latest fixes. Your games are saved.")
             : updating
@@ -218,9 +288,17 @@ export default function AppUpdateBanner() {
               : latest.notes || `Build ${latest.build} · tap Update to download and install.`}
         </span>
       </div>
-      {isWeb || desktop || latest.apk ? (
-        <button type="button" style={btn} onClick={onUpdate} disabled={updating}>
-          {updating ? (isWeb ? "Reloading…" : desktop ? "Opening…" : "Downloading…") : "Update now"}
+      {ready ? (
+        <button type="button" style={btn} onClick={onRestart}>
+          Restart now
+        </button>
+      ) : isWeb || desktop || latest.apk ? (
+        <button type="button" style={btn} onClick={onUpdate} disabled={updating || busy}>
+          {busy
+            ? `${progress.percent || 0}%`
+            : updating
+              ? (isWeb ? "Reloading…" : desktop ? "Opening…" : "Downloading…")
+              : "Update now"}
         </button>
       ) : null}
       <button type="button" style={dismissBtn} onClick={onDismiss} aria-label="Dismiss update notice">


### PR DESCRIPTION
The update banner's only answer to "a new version exists" was to open the installer's download URL in the player's browser and leave them to find the file and run the wizard. It now downloads and applies the update itself, then restarts into it.

## How it reaches the page without a preload

`startServer()` imports `server.js` **into the Electron main process** — the Express routes and `electron-updater` are the same process. So the server calls straight into the updater through a handle on `globalThis`, with no IPC and no preload on the game window (which the code comments say is what broke the app last time).

Three routes, all inert anywhere that handle is absent — the zip build, the website, a dev run:

| route | does |
|---|---|
| `GET /api/app-update/status` | `{ supported, state, percent, version, error }` |
| `POST /api/app-update/download` | starts it, returns immediately |
| `POST /api/app-update/restart` | `quitAndInstall`, 409 if nothing is downloaded |

`GET /api/app-update` grows an `autoUpdate` flag so the banner knows which of the two it is offering *before* the player clicks.

## Two things were broken and had to be fixed for any of this to work

1. **Every build shipped `version: 0.0.0`.** electron-updater decides whether an update exists by comparing semver, so every release looked identical to the one already installed. The workflow now stamps `0.0.<run_number>` before building — one version per run, shared by all three platform jobs.
2. **Nothing generated the `latest*.yml` feed.** That file *is* the update feed; without it electron-updater has nothing to read. A `publish` block (generic provider, pointed at the rolling `desktop-stable` release) makes electron-builder write them, and the release step uploads them next to the installers. Generic rather than the GitHub provider because this ships as one rolling tag that gets re-uploaded over, not a new release per version.

## macOS is deliberately excluded

Squirrel.Mac validates the running app's code signature before applying anything, and the workflow builds unsigned (`CSC_IDENTITY_AUTO_DISCOVERY: false` — there is no Developer ID certificate). Attempting it there produces an error and nothing else. **Mac keeps the manual download** until there is a certificate to sign with. Windows and Linux update in place.

Every other failure — no feed file, offline mid-download, a refused route — falls back to the same download link the banner uses today, and the button re-enables itself rather than sitting disabled reading "Opening…". Nothing gets worse than it is now.

## Install behaviour

Silent, and it relaunches. The NSIS build is assisted (`oneClick: false`) and per-user (`perMachine: false`), so a silent update rewrites the existing install with no wizard and no elevation prompt. A player who downloads but never presses **Restart now** gets it applied on the next quit (`autoInstallOnAppQuit`). Games live in `userData` and are untouched either way.

The download is not started until the player asks — someone on a metered connection should not have ~100MB pulled out from under them by opening the game.

## Verification

- **5 new tests** (`server/appUpdate.test.js`) drive the routes against a stand-in updater: unsupported builds 404, status passes state through, `download` returns immediately rather than holding a request open for the length of a ~100MB transfer, and `restart` refuses with **409 mid-download** instead of throwing the download away. Full suite 31/31, build clean, lint clean.
- Workflow YAML parses and its step list is intact.

**What I could not verify:** the real Squirrel round trip. That needs two signed-in-sequence releases and a real install to update from, which cannot be done from here. The first release built off this branch is the test — install it, publish a second, and confirm the banner downloads and restarts rather than opening a browser tab. If the feed is wrong the banner falls back to the current behaviour rather than failing visibly, so it is worth watching `/api/app-update/status` once on the first run.
