### PR TITLE
Fix the 400 that stopped spies saving anything on the desktop app

### DIFF
--- a/server/libraryStore.js
+++ b/server/libraryStore.js
@@ -2405,7 +2405,17 @@ const writeRuntimeJsonAsset = (assetKey, value) => {
   // forever, which looks exactly like "my game saved nothing". Refusing is safe —
   // writeJson throws on a non-ok response, so the caller sees a real failure
   // instead of silently corrupting a save.
-  const expectsArray = assetKey in STORAGE_JSON_ASSET_FILES || assetKey in RUNTIME_ONLY_JSON_ASSET_FILES;
+  //
+  // The expectation comes from the asset's DECLARED DEFAULT, not from which
+  // registry it sits in. This used to read "storage or runtime-only means an
+  // array", which was only accidentally true: every asset in those two sets
+  // happened to be an array until `intercepts` — an object keyed by polity —
+  // joined the runtime-only set, at which point every write of it was rejected
+  // with a 400 and the Spy tab could not save what a spy had gathered.
+  // JSON_ASSET_DEFAULTS already states each asset's shape, so deriving it there
+  // cannot drift apart again. A key with no declared default (flags, tags) is an
+  // object, which is what it was before.
+  const expectsArray = Array.isArray(JSON_ASSET_DEFAULTS[assetKey]);
   const shapeOk = expectsArray
     ? Array.isArray(value)
     : Boolean(value) && typeof value === "object" && !Array.isArray(value);

--- a/server/runtimeJsonShape.test.js
+++ b/server/runtimeJsonShape.test.js
@@ -1,0 +1,81 @@
+/*! Open Historia — runtime JSON shape-guard tests © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// The write path refuses a body of the wrong shape, so a PUT that never parsed
+// (express.json hands the route {}) cannot overwrite a game's event log with an
+// empty object. The expectation used to be "storage or runtime-only means an
+// array", which was accidentally true until `intercepts` — an object keyed by
+// polity — joined the runtime-only set: every Spy-tab save then 400'd with
+//
+//   Failed to save /api/runtime/json/intercepts?v=…: HTTP 400
+//
+// These drive the real routes, one assertion per asset shape, so the guard and
+// the declared defaults can never drift apart again without a red test.
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test, { after, before } from "node:test";
+
+const DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), "oh-shape-test-"));
+process.env.OH_DATA_DIR = DATA_DIR;
+process.env.PORT = "39518";
+
+let httpServer;
+let base;
+
+const put = (key, body) =>
+  fetch(`${base}/api/runtime/json/${key}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+const get = async (key) => (await fetch(`${base}/api/runtime/json/${key}`)).json();
+
+before(async () => {
+  ({ httpServer } = await import("./server.js"));
+  base = `http://127.0.0.1:${process.env.PORT}`;
+});
+
+after(() => {
+  httpServer?.close();
+  fs.rmSync(DATA_DIR, { recursive: true, force: true });
+});
+
+test("intercepts is an object asset and round-trips", async () => {
+  const intercepts = {
+    Germany: {
+      gatheredAt: "1938-03-12",
+      round: 3,
+      planted: false,
+      exchanges: [{ id: "germany:3:0", counterpart: "Italy", date: "1938-03-04", subject: "Austria", messages: [{ speaker: "Germany", cipher: "AAAA" }] }],
+    },
+  };
+  const res = await put("intercepts", intercepts);
+  assert.equal(res.status, 200, "an object body must be accepted for intercepts");
+  assert.deepEqual(await get("intercepts"), intercepts);
+});
+
+test("the array assets still reject an object", async () => {
+  // The corruption this guard exists to stop: a body that never parsed arriving
+  // as {} and replacing a game's whole event log.
+  for (const key of ["events", "actions", "chat", "advisor", "snapshots"]) {
+    const res = await put(key, {});
+    assert.equal(res.status, 400, `${key} must refuse an object`);
+    assert.match(await res.text(), /expected an array/, `${key} must say what it wanted`);
+  }
+});
+
+test("the object assets still reject an array", async () => {
+  for (const key of ["world", "game", "prompts", "colors", "intercepts"]) {
+    const res = await put(key, []);
+    assert.equal(res.status, 400, `${key} must refuse an array`);
+    assert.match(await res.text(), /expected an object/, `${key} must say what it wanted`);
+  }
+});
+
+test("the array assets still accept an array", async () => {
+  for (const key of ["events", "actions", "chat", "advisor", "snapshots"]) {
+    assert.equal((await put(key, [])).status, 200, `${key} must accept an array`);
+  }
+});


### PR DESCRIPTION
Reported from a live game:

```
United States: Failed to save /api/runtime/json/intercepts?v=…: HTTP 400
```

## Cause — mine, from the spy feature

The runtime write path's shape guard decided what an asset should look like from **which registry it sits in**:

```js
const expectsArray = assetKey in STORAGE_JSON_ASSET_FILES || assetKey in RUNTIME_ONLY_JSON_ASSET_FILES;
```

That was only *accidentally* true. Every asset in those two sets was an array — until `intercepts`, an object keyed by target polity, joined the runtime-only set in #675. From then on every intercepts write was refused, so a spy could gather but never store what it found.

## Fix

The guard now derives the expectation from the asset's **declared default** in `JSON_ASSET_DEFAULTS`, which already states each shape (`snapshots: []`, `intercepts: {}`). Checked equivalent to the old rule for every other key:

| key | old rule | declared default | agree |
|---|---|---|---|
| actions, advisor, chat, events | array | `[]` | ✓ |
| snapshots | array | `[]` | ✓ |
| game, prompts, world, colors | object | `{}` | ✓ |
| **intercepts** | **array** | **`{}`** | ✗ — the bug |

A key with no declared default (`flags`, `tags`) is treated as an object, as before. `libraryStore.js:2408` was the only site with the assumption.

## Why testing missed it

Only the **desktop server** has this guard — the web store assigns the value with no shape check, and the browser is where I verified the feature. So it passed everywhere I looked and failed on the build you actually play.

The new test closes that gap by driving the real HTTP routes rather than the store I happened to be in.

## Verification

Four tests in `server/runtimeJsonShape.test.js`:

- `intercepts` round-trips as an object
- the array assets still reject an object — the corruption this guard exists to stop, where an unparsed body arrives as `{}` and wipes a game's event log
- the object assets still reject an array
- the array assets still accept an array

**Confirmed they fail 2/4 against the old guard and pass 4/4 with the fix.** Also reproduced your exact PUT against a real desktop server: 200, and `storage/intercepts.json` on disk. Suite 186/186.

Worth knowing: any intercept a spy gathered before this lands was lost at save time, so the Spy tab will be empty until the next Gather.
