### PR TITLE
Idle diplomacy: show the model the conversation it is replying to

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -4,6 +4,7 @@ import { normalizePromptPack } from "./gameplayPrompts.js";
 import { getGameplayTool, validateGameplayPayload } from "./gameplaySchemas.js";
 import { toCountryName } from "../../runtime/ownerNames.js";
 import { activeSpies, espionageBrief, normalizeIntercepts, normalizeSpies, resolveEspionage } from "../../runtime/spycraft.js";
+import { echoesExistingMessage, renderOpenChatsForPrompt } from "../../runtime/chatEcho.js";
 import { isSeal, newSeal, openExchange, sealExchange } from "../../runtime/spySeal.js";
 import {
   buildActionHistoryText,
@@ -2567,10 +2568,32 @@ export const maybeSendIdleDiplomacy = async ({ chance = IDLE_DIPLOMACY_CHANCE } 
     const bundle = await readGameStateBundle({ force: true });
     if (!normalizeString(bundle.game?.country)) return null; // no active game
     const variables = await buildTemplateVariables(bundle);
+    const openChats = normalizeChats(bundle.chats);
+    // The prompt template shows only ONE line per chat (chatSummary: the last
+    // message, prefixed by its speaker), and a note sent to a polity the player
+    // is already talking to gets APPENDED to that thread. So the model was asked
+    // for an opener while its note became a reply, with almost none of the
+    // conversation in view — which is how a polity ended up answering a hostile
+    // message with an unrelated pleasantry, and how it ended up repeating the
+    // player's own line back at them.
+    const conversationContext = [
+      "",
+      "These are the conversations already open with the player, oldest message first:",
+      "",
+      renderOpenChatsForPrompt(openChats),
+      "",
+      "A note addressed to a polity the player is ALREADY talking to is appended to that"
+      + " conversation, so it must read as the next thing that polity says: answer what was"
+      + " actually said, never restate or quote it back, and never open as though the exchange"
+      + " were new. If nothing there warrants a reply and no polity has a fresh reason to"
+      + " write, return {\"chat\": null}.",
+    ].join("\n");
     const { payload } = await runJsonTask("idleDiplomacy", {
       timeoutMs: getMapSetting(MAP_SETTING_KEYS.limitAiGeneration) ? 60000 : 0,
       userMessage:
-        "A quiet moment between rounds. Decide whether any single polity would send the player a short diplomatic note right now. Return JSON only.",
+        "A quiet moment between rounds. Decide whether any single polity would send the player a short diplomatic note right now."
+        + conversationContext
+        + "\n\nReturn JSON only.",
       validatePayload: async (candidate, { finalAttempt } = {}) => {
         if (candidate?.chat == null) return "";
         const countries = await resolveInvitees(candidate.chat.countries, bundle.world);
@@ -2607,6 +2630,11 @@ export const maybeSendIdleDiplomacy = async ({ chance = IDLE_DIPLOMACY_CHANCE } 
     if (existing) {
       const note = built.messages[0];
       if (!note) return null;
+      // Even told not to, a model hands back the line it was just shown. Posting
+      // it would have the polity parrot the player in their own thread, which is
+      // worse than saying nothing — and silence is what this whole path defaults
+      // to anyway.
+      if (echoesExistingMessage(note.text, existing.messages)) return null;
       nextChats = chats.map((chat) => (chat === existing
         ? { ...chat, messages: [...chat.messages, { ...note, time: normalizeString(bundle.game?.gameDate) }] }
         : chat));

--- a/src/runtime/chatEcho.js
+++ b/src/runtime/chatEcho.js
@@ -1,0 +1,63 @@
+/*! Open Historia — unprompted-note echo guard © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+
+// Why this exists: the idle-diplomacy note is generated from a one-line-per-chat
+// SUMMARY, whose last entry for a thread is often the player's own message. Asked
+// for an opening note, a model handed "China: France: We think you suck!" has
+// repeated the player's line straight back as China's — the note is then appended
+// to that very thread, so the player watches a country parrot them. The prompt
+// already says never to repeat a note already visible; that is advice, and this is
+// the check.
+//
+// Pure and dependency-free on purpose, like eventDedup.js: it is unit-tested
+// directly, without the browser-only asset layer gameplay.js pulls in.
+
+// Lowercased, punctuation and whitespace flattened, so "We think you suck!" and
+// "we think you suck" collide while genuinely different sentences do not.
+const norm = (value) =>
+  String(value ?? "")
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
+    .trim();
+
+// True when `text` says the same thing as something already in the thread.
+//
+// Exact match after normalization, plus containment in EITHER direction, which is
+// what catches the real failure: a model that echoes the player's line verbatim
+// and then tacks on a clause. Anything shorter than a few characters is ignored —
+// "ok" or "no" legitimately recur in a conversation and must not block a note.
+export const echoesExistingMessage = (text, messages, { minLength = 12 } = {}) => {
+  const candidate = norm(text);
+  if (candidate.length < minLength) return false;
+  return (Array.isArray(messages) ? messages : []).some((message) => {
+    const existing = norm(message?.text);
+    if (existing.length < minLength) return false;
+    return existing === candidate || existing.includes(candidate) || candidate.includes(existing);
+  });
+};
+
+// The last few exchanges of one chat, rendered for a prompt: who said it and what
+// they said, oldest first. The player is labelled by their polity name like every
+// other speaker, so the model is never guessing which side a line came from —
+// which is the ambiguity that produced the echo in the first place.
+export const renderChatForPrompt = (chat, { messageLimit = 8 } = {}) => {
+  const countries = (Array.isArray(chat?.countries) ? chat.countries : [])
+    .map((country) => String(country?.name ?? "").trim())
+    .filter(Boolean);
+  const messages = (Array.isArray(chat?.messages) ? chat.messages : []).slice(-messageLimit);
+  const lines = messages.map((message) => {
+    const speaker = String(message?.speaker ?? "").trim() || (message?.role === "user" ? "the player" : "unknown");
+    return `  ${speaker}: ${String(message?.text ?? "").trim()}`;
+  });
+  return [
+    `With ${countries.join(", ") || "an unnamed polity"}:`,
+    lines.length ? lines.join("\n") : "  (no messages yet)",
+  ].join("\n");
+};
+
+// Every open conversation, most recently updated last, for the idle-diplomacy
+// prompt. Capped so a long campaign cannot crowd out the rest of the prompt.
+export const renderOpenChatsForPrompt = (chats, { limit = 5, messageLimit = 8 } = {}) => {
+  const open = (Array.isArray(chats) ? chats : []).filter((chat) => chat?.status !== "closed");
+  if (open.length === 0) return "There are no open conversations with the player.";
+  return open.slice(-limit).map((chat) => renderChatForPrompt(chat, { messageLimit })).join("\n\n");
+};

--- a/src/runtime/chatEcho.test.js
+++ b/src/runtime/chatEcho.test.js
@@ -1,0 +1,76 @@
+/*! Open Historia — unprompted-note echo guard tests © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// From a live game: the player wrote "We think you suck!" and the next
+// unprompted note from China was the same sentence, posted into that thread as
+// China's own words. A second note in the same thread ("We appreciate your solar
+// partnership…") answered nothing that had been said, because the model had only
+// ever seen one summary line of the conversation it was being appended to.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { echoesExistingMessage, renderChatForPrompt, renderOpenChatsForPrompt } from "./chatEcho.js";
+
+const thread = [
+  { role: "user", speaker: "France", text: "We think you suck!" },
+  { role: "leader", speaker: "China", text: "Our position on the strait has not changed." },
+];
+
+test("the reported echo is caught, punctuation and case included", () => {
+  assert.equal(echoesExistingMessage("We think you suck!", thread), true);
+  assert.equal(echoesExistingMessage("we think you suck", thread), true);
+  assert.equal(echoesExistingMessage("  WE THINK YOU SUCK!!  ", thread), true);
+});
+
+test("an echo with a clause tacked on is still an echo", () => {
+  // Containment in either direction: the failure mode is a model repeating the
+  // line and continuing from it.
+  assert.equal(echoesExistingMessage("We think you suck, and we will act accordingly.", thread), true);
+  assert.equal(echoesExistingMessage("Our position on the strait", thread), true);
+});
+
+test("a genuine new note is not blocked", () => {
+  assert.equal(echoesExistingMessage("We propose a summit in Geneva next month.", thread), false);
+  assert.equal(echoesExistingMessage("We appreciate your solar partnership.", thread), false);
+});
+
+test("short interjections never block a note", () => {
+  // "ok" / "no" legitimately recur; blocking on them would silence the feature.
+  const terse = [{ speaker: "China", text: "No." }, { speaker: "France", text: "Ok" }];
+  assert.equal(echoesExistingMessage("No.", terse), false);
+  assert.equal(echoesExistingMessage("Ok", terse), false);
+  assert.equal(echoesExistingMessage("", thread), false);
+  assert.equal(echoesExistingMessage(null, thread), false);
+});
+
+test("empty or malformed history is safe", () => {
+  assert.equal(echoesExistingMessage("Anything at all here", []), false);
+  assert.equal(echoesExistingMessage("Anything at all here", null), false);
+  assert.equal(echoesExistingMessage("Anything at all here", [null, {}, { text: null }]), false);
+});
+
+test("a rendered chat names every speaker, the player included", () => {
+  const out = renderChatForPrompt({ countries: [{ name: "China" }], messages: thread });
+  assert.match(out, /^With China:/);
+  assert.match(out, /France: We think you suck!/);
+  assert.match(out, /China: Our position on the strait has not changed\./);
+  // The ambiguity that caused this: a bare "China: France: ..." summary line.
+  assert.ok(!/China: France:/.test(out));
+});
+
+test("a message with no speaker is labelled by its side, not left blank", () => {
+  const out = renderChatForPrompt({ countries: [{ name: "China" }], messages: [{ role: "user", text: "Hello" }] });
+  assert.match(out, /the player: Hello/);
+});
+
+test("open chats render oldest-first, closed ones are excluded, and the list is capped", () => {
+  const chats = [
+    { countries: [{ name: "Italy" }], status: "closed", messages: [{ speaker: "Italy", text: "Closed thread" }] },
+    ...Array.from({ length: 7 }, (_, i) => ({ countries: [{ name: `P${i}` }], messages: [{ speaker: `P${i}`, text: `line ${i}` }] })),
+  ];
+  const out = renderOpenChatsForPrompt(chats, { limit: 5 });
+  assert.ok(!out.includes("Closed thread"), "a closed chat is not offered for a reply");
+  assert.equal(out.split("With ").length - 1, 5, "capped at the limit");
+  assert.ok(out.includes("With P6:"), "the most recent is kept");
+  assert.ok(!out.includes("With P0:"), "the oldest is dropped first");
+  assert.equal(renderOpenChatsForPrompt([]), "There are no open conversations with the player.");
+});


### PR DESCRIPTION
From the screenshots: the player wrote **"We think you suck!"** and the next unprompted note from China was *that same sentence*, posted into the thread as China's own words. A second note answered nothing that had been said — *"We appreciate your solar partnership and look forward to further collaboration"* — in a thread that had just turned hostile.

## One cause, two symptoms

A note addressed to a polity the player is **already talking to** is *appended to that thread*. But the model is asked for an **opener**, and the only view of the conversation it gets is `chatSummary`: one line per chat, the last message prefixed by its speaker. For the reported chat that line read:

```
- China: France: We think you suck!
```

The player's own words, under the heading of the chat with China. So the model had almost none of the conversation, and what little it had was ambiguous about who was speaking — which is both the non-sequitur *and* the parrot.

## Fix

**Give it the conversation.** Every open chat, oldest message first, each line labelled with the polity that said it — the player included, by name — plus the rule that a note to an existing counterpart is appended and must answer what was actually said rather than open afresh.

This goes in the **`userMessage`, not the prompt template**. A game freezes its prompt pack at creation, so an edit to `defaultPrompts.json` would only ever reach *new* games; this reaches every one, including yours.

**Guard the echo**, because advice in a prompt is not a check. A note whose text matches something already in the thread is dropped — case and punctuation flattened, containment in either direction so a parroted line with a clause tacked on is caught too. Silence is what this path defaults to anyway, and it beats a country repeating the player back at them.

Anything under 12 normalized characters is exempt: "No." and "Ok" legitimately recur and must not silence the feature.

## Verified against the reported exchange

What the model now receives:

```
With China:
  China: We welcome cooperation on solar manufacturing.
  France: We think you suck!
```

- the reported echo → **blocked**
- a genuine reply ("Your hostility is noted; the solar talks are suspended.") → **posted**

8 tests on the pure helper (`chatEcho.test.js`), including the reported line verbatim, the tacked-on-clause variant, and that short interjections never block a note. Suite 194/194.

## Note

This covers the *unprompted* notes — what you described as the AI writing "on its own". Replies you provoke by sending a message go through a different path (`sendDiplomaticMessage`), which already carries that thread's full history.
