### PR TITLE
Drop the terrain memo's unused isGlobe dependency

### DIFF
--- a/src/Game/Map/World.jsx
+++ b/src/Game/Map/World.jsx
@@ -162,7 +162,7 @@ const buildWorldStyle = (basemapId, customBg, backgroundDeclared, isGlobe, terra
     });
   }
 
-  return style
+  return style;
 };
 
 function World({ mapRef, projection, terrainEnabled, onInitialIdle }) {
@@ -196,7 +196,7 @@ function World({ mapRef, projection, terrainEnabled, onInitialIdle }) {
             exaggeration: 15,
           }
         : null,
-    [terrainEnabled, isGlobe, customBg, bgDeclared],
+    [terrainEnabled, customBg, bgDeclared],
   );
   // Render at reduced pixel density when zoomed far out: the whole-world view
   // draws every region, border and label at once, and full native resolution


### PR DESCRIPTION
9b414f5 removed !isGlobe from the terrain useMemo's condition when it re-enabled 3D terrain on the globe, but left isGlobe in the dependency array. The memo no longer reads it, so the array now claims a dependency the factory does not have and recomputes on every projection toggle -- harmless, since key={projection} remounts the map on that toggle anyway, but it leaves the next reader wondering what isGlobe is doing there.

react-hooks/exhaustive-deps reports it as an unnecessary dependency. It does not currently fire because eslint.config.js scopes its rules to **/*.{ts,tsx} and vite.config.ts is the only TypeScript file in the repo, so npm run lint checks one file out of 185. That is probably worth fixing on its own, separately..