### PR TITLE
Add a dispatch-only workflow for the SeventhDread beta release

### DIFF
--- a/.github/workflows/desktop-seventhdread-beta.yml
+++ b/.github/workflows/desktop-seventhdread-beta.yml
@@ -1,0 +1,164 @@
+# Builds the UNOFFICIAL SeventhDread beta from the Seventh-Dread-Beta branch for
+# Windows, macOS and Linux and publishes it to a pre-release.
+#
+# It is the same pipeline as desktop-installer.yml with one substitution — the
+# electron-builder config — and that config is what makes the beta a separate
+# application: it installs alongside the official Open Historia rather than over
+# it, while electron/main.cjs points both builds at the SAME save library, so a
+# tester can move between the two mid-campaign. Nothing here touches the stable
+# release or its `desktop-stable` tag.
+#
+# Run it from the Actions tab (Run workflow), choosing `Seventh-Dread-Beta` under
+# "Use workflow from". A copy of this file has to sit on the default branch for
+# GitHub to list it at all, but the copy on the branch you select is the one that
+# actually runs — same arrangement as android-apk-beta.yml.
+name: Desktop beta (SeventhDread)
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to publish the beta installers to
+        required: false
+        default: desktop-seventhdread-beta
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false # one platform failing must not throw away the other two
+      matrix:
+        include:
+          # Each installer must be built on its own OS: electron-builder shells out
+          # to platform tooling (NSIS on Windows, hdiutil for the .dmg), and a macOS
+          # build simply cannot be produced anywhere but macOS.
+          - os: windows-latest
+            args: --win
+          - os: macos-latest
+            args: --mac
+          - os: ubuntu-latest
+            args: --linux
+    runs-on: ${{ matrix.os }}
+    steps:
+      # Listing this workflow requires a copy on the default branch, so the branch
+      # dropdown also offers `main` — and a run from there would package official
+      # code as the beta. Fail before checkout rather than publish that. Scoped to
+      # the upstream repo: in the fork the default branch IS the beta work, so the
+      # branch name means nothing there and the rehearsal run must be allowed.
+      - name: Refuse to build anything but the beta branch
+        if: github.repository == 'Open-Historia/open-historia' && github.ref_name != 'Seventh-Dread-Beta'
+        shell: bash
+        run: |
+          echo "::error::Run this with 'Use workflow from: Seventh-Dread-Beta'."
+          exit 1
+
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      # Spotlight holds the mounted build volume and makes `hdiutil detach` fail
+      # with exit 16, which takes the whole macOS build with it. Nothing here
+      # needs an index. (Same reason as the stable workflow.)
+      - name: Stop Spotlight indexing the build volume
+        if: runner.os == 'macOS'
+        run: sudo mdutil -a -i off || true
+
+      - name: Install dependencies
+        run: npm ci
+
+      # One id for all three platforms in this run, baked into the app and written
+      # into latest.json below. The beta app compares the two — against ITS OWN
+      # release, not the stable one — to know a newer build exists.
+      - name: Stamp the build id
+        shell: bash
+        run: |
+          echo "{\"build\":\"${{ github.run_id }}\"}" > electron/build-id.json
+          cat electron/build-id.json
+
+      # What makes the packaged app behave as the beta at RUNTIME: its own Chromium
+      # profile, its update manifest, the in-app badge. The installer config
+      # below only decides how it is installed and what it is called.
+      - name: Stamp the release channel
+        run: node scripts/stamp-channel.mjs beta
+
+      - name: Build the client
+        run: npm run build
+
+      # --config is the only difference from the stable workflow: separate appId,
+      # productName, artifact names, and ohChannel=beta baked into the packaged
+      # package.json.
+      - name: Build the installer
+        run: npx electron-builder ${{ matrix.args }} --config electron-builder.beta.yml --publish never
+        env:
+          # No code-signing certificate. Without this electron-builder tries to
+          # discover one and fails the build rather than skipping signing.
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+
+      - name: Upload as a build artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: open-historia-seventhdread-beta-${{ matrix.os }}
+          # Only the finished installers; release/ also holds the unpacked app tree.
+          path: |
+            release/*.exe
+            release/*-mac-*.zip
+            release/*.AppImage
+          if-no-files-found: error
+
+      - name: Attach to the beta release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # A FIXED tag, never the branch or a per-build tag: this exact URL is
+          # baked into every shipped build as BETA_UPDATE_MANIFEST, so publishing
+          # anywhere else silently stops testers being offered updates. The input
+          # exists only for one-off builds that deliberately go somewhere private.
+          TAG: ${{ inputs.tag || 'desktop-seventhdread-beta' }}
+        shell: bash
+        run: |
+          # --prerelease so GitHub labels it, and never marks it "Latest" over the
+          # stable release in the same repo. Three jobs race here, so creating it
+          # tolerates "already exists"; --clobber lets a re-run replace assets.
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            printf '%s\n' \
+              '**Unofficial beta build of Open Historia, maintained by SeventhDread.** Not the official release — that is the one marked `Latest` on this page.' \
+              '' \
+              'It installs **alongside** the official app as *Open Historia (SeventhDread Beta)*, with its own Start Menu entry and a BETA-badged icon, and **shares your saves** with it: the same games, scenarios, settings and downloaded world map. Play a campaign here, then open the official app and carry on with it.' \
+              '' \
+              '- Windows: `Open-Historia-SeventhDread-Beta-Setup.exe`' \
+              '- macOS: `Open-Historia-SeventhDread-Beta-mac-arm64.zip` (Apple Silicon) or `-x64` (Intel) — unsigned, so right-click → Open the first time.' \
+              '- Linux: `Open-Historia-SeventhDread-Beta-x86_64.AppImage`' \
+              '' \
+              '**Already running the older "Open Historia Beta"?** Uninstall it first — this is a separate application and installs to its own folder. Your saves live somewhere else entirely and are not touched by the uninstall.' \
+              '' \
+              '**Do not run two builds at the same time** — they write the same save files. This one warns you if another is already running.' \
+              '' \
+              'Beta-only features (units, projects) may be dropped from a save if you then play that save in the official app. Back up `%APPDATA%\open-historia\server\data` before testing anything you care about.' \
+              '' \
+              'Feedback: [open an issue](https://github.com/Open-Historia/open-historia/issues).' \
+              > notes.md
+            # --target pins the tag to the commit this run built. Without it the tag
+            # would be created on the repository's DEFAULT branch — main — which is
+            # the one place a beta release must never point.
+            gh release create "$TAG" --prerelease --target "$GITHUB_SHA" \
+              --title "Open Historia (SeventhDread Beta)" \
+              --notes-file notes.md || true
+          fi
+          shopt -s nullglob
+          files=(release/*.exe release/*-mac-*.zip release/*.AppImage)
+          # Only the Windows job writes latest.json, so three racing jobs cannot
+          # each publish a different view of the same release. The filenames here
+          # must match the artifactNames in electron-builder.beta.yml exactly — a
+          # mismatch breaks self-update silently, with no failing build to notice.
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            B="https://github.com/${{ github.repository }}/releases/download/$TAG"
+            printf '{\n  "build": "%s",\n  "notes": "%s",\n  "windows": "%s/Open-Historia-SeventhDread-Beta-Setup.exe",\n  "mac": "%s/Open-Historia-SeventhDread-Beta-mac-arm64.zip",\n  "linux": "%s/Open-Historia-SeventhDread-Beta-x86_64.AppImage"\n}\n' \
+              "${{ github.run_id }}" "A newer SeventhDread beta build is available." "$B" "$B" "$B" > latest.json
+            cat latest.json
+            files+=(latest.json)
+          fi
+          gh release upload "$TAG" "${files[@]}" --clobber


### PR DESCRIPTION
Adds `.github/workflows/desktop-seventhdread-beta.yml` so the beta build on the
`Seventh-Dread-Beta` branch can be released from the Actions tab.

**This file does nothing on `main`.** It has no `push` trigger and no `pull_request`
trigger — `workflow_dispatch` only, so it cannot run unless someone deliberately clicks
"Run workflow". It is not bundled into the app (workflows aren't in electron-builder's
`files` list), and it touches no existing workflow, config or source file.

It has to live here because GitHub only lists a `workflow_dispatch` workflow in the
Actions tab if a copy exists on the default branch. Once listed, choosing
**Use workflow from: `Seventh-Dread-Beta`** runs the copy of the file on that branch, so
the build steps stay maintained on the branch rather than here.

This is the same arrangement as the existing `android-apk-beta.yml`, which sits on `main`,
is dispatch-only, builds from the `alpha` branch, and publishes to an isolated
`android-beta` pre-release.

### What it does when run

- Builds Windows / macOS / Linux installers from `Seventh-Dread-Beta` using
  `electron-builder.beta.yml` — a separate `appId` and `productName`, so it installs
  *beside* the official app rather than over it, and shares the same save library.
- Publishes to a `desktop-seventhdread-beta` pre-release. Separate tag, `--prerelease`,
  so it never takes the `Latest` badge from `desktop-stable`.
- `--target "$GITHUB_SHA"` pins the release tag to the beta commit, so it cannot land
  on `main`.

### Safety

The first step refuses to run if it is dispatched from any branch other than
`Seventh-Dread-Beta`, so a misclick on the branch dropdown fails in seconds rather than
packaging official code as a beta:

```yaml
- name: Refuse to build anything but the beta branch
  if: github.repository == 'Open-Historia/open-historia' && github.ref_name != 'Seventh-Dread-Beta'
  run: |
    echo "::error::Run this with 'Use workflow from: Seventh-Dread-Beta'."
    exit 1
```

Nothing about the stable release path changes: `desktop-installer.yml`, the
`desktop-stable` tag, `package.json`'s `build` block and the website are all untouched.