### PR TITLE
Android: no demo notice — the app is not a demo of anything

### DIFF
--- a/src/runtime/web/homePage.js
+++ b/src/runtime/web/homePage.js
@@ -153,12 +153,20 @@ const enter = () => { try { sessionStorage.setItem(ENTERED_KEY, "1"); } catch { 
 // the only way through, and it is remembered for the tab session so a player who
 // has read it is not asked again.
 const DEMO_ACK_KEY = "oh:demo-ack";
+
+// The Android app is this same bundle packaged with Capacitor, so it inherits a
+// notice written for the WEBSITE: "this is a demo, get the desktop app, expect
+// lag". None of that is true there — the app IS the real thing, it keeps its own
+// games and its own copy of the map, and there is no desktop app to send an
+// Android player to. Capacitor injects window.Capacitor before the bundle runs,
+// which is the same signal the API router uses to pick native HTTP.
+const isNativeApp = () => typeof window !== "undefined" && Boolean(window.Capacitor);
 const demoAcknowledged = () => {
   try { return sessionStorage.getItem(DEMO_ACK_KEY) === "1"; } catch { return false; }
 };
 
 const showDemoNotice = (onContinue) => {
-  if (demoAcknowledged()) return onContinue();
+  if (isNativeApp() || demoAcknowledged()) return onContinue();
 
   const close = () => {
     try { sessionStorage.setItem(DEMO_ACK_KEY, "1"); } catch { /* private mode */ }


### PR DESCRIPTION
The APK ships the web bundle (#671), so it inherited a dialog written for the **website**:

> **This is a demo of the game** — Open Historia is meant to be played in the **desktop app**… expect **noticeable lag**…
> `Get the desktop app`  ·  `Play the demo anyway`

None of that is true on Android. The app keeps its own games and its own copy of the world map on the device, there is no desktop app to send an Android player to, and it is not a preview of something else — it *is* the thing. Pressing **Enter Open Historia** now goes straight into the game.

## How it knows

`window.Capacitor`, which the shell injects before the bundle runs — the same signal `router.js` already uses to pick native HTTP over `fetch`. The website is untouched.

## Verified in the built bundle, both ways

| | dialog | "Get the desktop app" | "Play the demo anyway" |
|---|---|---|---|
| as a browser | shown | present | present |
| with Capacitor present | **skipped** | — | — |

…and Enter goes straight into the game in the native case. Suite 186/186. One file, one condition.
