### PR TITLE
Fix the website losing five of every six writes at the end of a turn

### DIFF
--- a/src/runtime/web/libraryStore.js
+++ b/src/runtime/web/libraryStore.js
@@ -6,6 +6,7 @@
 // Web build only.
 
 import { STORES, idbGet, idbGetAll, idbGetAllKeys, idbPut, idbPutPair, idbDelete, kvGet, kvPut } from "./idb.js";
+import { serializeWrite } from "./writeQueue.js";
 import {
   cloneJson, nowIso, jsonResponse, errorResponse, binaryResponse, base64ToBytes, bytesToBase64,
   parseJsonValue, serializeJsonValue,
@@ -537,7 +538,15 @@ const runtimeValueFromRecord = (record, assetKey, scenarioScope = false) => {
 const coerceRuntimeValue = (assetKey, value) =>
   (assetKey === "colors" || assetKey === "flags" ? parseJsonValue(value, {}) : value);
 
-const writeRuntimeJsonAsset = async (assetKey, value) => {
+// Serialized: this is a read-modify-write of the WHOLE game record (every runtime
+// JSON asset lives in one), and the end of a turn fires six of these at once. Run
+// concurrently they each read the record before any has written, and the last to
+// finish restores its stale copy of the other five — which is how the new game
+// date got reverted on the website but never in the app. See writeQueue.js.
+const writeRuntimeJsonAsset = (assetKey, value) =>
+  serializeWrite(() => writeRuntimeJsonAssetLocked(assetKey, value));
+
+const writeRuntimeJsonAssetLocked = async (assetKey, value) => {
   if (!JSON_ASSET_KEYS.includes(assetKey) && !OPTIONAL_JSON_ASSET_KEYS.includes(assetKey) && !RUNTIME_ONLY_JSON_ASSET_KEYS.includes(assetKey)) {
     throw new Error(`Unsupported JSON asset key: ${assetKey}`);
   }

--- a/src/runtime/web/writeQueue.js
+++ b/src/runtime/web/writeQueue.js
@@ -1,0 +1,39 @@
+/*! Open Historia — web-mode write serializer © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// Serializes read-modify-write of the web store's records, because in web mode
+// every runtime JSON asset for a game lives inside ONE IndexedDB record.
+//
+// The desktop server has no such coupling: game.json, world.json, events.json and
+// the rest are separate files, so six PUTs at once are six independent writes and
+// cannot interfere. The web store packs all of them into one record, so writing
+// ONE asset is a read-modify-write of ALL of them — and the end of every turn does
+// exactly that six times concurrently (gameplay.js, the Promise.all after a jump):
+//
+//   writeActionsState, writeChatsState, writeEventsState,
+//   writeGameData,     writeJson(colors), writeWorldState
+//
+// Each reads the record before any of them has written, and they land in whatever
+// order they finish. The last one to write puts back ITS stale copy of the other
+// five — so the new game date, written by writeGameData, is silently reverted by
+// whichever sibling finishes after it. That is the reported "the date doesn't
+// progress on the website but does in the app": same game code, different store,
+// and only one of the two stores has the coupling that makes the race possible.
+//
+// A single chain rather than one per record: these all mutate "the active game",
+// the operations are short, and one queue cannot deadlock or leak a key.
+
+let tail = Promise.resolve();
+
+// Runs `task` after every task already queued, and resolves with its result.
+// Rejections are the caller's to handle — the chain itself always continues, so
+// one failed write can never wedge every later one.
+export const serializeWrite = (task) => {
+  const result = tail.then(task, task);
+  tail = result.then(
+    () => {},
+    () => {},
+  );
+  return result;
+};
+
+// Test seam: waits for everything currently queued to finish.
+export const writeQueueIdle = () => tail;

--- a/src/runtime/web/writeQueue.test.js
+++ b/src/runtime/web/writeQueue.test.js
@@ -1,0 +1,122 @@
+/*! Open Historia — web-mode write serializer tests © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// Reported: on the website the game date does not progress properly; in the
+// desktop app it always does. Same game code — the difference is the store. The
+// web store keeps every runtime JSON asset of a game in ONE IndexedDB record, so
+// writing one asset is a read-modify-write of all of them, and the end of a turn
+// fires six of those concurrently (gameplay.js, the Promise.all after a jump).
+//
+// The first test below is the bug itself, reproduced against a stand-in store: it
+// asserts the OLD behaviour loses writes, so if the coupling is ever removed and
+// this stops being possible, it fails and says so. The rest pin the fix.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { serializeWrite, writeQueueIdle } from "./writeQueue.js";
+
+// A stand-in for the IndexedDB game record: one object holding all six assets,
+// with a real await between read and write so the interleave is genuine.
+const makeStore = () => {
+  let record = { game: { gameDate: "1936-01-01", round: 1 }, world: {}, events: [], actions: [], chat: [], colors: {} };
+  return {
+    read: async () => {
+      await Promise.resolve();
+      return structuredClone(record);
+    },
+    write: async (next) => {
+      await Promise.resolve();
+      record = structuredClone(next);
+    },
+    get: () => structuredClone(record),
+  };
+};
+
+// What writeRuntimeJsonAsset does: read the whole record, set one key, write it back.
+const writeAsset = (store, key, value) => async () => {
+  const current = await store.read();
+  current[key] = value;
+  await store.write(current);
+};
+
+// The six writes a finished turn issues, with the new date among them.
+const turnWrites = (store) => [
+  writeAsset(store, "actions", [{ id: "a1", status: "resolved" }]),
+  writeAsset(store, "chat", [{ id: "c1" }]),
+  writeAsset(store, "events", [{ id: "e1", title: "Anschluss" }]),
+  writeAsset(store, "game", { gameDate: "1938-03-12", round: 2 }),
+  writeAsset(store, "colors", { GER: [1, 2, 3] }),
+  writeAsset(store, "world", { units: ["u1"] }),
+];
+
+test("the bug: six concurrent writes lose all but the last", async () => {
+  const store = makeStore();
+  await Promise.all(turnWrites(store).map((run) => run()));
+
+  const after = store.get();
+  const landed = [
+    after.game.gameDate === "1938-03-12",
+    after.events.length === 1,
+    after.world.units?.length === 1,
+    after.actions.length === 1,
+    after.chat.length === 1,
+    Boolean(after.colors.GER),
+  ].filter(Boolean).length;
+
+  // Exactly one survives: every writer read the same starting record, so whichever
+  // put last overwrote the other five with its stale copy. This is why the date
+  // stops progressing — writeGameData is simply not the last one to finish.
+  assert.equal(landed, 1, "unserialized concurrent read-modify-writes must lose data");
+  assert.equal(after.game.gameDate, "1936-01-01", "the date write is one of the five that got clobbered");
+});
+
+test("serialized, the same six all land and the date progresses", async () => {
+  const store = makeStore();
+  await Promise.all(turnWrites(store).map((run) => serializeWrite(run)));
+
+  const after = store.get();
+  assert.equal(after.game.gameDate, "1938-03-12");
+  assert.equal(after.game.round, 2);
+  assert.equal(after.events.length, 1);
+  assert.equal(after.world.units.length, 1);
+  assert.equal(after.actions.length, 1);
+  assert.equal(after.chat.length, 1);
+  assert.deepEqual(after.colors.GER, [1, 2, 3]);
+});
+
+test("tasks run in the order they were queued", async () => {
+  const order = [];
+  await Promise.all(
+    [1, 2, 3, 4, 5].map((n) =>
+      serializeWrite(async () => {
+        // A varying delay so a broken queue interleaves visibly rather than by luck.
+        await new Promise((resolve) => setTimeout(resolve, (6 - n) * 4));
+        order.push(n);
+      }),
+    ),
+  );
+  assert.deepEqual(order, [1, 2, 3, 4, 5]);
+});
+
+test("a rejected task does not wedge the queue or lose the ones behind it", async () => {
+  const done = [];
+  const failing = serializeWrite(async () => {
+    throw new Error("quota exceeded");
+  });
+  const after = serializeWrite(async () => { done.push("after"); });
+
+  await assert.rejects(failing, /quota exceeded/, "the failure still reaches its own caller");
+  await after;
+  assert.deepEqual(done, ["after"], "a failed write must not strand every write behind it");
+});
+
+test("the caller gets its own task's result back", async () => {
+  assert.equal(await serializeWrite(async () => "normalized record"), "normalized record");
+});
+
+test("writeQueueIdle resolves once the queue drains", async () => {
+  const seen = [];
+  serializeWrite(async () => { seen.push("a"); });
+  serializeWrite(async () => { seen.push("b"); });
+  await writeQueueIdle();
+  assert.deepEqual(seen, ["a", "b"]);
+});


### PR DESCRIPTION
The reported symptom is that **the game date does not progress properly on the website, but always does in the desktop app**. Same game code — the difference is the store, and the date is only the visible half of it.

## What is happening

The desktop server keeps each runtime JSON asset in its **own file**. The web store packs all of them into **one IndexedDB record**, so writing one asset is a read-modify-write of *all* of them.

The end of every turn issues six writes at once (`gameplay.js`, the `Promise.all` after a jump):

```js
await Promise.all([
  writeActionsState(nextActions),
  writeChatsState(chatsToWrite),
  writeEventsState(nextEvents),
  writeGameData(nextGame),          // <- carries the new gameDate and round
  writeJson(JSON_URLS.colors, nextColors, { pretty: true }),
  writeWorldState(nextWorld),
]);
```

On desktop that is six independent file writes. On the web it is six concurrent read-modify-writes of the same record: each reads before any has written, then they land in completion order, and **the last one puts back its stale copy of the other five**.

So five of the six are discarded every turn, and which five is a race. `writeGameData` is usually among the losers — which is exactly "the date doesn't progress". The turn's events, world impacts, chats and actions are being thrown away the same way; players just notice the date.

## The fix

`writeRuntimeJsonAsset` now runs through a serializing queue, so each read-modify-write sees the previous one's result. It also closes a second race in the same function, where two concurrent writes arriving with no active game could each create one.

## Verified in a browser against the real web build

Six concurrent PUTs driven through the actual router and IndexedDB, identical in both runs:

| | date | round | events | actions | chat | colors | world |
|---|---|---|---|---|---|---|---|
| **unserialized** | 2016-01-01 → **2016-01-01** | 1 | ✗ | ✗ | ✗ | ✗ | ✓ |
| **serialized** | 2016-01-01 → **1938-03-12** | 2 | ✓ | ✓ | ✓ | ✓ | ✓ |

Only `world` survived without the fix — it happened to finish last.

Plus 6 unit tests. The first one **reproduces the data loss itself** rather than only testing the fix, so if the one-record coupling is ever removed and this stops being possible, it fails and says so. Suite 167/167.

## Note

This is a general hazard of the web store, not a one-off: any code that writes two runtime assets concurrently races the same way, and the desktop build will never show it. The queue makes the existing call sites safe; worth keeping in mind before adding more.
