### PR TITLE
Fix the Linux AppImage aborting on launch (#658)

### DIFF
--- a/electron/linuxSandbox.cjs
+++ b/electron/linuxSandbox.cjs
@@ -1,0 +1,58 @@
+/*! Open Historia — Linux AppImage sandbox detection © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// Decides whether Chromium's sandbox can start at all, because on one common Linux
+// setup it cannot and the app dies on launch before a window ever appears:
+//
+//   FATAL:setuid_sandbox_host.cc(163)] The SUID sandbox helper binary was found,
+//   but is not configured correctly. Rather than run without sandboxing I'm
+//   aborting now. You need to make sure that .../chrome-sandbox is owned by root
+//   and has mode 4755.
+//
+// Chromium sandboxes a renderer one of two ways: unprivileged user namespaces, or
+// the setuid helper binary named in that message. INSIDE AN APPIMAGE THE SECOND ONE
+// CAN NEVER WORK — the bundle is mounted through FUSE with nosuid, and nothing in it
+// is owned by root, so the setuid bit could not take effect even if it were set. An
+// AppImage therefore depends entirely on user namespaces.
+//
+// Ubuntu 24.04 (and derivatives — the report was a KDE one) ships an AppArmor policy
+// that restricts unprivileged user namespaces. Chromium loses option one, falls back
+// to option two, finds the helper unusable, and aborts. Debian and Arch hardening
+// guides disable user namespaces outright, with the same result.
+//
+// So: when this is an AppImage AND user namespaces are positively known to be
+// unavailable, start without the sandbox — a game that runs unsandboxed beats one
+// that does not run. Everywhere else, including an AppImage on a kernel where user
+// namespaces work, the sandbox is left exactly as it is. The check is deliberately
+// "prove it is broken", not "prove it is fine": an unreadable or absent sysctl is the
+// ordinary healthy case on most distributions and must not cost anyone their sandbox.
+
+const fs = require("node:fs");
+
+const readSysctl = (file) => {
+  try {
+    return fs.readFileSync(file, "utf8").trim();
+  } catch {
+    return null; // not present on this kernel, which is itself the common case
+  }
+};
+
+// Each entry is a sysctl and the value that means "unprivileged user namespaces are
+// not available to us".
+const USERNS_BLOCKED = [
+  // Debian/Ubuntu's older switch, and what hardening guides set to 0.
+  ["/proc/sys/kernel/unprivileged_userns_clone", "0"],
+  // Ubuntu 24.04+: namespaces exist but AppArmor refuses them to unconfined binaries.
+  ["/proc/sys/kernel/apparmor_restrict_unprivileged_userns", "1"],
+  // The generic kernel limit — zero of them allowed is the same thing.
+  ["/proc/sys/user/max_user_namespaces", "0"],
+];
+
+// platform/env/read are injected so this is testable off a real Linux box.
+const needsNoSandbox = ({ platform = process.platform, env = process.env, read = readSysctl } = {}) => {
+  if (platform !== "linux") return false;
+  // APPIMAGE is set by the AppImage runtime to the bundle's own path. An ordinary
+  // install (a .deb, or a dev run) has a working chrome-sandbox and is left alone.
+  if (!env.APPIMAGE) return false;
+  return USERNS_BLOCKED.some(([file, blockedValue]) => read(file) === blockedValue);
+};
+
+module.exports = { needsNoSandbox, readSysctl, USERNS_BLOCKED };

--- a/electron/linuxSandbox.test.js
+++ b/electron/linuxSandbox.test.js
@@ -1,0 +1,73 @@
+/*! Open Historia — Linux AppImage sandbox detection tests © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// Issue #658: the AppImage aborted on launch on an Ubuntu-based KDE distro with
+// "The SUID sandbox helper binary was found, but is not configured correctly".
+// These pin the decision that fixes it, and — more importantly — pin the cases
+// where the sandbox must be LEFT ALONE, since the failure mode of getting this
+// wrong is silently unsandboxing people who did not need it.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createRequire } from "node:module";
+
+const { needsNoSandbox } = createRequire(import.meta.url)("./linuxSandbox.cjs");
+
+// A fake /proc. Anything not named here reads as absent, which is what most
+// kernels actually do.
+const proc = (files = {}) => (file) => (file in files ? files[file] : null);
+
+const APPIMAGE = { APPIMAGE: "/home/player/Open-Historia-x86_64.AppImage" };
+const HEALTHY = proc({ "/proc/sys/user/max_user_namespaces": "15000" });
+
+test("the reported case: an AppImage where AppArmor restricts user namespaces", () => {
+  // Ubuntu 24.04 and its derivatives. Namespaces exist, AppArmor refuses them, and
+  // an AppImage cannot fall back to the setuid helper — so there is no sandbox.
+  const read = proc({ "/proc/sys/kernel/apparmor_restrict_unprivileged_userns": "1" });
+  assert.equal(needsNoSandbox({ platform: "linux", env: APPIMAGE, read }), true);
+});
+
+test("an AppImage with user namespaces disabled outright", () => {
+  for (const [file, value] of [
+    ["/proc/sys/kernel/unprivileged_userns_clone", "0"],
+    ["/proc/sys/user/max_user_namespaces", "0"],
+  ]) {
+    assert.equal(
+      needsNoSandbox({ platform: "linux", env: APPIMAGE, read: proc({ [file]: value }) }),
+      true,
+      `${file}=${value} must count as no sandbox available`,
+    );
+  }
+});
+
+test("an AppImage on a kernel that allows user namespaces keeps its sandbox", () => {
+  assert.equal(needsNoSandbox({ platform: "linux", env: APPIMAGE, read: HEALTHY }), false);
+  // AppArmor present but NOT restricting is the majority of Ubuntu installs.
+  const permissive = proc({ "/proc/sys/kernel/apparmor_restrict_unprivileged_userns": "0" });
+  assert.equal(needsNoSandbox({ platform: "linux", env: APPIMAGE, read: permissive }), false);
+});
+
+test("silence is not evidence: absent sysctls keep the sandbox", () => {
+  // Most distributions have none of these files. Reading that as "broken" would
+  // unsandbox nearly every Linux player to fix one configuration.
+  assert.equal(needsNoSandbox({ platform: "linux", env: APPIMAGE, read: proc({}) }), false);
+});
+
+test("only an AppImage is affected", () => {
+  // A .deb or a dev run has a real chrome-sandbox owned by root, so the same
+  // hostile kernel settings are not a problem there.
+  const blocked = proc({ "/proc/sys/kernel/apparmor_restrict_unprivileged_userns": "1" });
+  assert.equal(needsNoSandbox({ platform: "linux", env: {}, read: blocked }), false);
+});
+
+test("never on Windows or macOS", () => {
+  const blocked = proc({ "/proc/sys/kernel/apparmor_restrict_unprivileged_userns": "1" });
+  for (const platform of ["win32", "darwin"]) {
+    assert.equal(needsNoSandbox({ platform, env: APPIMAGE, read: blocked }), false);
+  }
+});
+
+test("reads the real /proc without throwing on any platform", () => {
+  // The default reader is the one that actually ships; a throw here would take the
+  // app down before its window exists, which is the very failure being fixed.
+  assert.doesNotThrow(() => needsNoSandbox());
+  assert.equal(typeof needsNoSandbox(), "boolean");
+});

--- a/electron/main.cjs
+++ b/electron/main.cjs
@@ -14,6 +14,20 @@ const path = require("node:path");
 const fs = require("node:fs");
 const net = require("node:net");
 const { spawn } = require("node:child_process");
+const { needsNoSandbox } = require("./linuxSandbox.cjs");
+
+// Must run before app.whenReady(): Chromium reads its command line when the zygote
+// starts, and the crash this prevents happens there. See linuxSandbox.cjs — on an
+// AppImage whose kernel refuses unprivileged user namespaces there is no sandbox
+// available at all, and Chromium aborts on launch rather than continue without one.
+if (needsNoSandbox()) {
+  console.log(
+    "Unprivileged user namespaces are unavailable and an AppImage cannot use the setuid "
+    + "sandbox, so Open Historia is starting without Chromium's sandbox. Installing the "
+    + "app outside an AppImage restores it.",
+  );
+  app.commandLine.appendSwitch("no-sandbox");
+}
 
 // Everything the app writes lives under Electron's per-user data directory.
 // Program Files is read-only for a normal user and the app bundle is read-only

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "preview:web": "vite preview --outDir dist-web",
-    "test": "node --test \"server/**/*.test.js\"",
+    "test": "node --test \"server/**/*.test.js\" \"electron/**/*.test.js\"",
     "electron": "electron .",
     "dist:win": "npm run build && electron-builder --win",
     "dist:mac": "npm run build && electron-builder --mac",


### PR DESCRIPTION
Fixes #658.

## What is happening

Chromium sandboxes a renderer one of two ways: **unprivileged user namespaces**, or the **setuid helper binary** (`chrome-sandbox`) named in the crash.

Inside an AppImage the second one can *never* work — the bundle is mounted through FUSE with `nosuid` and nothing in it is owned by root, so the setuid bit could not take effect even if it were set. An AppImage therefore depends entirely on user namespaces.

Ubuntu 24.04 and its derivatives (the report is a KDE one) ship an AppArmor policy that **restricts unprivileged user namespaces**. Chromium loses option one, falls back to option two, finds the helper unusable, and aborts — which is exactly the reporter's log. Debian and Arch hardening guides disable user namespaces outright, with the same result.

The advice in the message itself (`chmod 4755` the helper) cannot be followed: the file is inside a read-only FUSE mount.

## The fix

When the app is running from an AppImage **and** the kernel is positively known to refuse user namespaces, start with `--no-sandbox` and say so on stdout. A game that runs unsandboxed beats one that does not run.

The check is deliberately *"prove it is broken"*, not *"prove it is fine"*, and that direction is the whole risk here — on most distributions none of these sysctls exist at all, and reading their absence as "no sandbox available" would quietly unsandbox nearly every Linux player to fix one configuration. Three signals, each only counted when the file exists and says so:

| sysctl | value meaning "unavailable" |
|---|---|
| `kernel/apparmor_restrict_unprivileged_userns` | `1` — Ubuntu 24.04+ |
| `kernel/unprivileged_userns_clone` | `0` — older Debian/Ubuntu, hardening guides |
| `user/max_user_namespaces` | `0` — the generic kernel limit |

Untouched: an AppImage on a kernel that allows user namespaces, any ordinary install (a `.deb` or a dev run has a real root-owned `chrome-sandbox`), and every non-Linux platform.

## Verification

7 tests (`electron/linuxSandbox.test.js`), including the reported configuration and — more importantly — the five where the sandbox must be **left alone**. The last one calls the shipping code path against the real `/proc` to prove it cannot throw, since a throw there would take the app down before its window exists, which is the very failure being fixed. Suite 33/33.

They needed the test glob widened to `electron/` — nothing in there was covered before.

**What I could not verify:** the actual launch on Ubuntu 24.04. I have no Linux box here, so the sysctl values and the AppImage `nosuid` behaviour are reasoned from the crash log rather than reproduced. @azalty running the next AppImage build is the real confirmation.

## Worth considering separately

Shipping a **`.deb`** alongside the AppImage would fix this properly for Ubuntu users rather than working around it — electron-builder's `deb` postinst sets `chrome-sandbox` to `root:root 4755`, so the sandbox works as intended. The catch is that electron-updater does not auto-update `deb` installs, so those users would not get the self-update in #660. Left out of this PR as a separate call.
