### PR TITLE
Scale the site with the screen instead of pinning it to 16px

### DIFF
--- a/public/guides.css
+++ b/public/guides.css
@@ -7,7 +7,9 @@
 }
 
 html {
-  font-size: 16px;
+  /* Fluid root size, matching the landing page: the guides are sized in rem, so
+     this scales them as one. Unchanged at/below ~90rem. */
+  font-size: clamp(16px, 0.536vw + 8.29px, 24px);
   scroll-behavior: smooth;
 }
 
@@ -29,17 +31,17 @@ a:hover {
 }
 
 .page {
-  max-width: 800px;
+  max-width: 50rem;
   margin: 0 auto;
   padding: 3rem 1.5rem 5rem;
 }
 
 .logo {
   display: block;
-  width: 64px;
-  height: 64px;
+  width: 4rem;
+  height: 4rem;
   margin: 0 auto 1.5rem;
-  border-radius: 12px;
+  border-radius: 0.75rem;
 }
 
 h1 {
@@ -84,7 +86,7 @@ p {
 .card {
   background: #121a2e;
   border: 1px solid #1e2a44;
-  border-radius: 10px;
+  border-radius: 0.625rem;
   padding: 1.5rem;
   margin-bottom: 1.2rem;
 }
@@ -102,7 +104,7 @@ p {
 .step {
   background: #121a2e;
   border: 1px solid #1e2a44;
-  border-radius: 10px;
+  border-radius: 0.625rem;
   padding: 1.2rem 1.5rem;
   margin-bottom: 1rem;
 }
@@ -123,7 +125,7 @@ code {
   background: #1a2440;
   color: #b8d8ff;
   padding: 0.15em 0.4em;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   font-size: 0.9em;
   font-family: 'Fira Code', 'Cascadia Code', 'Consolas', monospace;
 }
@@ -131,7 +133,7 @@ code {
 pre {
   background: #0a1020;
   border: 1px solid #1e2a44;
-  border-radius: 8px;
+  border-radius: 0.5rem;
   padding: 1rem 1.2rem;
   overflow-x: auto;
   margin: 0.8rem 0 1.2rem;
@@ -155,7 +157,7 @@ li {
 
 .feature-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
   gap: 1rem;
   margin: 1.2rem 0 1.8rem;
 }
@@ -163,7 +165,7 @@ li {
 .feature-tag {
   background: #121a2e;
   border: 1px solid #1e2a44;
-  border-radius: 6px;
+  border-radius: 0.375rem;
   padding: 0.65rem 1rem;
   font-size: 0.9rem;
   color: #b0c0e0;
@@ -183,7 +185,7 @@ li {
   font-weight: 600;
   padding: 0.7rem 1rem;
   text-align: left;
-  border-bottom: 2px solid #2a3a5c;
+  border-bottom: 0.125rem solid #2a3a5c;
 }
 
 .comparison-table td {
@@ -202,7 +204,7 @@ li {
   font-weight: 600;
   font-size: 1rem;
   padding: 0.75rem 2rem;
-  border-radius: 8px;
+  border-radius: 0.5rem;
   margin-top: 1rem;
   transition: background 0.2s;
 }
@@ -215,7 +217,7 @@ li {
 
 .cta-secondary {
   background: transparent;
-  border: 2px solid #2a5cdb;
+  border: 0.125rem solid #2a5cdb;
   color: #7cb8ff;
 }
 

--- a/site/index.html
+++ b/site/index.html
@@ -89,51 +89,56 @@
     --bronze:#9a6b2f; --bronze-d:#7c531d; --gold:#b8860b; --gold-l:#caa53f;
     --red:#8a2331; --red-d:#6d1a25; --green:#4c7a3d;
     --grad-gold:linear-gradient(100deg,#7c4f18 0%,#b8860b 52%,#8f6a22 100%);
-    --shadow:0 18px 42px -22px rgba(60,40,14,.55);
-    --radius:14px;
+    --shadow:0 1.125rem 2.625rem -1.375rem rgba(60,40,14,.55);
+    --radius:0.875rem;
     --serif:'EB Garamond',Georgia,'Times New Roman',serif;
     --display:'Cinzel',Georgia,'Times New Roman',serif;
   }
   *{box-sizing:border-box}
-  html{scroll-behavior:smooth}
+  html{
+    scroll-behavior:smooth;
+    /* Fluid root size: everything below is rem, so this scales the page as one.
+       Clamped to 1rem at/below ~90rem, so nothing changes on a laptop. */
+    font-size:clamp(1rem, 0.536vw + 0.51812rem, 1.5rem);
+  }
   body{
-    margin:0; color:var(--ink); font-family:var(--serif); font-size:18px; line-height:1.62;
+    margin:0; color:var(--ink); font-family:var(--serif); font-size:1.125rem; line-height:1.62;
     -webkit-font-smoothing:antialiased; position:relative;
     background:
-      radial-gradient(1200px 540px at 50% -12%, rgba(184,134,11,.12), transparent 60%),
-      radial-gradient(1000px 560px at 100% 2%, rgba(138,35,49,.06), transparent 55%),
-      repeating-linear-gradient(112deg, rgba(120,90,40,.028) 0 2px, transparent 2px 7px),
+      radial-gradient(75rem 33.75rem at 50% -12%, rgba(184,134,11,.12), transparent 60%),
+      radial-gradient(62.5rem 35rem at 100% 2%, rgba(138,35,49,.06), transparent 55%),
+      repeating-linear-gradient(112deg, rgba(120,90,40,.028) 0 0.125rem, transparent 0.125rem 0.4375rem),
       var(--parch);
     overflow-x:hidden;
   }
   a{color:inherit;text-decoration:none}
-  .wrap{max-width:1040px;margin:0 auto;padding:0 24px}
+  .wrap{max-width:65rem;margin:0 auto;padding:0 1.5rem}
   h1,h2,h3,.brand,.eyebrow,.tab,.btn,.step .n,.tag{font-family:var(--display)}
   .muted{color:var(--sepia)}
 
   /* ---------- Roman colonnade down both sides ---------- */
   .colonnade{display:none}
   @media(min-width:1180px){.colonnade{display:block}}
-  .col{position:absolute;top:0;bottom:0;width:80px;z-index:1;pointer-events:none;display:flex;flex-direction:column;
-    box-shadow:0 0 30px rgba(52,36,12,.14)}
+  .col{position:absolute;top:0;bottom:0;width:5rem;z-index:1;pointer-events:none;display:flex;flex-direction:column;
+    box-shadow:0 0 1.875rem rgba(52,36,12,.14)}
   .col.l{left:0}.col.r{right:0}
-  .col .cap{position:relative;height:60px;flex:none}
-  .col .abacus{position:absolute;top:0;left:-8px;right:-8px;height:15px;border-radius:2px;border:1px solid var(--line2);
-    background:linear-gradient(90deg,#b3a37e,#f7f0d8 50%,#b3a37e);box-shadow:0 3px 7px rgba(52,36,12,.28)}
-  .col .echinus{position:absolute;left:2px;right:2px;top:15px;bottom:0;border-bottom:1px solid var(--line2);
+  .col .cap{position:relative;height:3.75rem;flex:none}
+  .col .abacus{position:absolute;top:0;left:-0.5rem;right:-0.5rem;height:0.9375rem;border-radius:0.125rem;border:1px solid var(--line2);
+    background:linear-gradient(90deg,#b3a37e,#f7f0d8 50%,#b3a37e);box-shadow:0 0.1875rem 0.4375rem rgba(52,36,12,.28)}
+  .col .echinus{position:absolute;left:0.125rem;right:0.125rem;top:0.9375rem;bottom:0;border-bottom:1px solid var(--line2);
     background:linear-gradient(90deg,#a2926c,#f2ead0 50%,#a2926c);clip-path:polygon(0 0,100% 0,83% 100%,17% 100%)}
-  .col .shaft{flex:1;margin:0 9px;position:relative;border-left:1px solid var(--line);border-right:1px solid var(--line);
+  .col .shaft{flex:1;margin:0 0.5625rem;position:relative;border-left:1px solid var(--line);border-right:1px solid var(--line);
     background:
       linear-gradient(90deg, rgba(58,40,16,.34) 0%, rgba(255,250,235,.14) 24%, rgba(255,253,244,.60) 50%, rgba(255,250,235,.12) 76%, rgba(58,40,16,.38) 100%),
-      repeating-linear-gradient(90deg, #c8bb96 0 2px, #efe7cd 2px 9px, #c8bb96 9px 11px);
+      repeating-linear-gradient(90deg, #c8bb96 0 0.125rem, #efe7cd 0.125rem 0.5625rem, #c8bb96 0.5625rem 0.6875rem);
     background-blend-mode:normal;}
-  .col .necking{position:absolute;top:0;left:-2px;right:-2px;height:8px;border-radius:2px;
+  .col .necking{position:absolute;top:0;left:-0.125rem;right:-0.125rem;height:0.5rem;border-radius:0.125rem;
     background:linear-gradient(90deg,#a2926c,#efe6cc 50%,#a2926c);border:1px solid var(--line)}
-  .col .base{position:relative;height:56px;flex:none}
-  .col .torus{position:absolute;left:2px;right:2px;top:0;bottom:15px;border-top:1px solid rgba(255,255,255,.35);
+  .col .base{position:relative;height:3.5rem;flex:none}
+  .col .torus{position:absolute;left:0.125rem;right:0.125rem;top:0;bottom:0.9375rem;border-top:1px solid rgba(255,255,255,.35);
     background:linear-gradient(90deg,#a2926c,#f2ead0 50%,#a2926c);clip-path:polygon(17% 0,83% 0,100% 100%,0 100%)}
-  .col .plinth{position:absolute;bottom:0;left:-8px;right:-8px;height:15px;border-radius:2px;border:1px solid var(--line2);
-    background:linear-gradient(90deg,#b3a37e,#f7f0d8 50%,#b3a37e);box-shadow:0 -2px 6px rgba(52,36,12,.22)}
+  .col .plinth{position:absolute;bottom:0;left:-0.5rem;right:-0.5rem;height:0.9375rem;border-radius:0.125rem;border:1px solid var(--line2);
+    background:linear-gradient(90deg,#b3a37e,#f7f0d8 50%,#b3a37e);box-shadow:0 -0.125rem 0.375rem rgba(52,36,12,.22)}
 
   /* ---------- community bar ---------- */
   /* Above the sticky header, so it scrolls away once someone is reading and the
@@ -143,128 +148,128 @@
     background:linear-gradient(100deg,#4a3316 0%,#6d4a1c 52%,#4a3316 100%);
     border-bottom:1px solid rgba(255,225,160,.22)}
   .community-in{display:flex;flex-wrap:wrap;align-items:center;justify-content:center;
-    gap:8px 16px;min-height:46px;padding:8px 24px;text-align:center}
+    gap:0.5rem 1rem;min-height:2.875rem;padding:0.5rem 1.5rem;text-align:center}
   .community-in b{color:#fff3d6;font-weight:600}
-  .community-links{display:flex;flex-wrap:wrap;align-items:center;justify-content:center;gap:9px}
-  .community-btn{display:inline-flex;align-items:center;gap:7px;padding:6px 15px;border-radius:999px;
+  .community-links{display:flex;flex-wrap:wrap;align-items:center;justify-content:center;gap:0.5625rem}
+  .community-btn{display:inline-flex;align-items:center;gap:0.4375rem;padding:0.375rem 0.9375rem;border-radius:999px;
     font-family:var(--display);font-size:.76rem;letter-spacing:.08em;text-transform:uppercase;font-weight:700;
     white-space:nowrap;color:#f7eccf;border:1px solid rgba(255,225,160,.34);background:rgba(255,235,190,.10);
     transition:background .15s,border-color .15s,transform .12s}
   .community-btn:hover{background:rgba(255,235,190,.2);border-color:rgba(255,225,160,.62);transform:translateY(-1px)}
   /* On a narrow screen the two buttons ARE the message — the sentence is what goes. */
-  @media(max-width:560px){.community-in{gap:8px;padding:7px 12px;min-height:42px}.community-say{display:none}
-    .community-btn{font-size:.7rem;letter-spacing:.05em;padding:6px 12px}}
+  @media(max-width:560px){.community-in{gap:0.5rem;padding:0.4375rem 0.75rem;min-height:2.625rem}.community-say{display:none}
+    .community-btn{font-size:.7rem;letter-spacing:.05em;padding:0.375rem 0.75rem}}
 
   /* ---------- header ---------- */
-  header{position:sticky;top:0;z-index:50;backdrop-filter:blur(8px);
+  header{position:sticky;top:0;z-index:50;backdrop-filter:blur(0.5rem);
     background:color-mix(in srgb,var(--parch) 82%,transparent);border-bottom:1px solid var(--line)}
-  .nav{display:flex;align-items:center;justify-content:space-between;height:64px}
-  .brand{display:flex;align-items:center;gap:10px;font-weight:700;font-size:1.12rem;letter-spacing:.04em;color:var(--ink)}
+  .nav{display:flex;align-items:center;justify-content:space-between;height:4rem}
+  .brand{display:flex;align-items:center;gap:0.625rem;font-weight:700;font-size:1.12rem;letter-spacing:.04em;color:var(--ink)}
   .brand .globe{font-size:1.3rem}
-  .nav-links{display:flex;align-items:center;gap:28px;font-size:1.02rem}
+  .nav-links{display:flex;align-items:center;gap:1.75rem;font-size:1.02rem}
   .nav-links a{color:var(--sepia);transition:color .15s}
   .nav-links a:hover{color:var(--ink)}
   .nav-cta{font-family:var(--display);font-size:.86rem;letter-spacing:.08em;text-transform:uppercase;font-weight:700;
-    padding:9px 18px;border-radius:8px;background:var(--grad-gold);color:#fbf3dc;border:1px solid rgba(255,225,160,.35)}
+    padding:0.5625rem 1.125rem;border-radius:0.5rem;background:var(--grad-gold);color:#fbf3dc;border:1px solid rgba(255,225,160,.35)}
   @media(max-width:720px){.nav-links a:not(.nav-cta){display:none}}
 
   /* ---------- hero ---------- */
-  .hero{padding:74px 0 30px;text-align:center}
-  .badge{display:inline-flex;align-items:center;gap:8px;padding:7px 16px;border:1px solid var(--line2);
+  .hero{padding:4.625rem 0 1.875rem;text-align:center}
+  .badge{display:inline-flex;align-items:center;gap:0.5rem;padding:0.4375rem 1rem;border:1px solid var(--line2);
     border-radius:999px;font-size:.92rem;color:var(--sepia);background:var(--marble)}
   .badge b{color:var(--red);font-weight:600}
-  h1{font-size:clamp(2.6rem,6.4vw,4.6rem);line-height:1.04;letter-spacing:.01em;margin:24px 0 0;font-weight:800;color:var(--ink)}
+  h1{font-size:clamp(2.6rem,6.4vw,4.6rem);line-height:1.04;letter-spacing:.01em;margin:1.5rem 0 0;font-weight:800;color:var(--ink)}
   .grad{background:var(--grad-gold);-webkit-background-clip:text;background-clip:text;color:transparent}
-  .sub{font-size:clamp(1.15rem,2.3vw,1.4rem);color:var(--sepia);max-width:640px;margin:22px auto 0}
-  .cta-row{display:flex;flex-wrap:wrap;gap:14px;justify-content:center;margin:34px 0 10px}
-  .btn{display:inline-flex;align-items:center;gap:10px;padding:15px 28px;border-radius:11px;font-weight:700;
+  .sub{font-size:clamp(1.15rem,2.3vw,1.4rem);color:var(--sepia);max-width:40rem;margin:1.375rem auto 0}
+  .cta-row{display:flex;flex-wrap:wrap;gap:0.875rem;justify-content:center;margin:2.125rem 0 0.625rem}
+  .btn{display:inline-flex;align-items:center;gap:0.625rem;padding:0.9375rem 1.75rem;border-radius:0.6875rem;font-weight:700;
     font-size:.94rem;letter-spacing:.05em;text-transform:uppercase;border:1px solid transparent;
     transition:transform .12s ease,box-shadow .2s,background .2s;cursor:pointer}
-  .btn:hover{transform:translateY(-2px)}
+  .btn:hover{transform:translateY(-0.125rem)}
   .btn-primary{background:linear-gradient(180deg,#98283a,var(--red-d));color:#f7eccf;
-    border-color:rgba(255,222,160,.4);box-shadow:0 12px 30px -12px rgba(110,26,37,.7)}
+    border-color:rgba(255,222,160,.4);box-shadow:0 0.75rem 1.875rem -0.75rem rgba(110,26,37,.7)}
   .btn-primary:hover{background:linear-gradient(180deg,#a12b3e,#7a1e2b)}
   .btn-ghost{background:var(--marble);border-color:var(--line2);color:var(--ink)}
   .btn-ghost:hover{background:var(--marble2)}
-  .hero-note{font-size:.96rem;color:var(--sepia2);margin-top:8px;font-style:italic}
-  #heroNote{max-width:640px;margin-left:auto;margin-right:auto}
+  .hero-note{font-size:.96rem;color:var(--sepia2);margin-top:0.5rem;font-style:italic}
+  #heroNote{max-width:40rem;margin-left:auto;margin-right:auto}
   .hero-note a{color:var(--bronze);border-bottom:1px solid rgba(154,107,47,.4)}
 
-  .shot{margin:50px auto 0;max-width:940px;position:relative}
-  .shot::before{content:"";position:absolute;inset:-10px;border-radius:calc(var(--radius) + 8px);
-    background:var(--grad-gold);opacity:.5;filter:blur(2px);z-index:-1}
-  .shot img{width:100%;display:block;border-radius:var(--radius);border:3px solid #cdb87e;box-shadow:var(--shadow)}
+  .shot{margin:3.125rem auto 0;max-width:58.75rem;position:relative}
+  .shot::before{content:"";position:absolute;inset:-0.625rem;border-radius:calc(var(--radius) + 0.5rem);
+    background:var(--grad-gold);opacity:.5;filter:blur(0.125rem);z-index:-1}
+  .shot img{width:100%;display:block;border-radius:var(--radius);border:0.1875rem solid #cdb87e;box-shadow:var(--shadow)}
 
   /* ---------- sections ---------- */
-  section{padding:62px 0}
+  section{padding:3.875rem 0}
   .eyebrow{color:var(--bronze);font-weight:600;font-size:.82rem;letter-spacing:.22em;text-transform:uppercase;text-align:center}
-  h2{font-size:clamp(1.9rem,3.8vw,2.7rem);letter-spacing:.02em;text-align:center;margin:12px 0 0;font-weight:700;color:var(--ink)}
-  .lead{color:var(--sepia);text-align:center;max-width:620px;margin:16px auto 0;font-size:1.12rem}
+  h2{font-size:clamp(1.9rem,3.8vw,2.7rem);letter-spacing:.02em;text-align:center;margin:0.75rem 0 0;font-weight:700;color:var(--ink)}
+  .lead{color:var(--sepia);text-align:center;max-width:38.75rem;margin:1rem auto 0;font-size:1.12rem}
 
-  .rule{width:120px;height:2px;margin:20px auto 0;background:linear-gradient(90deg,transparent,var(--bronze),transparent)}
+  .rule{width:7.5rem;height:0.125rem;margin:1.25rem auto 0;background:linear-gradient(90deg,transparent,var(--bronze),transparent)}
 
   /* steps */
-  .steps{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin-top:42px}
-  .step{background:var(--marble);border:1px solid var(--line);border-radius:var(--radius);padding:26px 24px;box-shadow:var(--shadow)}
-  .step .n{width:46px;height:46px;border-radius:9px;background:var(--marble2);border:1px solid var(--line2);
+  .steps{display:grid;grid-template-columns:repeat(3,1fr);gap:1.125rem;margin-top:2.625rem}
+  .step{background:var(--marble);border:1px solid var(--line);border-radius:var(--radius);padding:1.625rem 1.5rem;box-shadow:var(--shadow)}
+  .step .n{width:2.875rem;height:2.875rem;border-radius:0.5625rem;background:var(--marble2);border:1px solid var(--line2);
     display:grid;place-items:center;font-weight:700;color:var(--bronze);font-size:1.25rem;letter-spacing:.02em}
-  .step h3{margin:16px 0 6px;font-size:1.22rem;letter-spacing:.02em;color:var(--ink);font-weight:600}
+  .step h3{margin:1rem 0 0.375rem;font-size:1.22rem;letter-spacing:.02em;color:var(--ink);font-weight:600}
   .step p{margin:0;color:var(--sepia);font-size:1.02rem}
-  .step code{background:var(--parch);border:1px solid var(--line);padding:1px 7px;border-radius:5px;font-size:.86em;font-family:ui-monospace,Consolas,monospace}
+  .step code{background:var(--parch);border:1px solid var(--line);padding:1px 0.4375rem;border-radius:0.3125rem;font-size:.86em;font-family:ui-monospace,Consolas,monospace}
   @media(max-width:760px){.steps{grid-template-columns:1fr}}
 
   /* os tabs */
-  .runbox{margin-top:24px;background:var(--marble);border:1px solid var(--line2);border-radius:var(--radius);overflow:hidden;box-shadow:var(--shadow)}
+  .runbox{margin-top:1.5rem;background:var(--marble);border:1px solid var(--line2);border-radius:var(--radius);overflow:hidden;box-shadow:var(--shadow)}
   .tabs{display:flex;border-bottom:1px solid var(--line)}
-  .tab{flex:1;padding:15px;background:none;border:0;color:var(--sepia);font-weight:600;font-size:.92rem;letter-spacing:.04em;
-    cursor:pointer;border-bottom:3px solid transparent;transition:.15s}
+  .tab{flex:1;padding:0.9375rem;background:none;border:0;color:var(--sepia);font-weight:600;font-size:.92rem;letter-spacing:.04em;
+    cursor:pointer;border-bottom:0.1875rem solid transparent;transition:.15s}
   .tab[aria-selected="true"]{color:var(--ink);border-bottom-color:var(--red);background:var(--marble2)}
-  .tab-body{padding:22px 26px;display:none;font-size:1.05rem;color:var(--sepia)}
+  .tab-body{padding:1.375rem 1.625rem;display:none;font-size:1.05rem;color:var(--sepia)}
   .tab-body.on{display:block}
   .tab-body b{color:var(--ink);font-weight:600}
-  .kbd{background:var(--parch);border:1px solid var(--line2);border-bottom-width:2px;border-radius:6px;padding:2px 9px;
+  .kbd{background:var(--parch);border:1px solid var(--line2);border-bottom-width:0.125rem;border-radius:0.375rem;padding:0.125rem 0.5625rem;
     font-family:ui-monospace,Consolas,monospace;font-size:.82em;color:var(--ink);white-space:nowrap}
 
   /* download cards */
-  .dl{display:grid;grid-template-columns:1.3fr 1fr 1fr;gap:18px;margin-top:42px}
-  .card{position:relative;background:var(--marble);border:1px solid var(--line);border-radius:var(--radius);padding:26px 24px;display:flex;flex-direction:column;box-shadow:var(--shadow)}
+  .dl{display:grid;grid-template-columns:1.3fr 1fr 1fr;gap:1.125rem;margin-top:2.625rem}
+  .card{position:relative;background:var(--marble);border:1px solid var(--line);border-radius:var(--radius);padding:1.625rem 1.5rem;display:flex;flex-direction:column;box-shadow:var(--shadow)}
   .card.feature{border-color:var(--bronze);box-shadow:0 0 0 1px rgba(154,107,47,.25) inset,var(--shadow)}
   .card .ic{font-size:1.8rem}
-  .card h3{margin:14px 0 2px;font-size:1.3rem;letter-spacing:.02em;color:var(--ink);font-weight:600}
+  .card h3{margin:0.875rem 0 0.125rem;font-size:1.3rem;letter-spacing:.02em;color:var(--ink);font-weight:600}
   .card .meta{color:var(--sepia2);font-size:.92rem;font-style:italic}
-  .card p{color:var(--sepia);font-size:1.02rem;margin:12px 0 20px;flex:1}
-  .card .btn{width:100%;justify-content:center;padding:13px}
-  .tag{position:absolute;top:16px;right:16px;font-size:.66rem;font-weight:700;letter-spacing:.1em;text-transform:uppercase;
-    color:#5b3d0c;background:linear-gradient(180deg,#e6c469,#c99a2e);padding:5px 11px;border-radius:999px;border:1px solid rgba(120,80,15,.4)}
+  .card p{color:var(--sepia);font-size:1.02rem;margin:0.75rem 0 1.25rem;flex:1}
+  .card .btn{width:100%;justify-content:center;padding:0.8125rem}
+  .tag{position:absolute;top:1rem;right:1rem;font-size:.66rem;font-weight:700;letter-spacing:.1em;text-transform:uppercase;
+    color:#5b3d0c;background:linear-gradient(180deg,#e6c469,#c99a2e);padding:0.3125rem 0.6875rem;border-radius:999px;border:1px solid rgba(120,80,15,.4)}
   @media(max-width:820px){.dl{grid-template-columns:1fr}}
 
   /* features */
-  .feats{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-top:42px}
-  .feat{background:var(--marble);border:1px solid var(--line);border-radius:12px;padding:22px}
+  .feats{display:grid;grid-template-columns:repeat(3,1fr);gap:1rem;margin-top:2.625rem}
+  .feat{background:var(--marble);border:1px solid var(--line);border-radius:0.75rem;padding:1.375rem}
   .feat .fi{font-size:1.55rem}
-  .feat h4{margin:10px 0 5px;font-size:1.12rem;letter-spacing:.02em;color:var(--ink);font-family:var(--display);font-weight:600}
+  .feat h4{margin:0.625rem 0 0.3125rem;font-size:1.12rem;letter-spacing:.02em;color:var(--ink);font-family:var(--display);font-weight:600}
   .feat p{margin:0;color:var(--sepia);font-size:.98rem}
   @media(max-width:820px){.feats{grid-template-columns:1fr 1fr}}
   @media(max-width:520px){.feats{grid-template-columns:1fr}}
 
   /* faq */
-  .faq{max-width:760px;margin:38px auto 0}
-  details{background:var(--marble);border:1px solid var(--line);border-radius:11px;padding:2px 22px;margin-bottom:12px}
+  .faq{max-width:47.5rem;margin:2.375rem auto 0}
+  details{background:var(--marble);border:1px solid var(--line);border-radius:0.6875rem;padding:0.125rem 1.375rem;margin-bottom:0.75rem}
   details[open]{border-color:var(--line2)}
-  summary{cursor:pointer;padding:17px 0;font-weight:600;font-size:1.1rem;list-style:none;display:flex;justify-content:space-between;align-items:center;color:var(--ink)}
+  summary{cursor:pointer;padding:1.0625rem 0;font-weight:600;font-size:1.1rem;list-style:none;display:flex;justify-content:space-between;align-items:center;color:var(--ink)}
   summary::-webkit-details-marker{display:none}
   summary::after{content:"+";color:var(--bronze);font-size:1.4rem;transition:transform .2s}
   details[open] summary::after{transform:rotate(45deg)}
-  details p{margin:0 0 18px;color:var(--sepia);font-size:1.04rem}
+  details p{margin:0 0 1.125rem;color:var(--sepia);font-size:1.04rem}
   details a{color:var(--bronze);border-bottom:1px solid rgba(154,107,47,.4)}
 
   /* cta band + footer */
-  .band{background:var(--marble);border:1px solid var(--line2);border-radius:20px;padding:52px 30px;text-align:center;margin-top:20px;
-    background-image:radial-gradient(720px 300px at 50% -40%,rgba(184,134,11,.16),transparent),linear-gradient(var(--marble),var(--marble));box-shadow:var(--shadow)}
-  footer{border-top:1px solid var(--line);margin-top:70px;padding:34px 0 60px;color:var(--sepia);font-size:.98rem}
-  .foot{display:flex;flex-wrap:wrap;gap:16px;justify-content:space-between;align-items:center}
+  .band{background:var(--marble);border:1px solid var(--line2);border-radius:1.25rem;padding:3.25rem 1.875rem;text-align:center;margin-top:1.25rem;
+    background-image:radial-gradient(45rem 18.75rem at 50% -40%,rgba(184,134,11,.16),transparent),linear-gradient(var(--marble),var(--marble));box-shadow:var(--shadow)}
+  footer{border-top:1px solid var(--line);margin-top:4.375rem;padding:2.125rem 0 3.75rem;color:var(--sepia);font-size:.98rem}
+  .foot{display:flex;flex-wrap:wrap;gap:1rem;justify-content:space-between;align-items:center}
   .foot a{color:var(--sepia)}.foot a:hover{color:var(--ink)}
-  .fnav{display:flex;gap:24px;flex-wrap:wrap}
+  .fnav{display:flex;gap:1.5rem;flex-wrap:wrap}
 </style>
 </head>
 <body>


### PR DESCRIPTION
On a large monitor the page sat as a fixed **1040px column of 16px-rooted text** in the middle of the screen — and the Roman colonnade and parchment weave stayed at their laptop size right next to it. Everything small, decoration included.

## What changed

The root font-size is now fluid, and **every length in both stylesheets is expressed in rem**, so the whole page scales as one thing: type, column width, pillar width, capital and plinth heights, the fluting stripes, the parchment weave, and the radial washes behind it. 157 px lengths converted on the landing page, 13 in `guides.css`.

The clamp is pinned so **nothing changes on a laptop** — at 1440px and below the root resolves to 16px, exactly what it has always been. It only grows above that:

```
1440 → 16.0px    1920 → 18.6px    2560 → 22.0px    3840+ → 24px (capped)
```

## The `/play/` connect screen too (second commit)

Same problem in miniature: a fixed 480px card at 17px with its own px colonnade. Its CSS is injected into the **game** page, so `html{}` is not ours to touch — scaling it would rescale the whole game UI under the overlay. A scoped unit does the same job: `--u` is the fluid root-equivalent, defined on `.oh-home`, and all 128 lengths in that sheet become multiples of it. Identical at ≤1440px, up to 24px on 4K.

## Three things deliberately did not convert

- **`@media` breakpoints** — they key off the viewport. Scaling them with the root font would make the breakpoints move as the page scaled, which is circular.
- **`1px`, everywhere** — hairline borders stay crisp instead of blurring to 1.5px at the top of the range.
- **`999px`** — the pill-radius idiom, not a real length.

## Measured

viewport → root / `.wrap` / `h1` / pillar / capital:

| viewport | root | .wrap | h1 | pillar | capital |
|---|---|---|---|---|---|
| **1440** | **16.01px** | **1040.5** | **73.6** | **80.0** | **60.0** |
| 1920 | 18.58px | 1207.8 | 85.5 | 92.9 | 69.7 |
| 2560 | 22.01px | 1430.8 | 101.3 | 110.0 | 82.5 |
| 3840 | 24.00px | 1560.0 | 110.4 | 120.0 | 90.0 |

The 1440 row is within 0.05px of the current site on every measure — that is the "don't touch my laptop" check.

No horizontal scroll at any width. At 375px the root stays 16px and the colonnade and nav links still collapse, so mobile is untouched.

## The game is not affected

`guides.css` is copied into `/play/` by the site assembler, so it was worth checking: `/play/index.html` links **only** its own bundle and never `guides.css`. The game UI's root font-size is unchanged — deliberately, and the connect screen's scoped unit is what keeps it that way.
