### PR TITLE
Fix a cloned scenario rendering no political map in web mode

### DIFF
--- a/src/runtime/web/libraryStore.js
+++ b/src/runtime/web/libraryStore.js
@@ -497,7 +497,15 @@ const readRuntimeJsonAsset = async (assetKey) => {
     }
     // Web build: the default scenario's regions.geojson isn't in the seed (too
     // big), so pull it from the content origin — otherwise its political map is blank.
-    if ((value === undefined || value === null) && assetKey === "regionsGeojson" && scenario && scenario.id === DEFAULT_SCENARIO_ID) {
+    //
+    // NOT gated on being the default scenario. A CLONE of Modern Day has its own
+    // id and no geometry of its own, so it fell through the borrow branch above
+    // into default's record — which, in the web build, is exactly the record that
+    // does not carry the file. The clone then rendered an empty FeatureCollection
+    // and showed no political map at all, while the scenario it was copied from
+    // looked fine. This is the last resort for ANY scenario that has ended up
+    // without region geometry, which is precisely the case the borrow was for.
+    if ((value === undefined || value === null) && assetKey === "regionsGeojson" && scenario) {
       value = await fetchDefaultRegionsGeojson();
     }
     // geojson may be a raw uploaded string; parse-with-fallback like readJsonFile.


### PR DESCRIPTION
Clone Modern Day, start a game from the clone, and the map comes up with **no regions at all** — while the scenario it was copied from is fine. Reported on Android; it affects the website equally.

## Cause

`readRuntimeJsonAsset` resolves region geometry in three steps:

1. the scenario's own copy;
2. failing that, borrow the **default scenario's**;
3. failing that, **fetch it from the content origin**.

Step 3 was gated on the active scenario *being* the default — because, as the comment above it says, default's `regions.geojson` is too big to ship in the web seed.

A clone has its own id and no geometry of its own, so it fell through to step 2 — and step 2 reads default's **record**, which in the web build is exactly the record that does not carry the file. Step 3 then declined to run because the clone is not the default. Result: an empty `FeatureCollection`, a scenario with no map.

## Fix

The origin fetch is the last resort for **any** scenario that has ended up without region geometry — precisely the case step 2 exists to serve. Same geometry and the same owner-space caveat as the borrow it backs up.

## Verified in the built web app

One clone of Modern Day, switching the active game between the two:

| | original | clone |
|---|---|---|
| before | 3662 regions | **0** |
| after | 3662 regions | **3662** |

Worth knowing for anyone reproducing this: it is the **active game's** scenario that decides which geometry is read, not the selected one — selecting the clone in the library does not reproduce it, and that cost me a wrong A/B before I spotted it.

Suite 186/186; `build:web` clean. One file, one condition.
