### PR TITLE
Let a self-hosted backend constrain tool arguments to the schema

### DIFF
--- a/src/Game/AI/main.jsx
+++ b/src/Game/AI/main.jsx
@@ -647,6 +647,7 @@ async function callOpenAIStyleChatCompletions({
     history,
     providerLabel,
     customParams = {},
+    toolStrict = false,
     retries = 3,
     retryDelay = 15000,
     deadline,
@@ -707,6 +708,12 @@ async function callOpenAIStyleChatCompletions({
                         name: tool.name,
                         description: tool.description,
                         parameters: tool.schema,
+                    // Opt-in only. OpenAI rejects strict:true unless every property
+                    // is named in required, which these schemas deliberately do not
+                    // do; self-hosted grammar backends (SGLang/xgrammar, vLLM) take
+                    // the schema as-is and constrain generation with it, which is
+                    // what stops a model emitting an unbalanced or mistyped argument.
+                    ...(toolStrict ? { strict: true } : {}),
                     } }],
                     // The string form, NOT OpenAI's {type:"function",function:{name}}
                     // object: llama.cpp-based servers (LM Studio, Jan, local Qwen et
@@ -870,6 +877,7 @@ async function callOpenAICompatible(systemPrompt, history, opts = {}) {
         history,
         providerLabel: "OpenAI Compatible",
         customParams: parseCustomParams(settings.customParams, "OpenAI Compatible"),
+        toolStrict: settings.toolStrict === true,
         allowJsonSchemaFallback: true,
         tokenLimitField: "max_tokens",
         ...opts,

--- a/src/Game/AI/providerConfig.js
+++ b/src/Game/AI/providerConfig.js
@@ -79,6 +79,7 @@ const PROVIDER_SETTINGS = {
             defaultValue: "",
         },
         customParams: { storageKey: "openai_compatible_custom_params", defaultValue: "" },
+        toolStrict: { storageKey: "openai_compatible_tool_strict", defaultValue: "" },
     },
 };
 
@@ -100,6 +101,7 @@ const FORM_FIELD_MAP = {
     openaiCompatibleEndpoint: { provider: "openai-compatible", field: "endpoint" },
     openaiCompatibleModel: { provider: "openai-compatible", field: "model" },
     openaiCompatibleCustomParams: { provider: "openai-compatible", field: "customParams" },
+    openaiCompatibleToolStrict: { provider: "openai-compatible", field: "toolStrict" },
 };
 
 function isSupportedProvider(value) {
@@ -162,6 +164,8 @@ export function getProviderSettings(provider) {
         endpoint: getProviderField(normalized, "endpoint"),
         model: getProviderField(normalized, "model"),
         customParams: getProviderField(normalized, "customParams"),
+        // Opt-in, so anything other than an explicit "1" leaves it off.
+        toolStrict: getProviderField(normalized, "toolStrict") === "1",
     };
 }
 

--- a/src/Game/GameUI/settings.jsx
+++ b/src/Game/GameUI/settings.jsx
@@ -563,6 +563,20 @@ const ProviderSettingsPanel = ({ provider, settings, onSettingChange }) => {
             placeholder='{"top_p": 0.9}'
             helperText="Optional. Merged into the request body — e.g. to limit reasoning budget/effort. Invalid JSON is ignored."
             />
+            <Toggle
+            label="Strict tool schema"
+            enabled={settings.openaiCompatibleToolStrict === "1"}
+            onToggle={() => onSettingChange(
+                "openaiCompatibleToolStrict",
+                settings.openaiCompatibleToolStrict === "1" ? "" : "1",
+            )}
+            />
+            <div style={{ ...helperStyle, marginTop: "-0.6rem" }}>
+            Sends strict:true with the tool call so a self-hosted backend constrains
+            generation to the schema (SGLang/xgrammar, vLLM). Stops malformed or
+            mistyped tool arguments. Leave off for OpenAI and Azure: they reject a
+            schema that does not list every property as required.
+            </div>
             </>
         )}
 


### PR DESCRIPTION
## Problem

Against a self-hosted OpenAI-compatible backend, `submit_jump_result` regularly comes back
with `events` as a **string** instead of an array, and the turn falls back. Other runs return
syntactically valid JSON that violates the schema, e.g. `impacts.createdChats[0].countries[0]`
as a string, or a `stability` key where the schema sets `additionalProperties: false`.

The cause is not the model inventing things at random. The tool arguments are generated
completely unconstrained. SGLang (and vLLM) can constrain generation to the tool schema via a
grammar backend, but they only do so when the tool is marked `strict`. Without it the tag is
built with `json_schema: true`, which for the Qwen XML tool-call style enforces only the XML
envelope, not the parameter contents. A single unescaped `"` inside a description then
truncates the string and the whole payload becomes unparseable, at which point the server
falls back to returning the raw text.

Reproduced against SGLang with the real `JUMP_FORWARD_SCHEMA`, streaming, `tool_choice:
"required"`, changing only `strict`:

| `strict` | type of `events` | result |
| --- | --- | --- |
| absent | `str` | turn falls back |
| `true` | `list` | valid array |

A typical failure, straight from the server log:

```
"title": "„Fall Weiß": Die Wehrmacht marschiert in Polen ein"
                    ^ unescaped quote ends the string
```

## Change

Adds a **Strict tool schema** toggle to the OpenAI Compatible settings, next to endpoint and
model. When enabled, the tool is sent with `strict: true`, so a grammar-capable backend
constrains generation to the schema.

It is **opt-in and off by default**, deliberately. OpenAI and Azure reject `strict: true`
unless every property is listed in `required`; these schemas intentionally do not do that
(90 of 148 properties in `JUMP_FORWARD_SCHEMA` are optional), and making them do so would
force the model to emit every optional field on every event. Self-hosted backends have no
such restriction and accept the schema as-is. Sending it unconditionally would therefore
break the hosted providers, so the setting is scoped to the provider where it helps and left
off unless asked for.

The default path is untouched: with the toggle off, the request body is byte-identical to
before.

## Testing

- `npm run build`, `npm test` (31/31) and `npm run lint` all pass
- Verified end to end against SGLang 0.5.x with xgrammar: with the toggle off the failure
  reproduces, with it on the same prompt and schema return a valid array
- Confirmed in normal play: 21 consecutive requests without a single parser warning
  server-side, where previously nearly every turn fell back

## Note for anyone chasing the same bug

I first tried a system-prompt rule telling the model not to write an unescaped `"`. That made
things measurably **worse** — naming the character raises its salience — so it is not part of
this PR.

A second, separate issue remains that this PR does not address: with a grammar active, values
for `anyOf`-with-`null` properties (`catalyst` via `nullableCatalystSchema`) can degenerate
into runs of tabs and newlines, which are invalid control characters inside a JSON string.
That looks like a backend/grammar limitation around `anyOf`, not a client problem.
