### PR TITLE
Espionage: notes for wiring real wars into hostility (+ a null-hostility fix)

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -1555,8 +1555,44 @@ const applySimulationResult = async ({
   // Espionage resolves on the world the turn produced, deterministically (keyed
   // on the round), and its consequences are EVENTS the model reads next turn —
   // an exposed ring, a suspected agent — so what was found out changes what
-  // happens. Hostility is approximated: a polity the player spies on, or one
-  // whose reputation is in the gutter, goes looking for a spy of its own.
+  // happens.
+  //
+  // HOSTILITY IS A STAND-IN. There is no war state in the world yet, so
+  // `hostile` is guessed: a polity the player spies on, or one whose reputation
+  // is in the gutter, goes looking for a spy of its own.
+  //
+  // ── For whoever wires real wars in ──────────────────────────────────────
+  // This block is the ONLY place hostility is derived; spycraft.js just takes
+  // what it is handed. When world state carries wars, replace the two-line
+  // heuristic below with the real thing and leave the rest alone:
+  //
+  //   1. Keep the contract: candidates is [{ polity, hostile }], one entry per
+  //      polity that could plant an agent this round. Every polity in the
+  //      world should be a candidate — being at peace only lowers the odds.
+  //
+  //   2. hostile: true for every polity currently AT WAR with the player. Keep
+  //      the reputation clause as an OR if you like (a pariah state still spies
+  //      on everyone); drop the "spiedOn" tit-for-tat, which only exists because
+  //      nothing better was available.
+  //
+  //   3. If wars carry a scale (skirmish vs total war, or belligerent vs
+  //      co-belligerent), pass `hostility` as a 0..1 number instead of the
+  //      boolean and read it in spycraft.js foreignDeployChance — the note
+  //      there says how. Do NOT change the seeded roll keys (`${polity}:deploy`)
+  //      or every existing save replays its next round differently.
+  //
+  //   4. Consider a target at war EXPELLING rather than turning a caught agent
+  //      (spycraft.js resolveEspionage, the turnChance branch): wartime
+  //      counter-intelligence tends to make arrests public. That is a design
+  //      choice, not a bug fix — leave it if you want double agents in wartime.
+  //
+  //   5. The simulator's [Espionage] block (spycraft.js espionageBrief) should
+  //      say who is at war with whom next to the agent list, so the model can
+  //      connect a stolen plan to the front it matters on. That is one line
+  //      added to the brief, fed from the same war state.
+  //
+  // What NOT to touch: detectionChance / suspicionChance are about the two
+  // services, not the relationship, and should stay independent of war.
   const espionageCandidates = (() => {
     const player = normalizeString(baseGame.country);
     const named = new Set([

--- a/src/runtime/spycraft.js
+++ b/src/runtime/spycraft.js
@@ -142,8 +142,19 @@ export const suspicionChance = (ownerIntelligence, targetIntelligence) => {
 
 // Per jump, another polity plants a spy in the player. A capable service does
 // it as a matter of course; a hostile one goes looking.
-export const foreignDeployChance = (polityIntelligence, { hostile = false } = {}) =>
-  clamp01(clampPct(polityIntelligence) / 100 * 0.12 + (hostile ? 0.15 : 0), 0, 0.4);
+//
+// `hostile` is a boolean today because the caller (gameplay.js, the
+// espionageCandidates block) has no war state to read and guesses it. When
+// real wars exist, the intended shape is a 0..1 `hostility` — at peace 0, cold
+// rivalry ~0.4, open war 1 — replacing the flat +0.15 with `+ hostility * 0.2`
+// so a full war roughly doubles a capable service's odds and a skirmish nudges
+// them. Keep the 0.4 cap: three agents in one polity at once is already the
+// limit (MAX_FOREIGN_SPIES), and higher per-roll odds just reach it sooner.
+export const foreignDeployChance = (polityIntelligence, { hostile = false, hostility = null } = {}) => {
+  // Accept the graded form already, so wiring it is a one-line change upstream.
+  const h = Number.isFinite(Number(hostility)) ? clamp01(Number(hostility)) : (hostile ? 0.75 : 0);
+  return clamp01(clampPct(polityIntelligence) / 100 * 0.12 + h * 0.2, 0, 0.4);
+};
 
 // ---- the per-jump resolution ------------------------------------------------
 //
@@ -151,8 +162,12 @@ export const foreignDeployChance = (polityIntelligence, { hostile = false } = {}
 // world is written. Deterministic: every roll is keyed on the round and the
 // spy, so the same inputs always produce the same outcome.
 //
-// candidates: [{ polity, hostile }] — polities that could plant a spy in the
-// player this round (the caller knows who is in the world; this file does not).
+// candidates: [{ polity, hostile, hostility? }] — polities that could plant a
+// spy in the player this round. The caller knows who is in the world and how
+// they stand with the player; this file does not, and must not start to: keep
+// war state upstream in gameplay.js and pass its verdict in. `hostility` (0..1)
+// is the graded form for when wars carry a scale; `hostile` is the boolean
+// stand-in used until then. Both are read by foreignDeployChance.
 export const resolveEspionage = (world, { round = 0, date = "", playerPolity = "", candidates = [] } = {}) => {
   const player = String(playerPolity ?? "").trim();
   let spies = normalizeSpies(world?.spies);
@@ -216,7 +231,7 @@ export const resolveEspionage = (world, { round = 0, date = "", playerPolity = "
       if (!polity || polity === player) continue;
       if (inPlayer().length >= MAX_FOREIGN_SPIES) break;
       if (inPlayer().some((spy) => spy.owner === polity)) continue;
-      if (roll(`${polity}:deploy`) < foreignDeployChance(intel(polity), { hostile: candidate?.hostile === true })) {
+      if (roll(`${polity}:deploy`) < foreignDeployChance(intel(polity), { hostile: candidate?.hostile === true, hostility: candidate?.hostility })) {
         spies = [...spies, {
           id: mintId(spies, polity, player), owner: polity, target: player, deployedAt: date,
           status: "active", turnedAt: "", exposedAt: "", coverStory: "", suspected: false,

--- a/src/runtime/spycraft.js
+++ b/src/runtime/spycraft.js
@@ -152,7 +152,8 @@ export const suspicionChance = (ownerIntelligence, targetIntelligence) => {
 // limit (MAX_FOREIGN_SPIES), and higher per-roll odds just reach it sooner.
 export const foreignDeployChance = (polityIntelligence, { hostile = false, hostility = null } = {}) => {
   // Accept the graded form already, so wiring it is a one-line change upstream.
-  const h = Number.isFinite(Number(hostility)) ? clamp01(Number(hostility)) : (hostile ? 0.75 : 0);
+  // typeof, not Number(): Number(null) is 0, which would silently drop the boolean path.
+  const h = typeof hostility === "number" && Number.isFinite(hostility) ? clamp01(hostility) : (hostile ? 0.75 : 0);
   return clamp01(clampPct(polityIntelligence) / 100 * 0.12 + h * 0.2, 0, 0.4);
 };
 


### PR DESCRIPTION
Follow-up to #675, which merged before these two commits were pushed to its branch (same slip as #676 — re-applied on current main).

## The notes

Hostility is derived in exactly one place — the `espionageCandidates` block in `gameplay.js` — and that is where the guide for whoever wires real wars lives. In order:

1. **Keep the contract:** `candidates` is `[{ polity, hostile }]`, one entry per polity in the world. Peace only lowers the odds; it excludes nobody.
2. **`hostile: true` for anyone at war with the player.** Keep the reputation clause as an OR if wanted; drop the "spied-on → spies back" tit-for-tat, which only exists because nothing better was available.
3. **If wars carry a scale**, pass `hostility` as 0..1 instead — `foreignDeployChance` in `spycraft.js` **already accepts it** (peace 0, rivalry ~0.4, war 1), so the upstream change is one line. Do not touch the seeded roll keys, or every existing save replays its next round differently.
4. A design option, not a fix: a wartime target could expel rather than turn a caught agent.
5. The simulator's `[Espionage]` brief should name who is at war with whom next to the agent list.

What not to touch: `detectionChance` / `suspicionChance` are about the two services, not the relationship.

## The fix

Adding the graded parameter, the fallback checked `Number.isFinite(Number(hostility))` — but `Number(null)` is `0`, so the default read as "at peace" and `hostile: true` silently stopped adding its +0.15. The existing test caught it; it now checks the type. Verified: `hostile:true` → 0.222, plain → 0.072, `hostility:1` → 0.272, `hostility:null` → 0.072. Suite 182/182.
