### PR TITLE
Ask the browser not to evict the map cache and the saved games

### DIFF
--- a/src/runtime/web/index.js
+++ b/src/runtime/web/index.js
@@ -13,6 +13,26 @@ import { ensureSeeded } from "./libraryStore.js";
 import { showHomePage, shouldShowHome } from "./homePage.js";
 import { connectBestNode } from "./nodeConnect.js";
 
+// Everything the player owns lives in this origin's storage: the games and
+// scenarios in IndexedDB, and the ~215MB of map archives in the preload Cache.
+// By default that is "best-effort" storage, which the browser or the OS may
+// evict under pressure — losing saved games outright, and turning the next
+// launch into a full re-download of the world map.
+//
+// Requesting persistence is what the desktop app gets for free by writing to a
+// real directory. Chrome grants it on engagement or when the app is installed,
+// Firefox prompts, Safari decides on its own — and an Android WebView shell is
+// an installed app, which is the case that matters most here. Best-effort in
+// every sense: a refusal is not an error, and nothing waits on the answer.
+const requestPersistentStorage = async () => {
+  try {
+    if (!navigator.storage?.persist || await navigator.storage.persisted()) return;
+    await navigator.storage.persist();
+  } catch {
+    /* not supported, or refused — the game works either way */
+  }
+};
+
 export const installWebBackend = async () => {
   // Seed the default scenario before any /api call, then intercept.
   try {
@@ -21,6 +41,7 @@ export const installWebBackend = async () => {
     console.error("Web-mode seeding failed:", error);
   }
   installWebApiRouter();
+  requestPersistentStorage();
 
   // Home page: connect to the best content node on entry.
   // Once the player has entered this tab session, just connect in the background.


### PR DESCRIPTION
Everything a web or Android player owns lives in this origin's storage, and none of it is protected from eviction. Measured on the built app:

| store | contents | size |
|---|---|---|
| Cache `open-historia-preload-v2` | `regions` 100.9 MB, `countries` 59.8 MB, `cities` 1.5 MB | **215.5 MB** |
| IndexedDB `open-historia-web` | every game, scenario, map-editor doc | — |

`navigator.storage.persisted()` returns **false**. That is best-effort storage: the browser or the OS may evict it under pressure, which loses saved games outright and turns the next launch into a full re-download of the world map.

`navigator.storage.persist()` asks for the protection the desktop app gets for free by writing to a real directory. Chrome grants it on engagement or when the app is installed, Firefox prompts, Safari decides on its own — and an **Android WebView shell is an installed app**, which is the case this matters most for now that the APK ships the web build (#671).

Best-effort in every sense: a refusal is not an error, nothing awaits the answer, and the game plays the same either way.

## What I could not verify

I could not observe a grant. Against a bare `http://127.0.0.1` origin Chrome declines — and calling `navigator.storage.persist()` **by hand in the same page also returns false**, so the refusal is the browser's engagement heuristic rather than the call site. The case this exists for, an installed app, cannot be exercised from a desktop browser; the first APK build is where to confirm it.
