### PR TITLE
Fix countries appearing several times in the diplomacy and spy pickers

### DIFF
--- a/src/Game/GameUI/chat.jsx
+++ b/src/Game/GameUI/chat.jsx
@@ -1,5 +1,6 @@
 /*! Open Historia — portions (era diplomacy + mobile panel sizing) © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
 import React, { memo, useEffect, useMemo, useRef, useState } from "react";
+import { dedupeByName } from "../../runtime/countryList.js";
 import ReactDOM from "react-dom";
 import ReactMarkdown from "react-markdown";
 import { sendDiplomaticMessage, startDiplomaticChat, loadDiplomaticHistory } from "../AI/main.jsx";
@@ -468,7 +469,15 @@ const CountrySelectorModal = ({
 }) => {
     const [search, setSearch]     = React.useState("");
     const [selected, setSelected] = React.useState([]);
-    const filtered      = useMemo(() => countries.filter(c => c.name.toLowerCase().includes(search.toLowerCase())), [countries, search]);
+    // Deduped before anything is rendered: the tiles and the selection are both
+    // keyed by name, so a repeated name collides React keys — the same country
+    // appears several times, a search misses what it matched, and clicking one
+    // tile marks another selected without highlighting it. countryList.js fixes
+    // the source of the duplicates; this makes the picker safe from any source.
+    const filtered = useMemo(
+        () => dedupeByName(countries).filter(c => c.name.toLowerCase().includes(search.toLowerCase())),
+        [countries, search],
+    );
     const filteredFlagUrls = useCountryFlagUrls(filtered);
     const selectedFlagUrls = useCountryFlagUrls(selected);
     const isSelectedName = (name) => selected.some(s => s.name === name);

--- a/src/runtime/assets.js
+++ b/src/runtime/assets.js
@@ -1,5 +1,6 @@
 /*! Open Historia — portions (custom regions.geojson runtime endpoint) © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
 import mapLibreGl from "maplibre-gl";
+import { mergeCountryOverrides } from "./countryList.js";
 import { PMTiles, Protocol, SharedPromiseCache } from "pmtiles";
 import { resolveRegionName } from "./regionNameFixes.js";
 
@@ -1002,24 +1003,11 @@ export const loadCountryNames = async ({ force = false } = {}) => {
 
       try {
         const world = await readJson(JSON_URLS.world, { defaultValue: {} });
-        const merged = new Map(countries.map((entry) => [entry.code || entry.name, entry]));
-
-        for (const [code, polity] of Object.entries(world?.polityOverrides ?? {})) {
-          const resolvedCode = polity?.code || code;
-          // A nameless polity override must NOT degrade an existing proper
-          // name to a bare code.
-          const resolvedName = polity?.name || merged.get(resolvedCode)?.name || resolvedCode;
-          if (!resolvedCode || !resolvedName) {
-            continue;
-          }
-
-          merged.set(resolvedCode, {
-            code: resolvedCode,
-            name: resolvedName,
-          });
-        }
-
-        return Array.from(merged.values()).sort((left, right) => left.name.localeCompare(right.name));
+        // world.polityOverrides is keyed by country NAME, not by code, and its
+        // entries carry no code of their own — so treating the key as a code
+        // added a SECOND entry per override instead of updating the tile's.
+        // See countryList.js: duplicate names break the pickers outright.
+        return mergeCountryOverrides(countries, world?.polityOverrides);
       } catch {
         return countries;
       }

--- a/src/runtime/countryList.js
+++ b/src/runtime/countryList.js
@@ -1,0 +1,92 @@
+/*! Open Historia — country picker list assembly © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+
+// Merges the AI's polity overrides onto the country list read from the tiles.
+//
+// Why this exists as its own pure module: it got this wrong in a way that only
+// showed up in the UI. world.polityOverrides is keyed by country NAME — the same
+// namespace as colors and internationalReputation — and its entries do not carry
+// a `code` (checked across real saves: 85 overrides in one campaign, 84 of them
+// name-keyed, none with a code). The merge treated that key as a code and did
+//
+//   merged.set(polity.code || key, { code: polity.code || key, name })
+//
+// so "Germany" was added ALONGSIDE the tile entry { code: "DEU", name: "Germany" }
+// instead of updating it. The list then carried the same name twice, and in a long
+// campaign dozens of times over.
+//
+// That is not cosmetic. The chat and spy pickers key their tiles AND their
+// selection by name (`key={c.name}`, `isSelectedName(c.name)`), so duplicate
+// names collide React keys: the same country renders repeatedly, a search misses
+// the country it matched, and clicking one tile marks a different one selected
+// without highlighting anything.
+
+const norm = (value) => String(value ?? "").trim().toLowerCase();
+const clean = (value) => String(value ?? "").trim();
+
+export const mergeCountryOverrides = (countries, polityOverrides) => {
+  // identity -> entry, plus a name index so an override keyed by name lands on
+  // the entry that already carries it rather than creating a twin.
+  const byId = new Map();
+  const idByName = new Map();
+
+  for (const entry of Array.isArray(countries) ? countries : []) {
+    const name = clean(entry?.name);
+    const code = clean(entry?.code);
+    const id = code || name;
+    if (!id || !name) continue;
+    byId.set(id, { code, name });
+    idByName.set(norm(name), id);
+  }
+
+  for (const [overrideKey, polity] of Object.entries(polityOverrides && typeof polityOverrides === "object" ? polityOverrides : {})) {
+    const explicitCode = clean(polity?.code);
+    const overrideName = clean(polity?.name);
+    const key = clean(overrideKey);
+
+    // Which existing entry does this describe? Resolved BEFORE the name, so a
+    // nameless override can borrow the name of the entry it lands on instead of
+    // degrading it to a bare key. An explicit code that names an entry wins;
+    // then the key itself as an id (a code-keyed override); then the entry
+    // already holding that name — under the key (the usual case, since the key
+    // IS the name) or under the new name, so a rename updates in place rather
+    // than splitting in two.
+    const id = (explicitCode && byId.has(explicitCode) ? explicitCode : null)
+      ?? (byId.has(key) ? key : null)
+      ?? idByName.get(norm(key))
+      ?? (overrideName ? idByName.get(norm(overrideName)) : null)
+      ?? (explicitCode || key);
+    if (!id) continue;
+
+    const previous = byId.get(id);
+    const name = overrideName || clean(previous?.name) || key;
+    if (!name) continue;
+    if (previous) idByName.delete(norm(previous.name));
+    // Keep the tile's real code where there is one; a polity the AI invented has
+    // no code and is identified by its name, as owners are everywhere else.
+    byId.set(id, { code: previous?.code || explicitCode || id, name });
+    idByName.set(norm(name), id);
+  }
+
+  // Unique names, guaranteed. The pickers cannot render a duplicate safely, and
+  // this is the one place that can promise they never see one.
+  const seen = new Set();
+  return [...byId.values()]
+    .filter((entry) => {
+      const key = norm(entry.name);
+      if (!key || seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    })
+    .sort((left, right) => left.name.localeCompare(right.name));
+};
+
+// Belt and braces for any list handed to a picker, whatever its source.
+export const dedupeByName = (countries) => {
+  const seen = new Set();
+  return (Array.isArray(countries) ? countries : []).filter((entry) => {
+    const key = norm(entry?.name);
+    if (!key || seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+};

--- a/src/runtime/countryList.test.js
+++ b/src/runtime/countryList.test.js
@@ -1,0 +1,77 @@
+/*! Open Historia — country picker list tests © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// Reported: every country listed three times in the diplomacy and spy pickers;
+// searching a country sometimes did not show it; clicking a country listed it as
+// selected without highlighting it. All of that follows from duplicate NAMES in
+// the list, because the pickers key their tiles and their selection by name.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { dedupeByName, mergeCountryOverrides } from "./countryList.js";
+
+const tiles = [
+  { code: "DEU", name: "Germany" },
+  { code: "FRA", name: "France" },
+  { code: "ITA", name: "Italy" },
+];
+
+test("the reported bug: a name-keyed override no longer mints a twin", () => {
+  // Exactly the shape found in real saves: keyed by name, carrying no code.
+  const out = mergeCountryOverrides(tiles, { Germany: { note: "unified" }, Italy: {} });
+  assert.deepEqual(out.map((c) => c.name), ["France", "Germany", "Italy"]);
+  assert.equal(out.filter((c) => c.name === "Germany").length, 1);
+  // The tile's real code survives — the override only ever described that entry.
+  assert.equal(out.find((c) => c.name === "Germany").code, "DEU");
+});
+
+test("a rename updates the entry in place instead of splitting it", () => {
+  const out = mergeCountryOverrides(tiles, { Germany: { name: "German Reich" } });
+  assert.deepEqual(out.map((c) => c.name), ["France", "German Reich", "Italy"]);
+  assert.equal(out.find((c) => c.name === "German Reich").code, "DEU", "keeps its tile code through a rename");
+  assert.equal(out.some((c) => c.name === "Germany"), false, "the old name is gone, not duplicated");
+});
+
+test("a polity the AI invented is added, identified by its name", () => {
+  const out = mergeCountryOverrides(tiles, { "Free Bavaria": { name: "Free Bavaria" } });
+  assert.equal(out.length, 4);
+  const added = out.find((c) => c.name === "Free Bavaria");
+  assert.equal(added.code, "Free Bavaria", "no tile code exists, so the name is the identity");
+});
+
+test("an override carrying a real code still matches by code", () => {
+  const out = mergeCountryOverrides(tiles, { anything: { code: "FRA", name: "French Republic" } });
+  assert.equal(out.filter((c) => c.code === "FRA").length, 1);
+  assert.equal(out.find((c) => c.code === "FRA").name, "French Republic");
+});
+
+test("a nameless override does not degrade a proper name to its key", () => {
+  const out = mergeCountryOverrides(tiles, { DEU: {} });
+  assert.equal(out.find((c) => c.code === "DEU").name, "Germany");
+});
+
+test("a campaign's worth of overrides yields no duplicate names", () => {
+  // 85 overrides in one real save. Every one of them used to add a twin.
+  const overrides = Object.fromEntries(tiles.map((c) => [c.name, { note: "x" }]));
+  const out = mergeCountryOverrides(tiles, overrides);
+  assert.equal(out.length, tiles.length);
+  assert.equal(new Set(out.map((c) => c.name.toLowerCase())).size, out.length);
+});
+
+test("case and padding do not sneak a duplicate through", () => {
+  const out = mergeCountryOverrides(tiles, { "  germany  ": { name: "  Germany  " } });
+  assert.equal(out.filter((c) => c.name.trim() === "Germany").length, 1);
+});
+
+test("malformed input is survivable", () => {
+  assert.deepEqual(mergeCountryOverrides(null, null), []);
+  assert.deepEqual(mergeCountryOverrides(tiles, "nonsense").map((c) => c.name), ["France", "Germany", "Italy"]);
+  assert.deepEqual(mergeCountryOverrides([{ name: "" }, null, { code: "X" }], {}), []);
+  // An override with nothing usable is skipped rather than adding a blank row.
+  assert.equal(mergeCountryOverrides(tiles, { "": {} }).length, 3);
+});
+
+test("dedupeByName is the picker's last line of defence", () => {
+  const dupes = [{ code: "DEU", name: "Germany" }, { code: "Germany", name: "Germany" }, { code: "FRA", name: "France" }];
+  assert.deepEqual(dedupeByName(dupes).map((c) => c.code), ["DEU", "FRA"], "the first wins, so a real code is kept");
+  assert.deepEqual(dedupeByName(null), []);
+});


### PR DESCRIPTION
Reported: every country listed **three times**; searching a country sometimes did not show it; clicking a country listed it as selected but **without the blue highlight or checkmark**.

All three are one fault.

## Cause

`world.polityOverrides` is keyed by country **NAME** — the same namespace as `colors` and `internationalReputation` — and its entries carry **no code of their own**. Checked against your real saves:

| save | overrides | name-keyed | carrying `.code` |
|---|---|---|---|
| the-great-war-1911 | 85 | 84 | **0** |
| red-dawn-2026 | 49 | 49 | **0** |
| greater-countries | 6 | 6 | **0** |

`loadCountryNames` treated that key as a code:

```js
merged.set(polity.code || key, { code: polity.code || key, name })
```

So `"Germany"` was added **alongside** the tile entry `{ code: "DEU", name: "Germany" }` instead of updating it — one duplicate row per override, dozens in a long campaign.

The pickers key their tiles **and** their selection by name (`key={c.name}`, `isSelectedName(c.name)`), so duplicate names collide React keys. That is precisely the three symptoms: repeated rows, a search that misses what it matched, and a click that marks one country selected while highlighting none.

## Fix

The merge now resolves each override onto the entry it actually describes — by explicit code, by the key as an id, or by name — and updates it **in place**. A rename stays one row and keeps its tile code; a polity the AI invented is still added, identified by its name as owners are everywhere else. The result is deduped by name, which the pickers depend on and nothing else was promising.

The picker also dedupes whatever list it is handed, so no future source of duplicates can break it the same way.

## Verified

Against the real override shape — six countries, six name-keyed overrides:

| | rows | duplicate names | "Germany" rows |
|---|---|---|---|
| before | 12 | 6 | `DEU`, `Germany` |
| after | **6** | **0** | `DEU` |

Nine tests (`countryList.test.js`) covering the reported case, renames, invented polities, code-keyed and nameless overrides (a nameless one must not degrade "Germany" to "DEU" — that one caught a real mistake in my first draft), case/padding, and malformed input. Suite 195/195.
