### PR TITLE
Keep the update banner polling through "available"

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "preview:web": "vite preview --outDir dist-web",
-    "test": "node --test \"server/**/*.test.js\"",
+    "test": "node --test \"server/**/*.test.js\" \"src/**/*.test.js\"",
     "electron": "electron .",
     "dist:win": "npm run build && electron-builder --win",
     "dist:mac": "npm run build && electron-builder --mac",

--- a/src/runtime/AppUpdateBanner.jsx
+++ b/src/runtime/AppUpdateBanner.jsx
@@ -5,6 +5,7 @@ import {
   APP_UPDATE_CHECK_INTERVAL_MS,
   APP_UPDATE_REFOCUS_THROTTLE_MS,
   isUpdateAvailable,
+  isUpdateSettled,
   parseUpdateManifest,
 } from "./appUpdate.js";
 
@@ -92,8 +93,11 @@ export default function AppUpdateBanner() {
   const lastRefocusRef = useRef(0);
 
   // A second-by-second poll, but only between pressing Update and the update being
-  // ready (or failing) — never while the banner is merely sitting there.
-  const running = progress?.state === "checking" || progress?.state === "downloading";
+  // ready (or failing) — never while the banner is merely sitting there. `progress`
+  // is null until the player presses Update, which is what keeps it idle; from then
+  // on it runs until the updater settles, through every intermediate state rather
+  // than only the two it happens to spend the longest in.
+  const running = progress !== null && !isUpdateSettled(progress.state);
   useEffect(() => {
     if (!running) return undefined;
     let stopped = false;
@@ -272,7 +276,10 @@ export default function AppUpdateBanner() {
     return "Installs itself in the background — your games are kept.";
   };
   const ready = Boolean(desktop && desktop.auto && progress?.state === "ready");
-  const busy = Boolean(desktop && desktop.auto && (progress?.state === "checking" || progress?.state === "downloading"));
+  // Anything the updater is still working through, by the same rule the poll uses —
+  // so a state with no percentage to show yet still reads as busy rather than
+  // falling through to the button's idle label and claiming a download is opening.
+  const busy = Boolean(desktop && desktop.auto && running);
 
   return (
     <div style={bar} role="status" aria-live="polite">

--- a/src/runtime/appUpdate.js
+++ b/src/runtime/appUpdate.js
@@ -18,6 +18,23 @@ export const APP_UPDATE_CHECK_INTERVAL_MS = 3 * 60 * 1000;
 // A re-check when the app regains focus, throttled so rapid focus flips can't hammer it.
 export const APP_UPDATE_REFOCUS_THROTTLE_MS = 60 * 1000;
 
+// The desktop updater states that will never change again on their own. A progress
+// poll that sees one has nothing left to wait for and can stop; every OTHER state is
+// transient and must keep it alive.
+//
+// Listing what is FINISHED rather than what is running, deliberately. The updater
+// passes through "available" between finding an update and its first
+// download-progress event, and a poll that only recognized "checking" and
+// "downloading" tore itself down there and never restarted — leaving the banner
+// frozen mid-update while the download ran to completion behind it. Written this way
+// round, an unrecognized state keeps polling instead of silently stopping, so
+// another lifecycle state can be added without reintroducing that freeze.
+export const APP_UPDATE_SETTLED_STATES = ["ready", "error", "none"];
+
+// Whether the app's own updater has come to rest. Anything unrecognized — including
+// no reading at all — counts as still moving.
+export const isUpdateSettled = (state) => APP_UPDATE_SETTLED_STATES.includes(state);
+
 // A positive integer build number, or null for anything else (dev/web/desktop have
 // no stamped build, so they can never see an "update available").
 export const toBuild = (value) => {

--- a/src/runtime/appUpdate.test.js
+++ b/src/runtime/appUpdate.test.js
@@ -3,7 +3,13 @@
 
 import test from "node:test";
 import assert from "node:assert/strict";
-import { toBuild, parseUpdateManifest, isUpdateAvailable } from "./appUpdate.js";
+import {
+  APP_UPDATE_SETTLED_STATES,
+  isUpdateAvailable,
+  isUpdateSettled,
+  parseUpdateManifest,
+  toBuild,
+} from "./appUpdate.js";
 
 test("toBuild accepts positive integers (number or string)", () => {
   assert.equal(toBuild(5), 5);
@@ -55,4 +61,30 @@ test("isUpdateAvailable accepts string build numbers on both sides", () => {
 test("isUpdateAvailable never throws on hostile input", () => {
   assert.doesNotThrow(() => isUpdateAvailable({}, []));
   assert.doesNotThrow(() => isUpdateAvailable(Symbol.iterator, () => {}));
+});
+
+// The banner polls for download progress only while the updater is unsettled, so a
+// state wrongly called settled stops that poll for good and freezes the banner
+// mid-update. These pin the classification rather than the wording.
+test("isUpdateSettled is true only for states that never change again", () => {
+  for (const state of APP_UPDATE_SETTLED_STATES) assert.equal(isUpdateSettled(state), true);
+});
+test("isUpdateSettled treats every transient updater state as still running", () => {
+  for (const state of ["idle", "checking", "available", "downloading"]) {
+    assert.equal(isUpdateSettled(state), false, `${state} must keep the progress poll alive`);
+  }
+});
+// The regression this was written for: "available" is what the updater reports
+// between finding an update and its first download-progress event. Classifying it as
+// settled stopped the poll there and left the banner stuck while the download ran on.
+test("isUpdateSettled keeps polling through 'available'", () => {
+  assert.equal(isUpdateSettled("available"), false);
+});
+test("isUpdateSettled treats an unknown or absent state as still running", () => {
+  for (const state of [undefined, null, "", "something-new", 0, {}]) {
+    assert.equal(isUpdateSettled(state), false);
+  }
+});
+test("APP_UPDATE_SETTLED_STATES holds exactly the finished states", () => {
+  assert.deepEqual([...APP_UPDATE_SETTLED_STATES].sort(), ["error", "none", "ready"]);
 });


### PR DESCRIPTION
A desktop update downloads and installs correctly, but the banner stops following it almost immediately and never recovers. The player is left with a disabled "Opening…" button and no progress, while the download runs to 100% and reaches "ready" behind it. Quitting the app installs the update, so the damage is to what the player is told, not to the update itself — they have no way to know it worked, and the obvious reading is that it hung.

The progress poll ran while the updater state was "checking" or "downloading". But there is a third state between those two: checkForUpdates fires update-available, setting "available", before downloadUpdate streams its first download-progress event. A poll tick landing in that window found neither of the two states it knew, so `running` went false, the effect cleanup cleared the interval — and nothing re-arms it. The banner then holds whatever it last read, forever.

That window is not narrow in practice. The poll ticks at 1s and checkForUpdates resolves in well under that on a fast connection, so the first tick after pressing Update usually lands in it. This reproduces nearly every time rather than occasionally.

Inverted the test: the poll now runs until the updater reaches a state that will not change again on its own — "ready", "error" or "none" — and treats everything else, including states it does not recognize, as still moving. That way another lifecycle state cannot silently reintroduce the freeze. The poll stays idle until the player presses Update, as before: `progress` is null until then.

`busy` now uses the same rule, so the button shows the download's percentage during "available" rather than falling through to "Opening…" and claiming a browser download that is not happening.

The classification lives in appUpdate.js with the other pure helpers so it is unit-tested without a browser, and npm test now runs src/**/*.test.js — those tests exist but nothing was executing them, this file's included.