### PR TITLE
Give the Linux packages a maintainer, so the deb builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
       "artifactName": "Open-Historia-mac-${arch}.${ext}"
     },
     "linux": {
+      "maintainer": "Arkniem <nichojkrol@gmail.com>",
       "target": [
         {
           "target": "AppImage",


### PR DESCRIPTION
Both Desktop installer runs since #673 (#14, #15) failed on the Linux job:

```
⨯ Please specify author 'email' in the application package.json
```

electron-builder's `deb` target writes a `Maintainer` field into the package and refuses to build without one. The AppImage never needed it, so nothing asked for it until the deb target existed — and because the workflow only runs on dispatch, the first time it was exercised was after #673 merged. My miss: I could not build a deb locally and said so in #673, and this is the thing that check would have caught.

Set as `build.linux.maintainer` rather than a top-level `author`, so it is scoped to the packages that carry it. The identity is the one every commit in this repo is attributed to.

Windows and macOS were unaffected: run #15 already put new `.exe`/`.zip` builds and the `latest*.yml` feed on `desktop-stable`. Linux is still July's AppImage until this merges and the workflow is dispatched again.

Not verified here — no Linux box, same as before. `package.json` parses; the workflow run is the test.