### PR TITLE
Spies report on their own; no self-targeting, no Gather button

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -1933,13 +1933,16 @@ export const gatherIntelligence = async (target, { signal } = {}) => {
   const exchanges = normalizeArray(payload?.exchanges)
     // The schema forbids it, but a model that names the target or the player as
     // the counterpart has produced a chat the player already has or nonsense.
+    // A spy reports on what the target says to OTHERS; the player's own dealings
+    // with them are already in the player's inbox. Case- and space-insensitive,
+    // because the model writes a display name and the old comparison was exact.
     .filter((exchange) => {
-      const counterpart = normalizeString(exchange?.counterpart);
-      return counterpart && counterpart !== name && counterpart !== normalizeString(bundle.game?.country);
+      const counterpart = regionKey(exchange?.counterpart);
+      return counterpart && counterpart !== regionKey(name) && counterpart !== regionKey(bundle.game?.country);
     })
     .map((exchange, index) => ({
       ...exchange,
-      id: `${name}:${bundle.game?.round ?? 0}:${index}`.toLowerCase().replace(/s+/g, "-"),
+      id: `${name}:${bundle.game?.round ?? 0}:${index}`.toLowerCase().replace(/\s+/g, "-"),
     }));
   // Stored sealed: the file, the network reply and the React tree hold ciphertext,
   // so copying the page or opening intercepts.json gives up nothing the player's
@@ -1969,6 +1972,37 @@ export const readOpenedIntercepts = async () => {
 // After a jump, every active spy reports again. Sequential and best-effort:
 // a failed report never fails the turn, and the writes go to the intercepts
 // asset only — never to world.json, whose turn write has just landed.
+// One roll per real-world minute, so an agent reports roughly every 20 minutes
+// the game is open. Deliberately slow: each report is a full AI call, and the
+// point of an agent is a steady trickle rather than something the player farms
+// by pressing a button. The player-facing Gather button is gone for the same
+// reason.
+const SPY_REPORT_CHANCE = 1 / 20;
+let spyReportInFlight = false;
+
+// Called on a timer by the UI. Picks ONE live agent and has it report, or does
+// nothing at all — every failure is silent, exactly like the diplomacy drip.
+export const maybeGatherIntelligence = async ({ chance = SPY_REPORT_CHANCE } = {}) => {
+  if (spyReportInFlight || isSimulationBusy()) return null;
+  if (Math.random() >= chance) return null;
+  spyReportInFlight = true;
+  try {
+    const world = normalizeWorldState(await readWorldState({ force: true }));
+    const player = normalizeString((await readGameData()).country);
+    if (!player) return null;
+    const agents = activeSpies(world, player);
+    if (agents.length === 0) return null;
+    const agent = agents[Math.floor(Math.random() * agents.length)];
+    if (isSimulationBusy()) return null;
+    await gatherIntelligence(agent.target);
+    return agent.target;
+  } catch {
+    return null; // silence is the safe outcome
+  } finally {
+    spyReportInFlight = false;
+  }
+};
+
 export const refreshSpyIntercepts = async () => {
   let world;
   try {

--- a/src/Game/GameUI/chat.jsx
+++ b/src/Game/GameUI/chat.jsx
@@ -3,7 +3,7 @@ import React, { memo, useEffect, useMemo, useRef, useState } from "react";
 import ReactDOM from "react-dom";
 import ReactMarkdown from "react-markdown";
 import { sendDiplomaticMessage, startDiplomaticChat, loadDiplomaticHistory } from "../AI/main.jsx";
-import { chooseNextDiplomaticSpeaker, gatherIntelligence } from "../AI/gameplay.js";
+import { chooseNextDiplomaticSpeaker } from "../AI/gameplay.js";
 import {
     MAX_ACTIVE_SPIES, activeSpies, deploySpy, expelSpy, foreignSpies, intelligenceOf, normalizeIntercepts, normalizeSpies,
     recallSpy, redactExchange, setCoverStory, signalClarity, turnSpy,
@@ -961,7 +961,6 @@ const SpyView = ({ playerCountry, gameDate, countries, loadingCountries }) => {
     const [intercepts, setIntercepts] = useState({});
     const [open, setOpen]             = useState(null); // { target, exchange }
     const [choosing, setChoosing]     = useState(false);
-    const [busy, setBusy]             = useState(""); // target being gathered
     const [error, setError]           = useState("");
 
     const refresh = async () => {
@@ -1002,20 +1001,12 @@ const SpyView = ({ playerCountry, gameDate, countries, loadingCountries }) => {
         try { await commitSpies(setCoverStory(world, spy.id, storyDraft[spy.id] ?? spy.coverStory)); } catch (err) { setError(err?.message || String(err)); }
     };
 
-    const handleGather = async (target) => {
-        setError(""); setBusy(target);
-        try { await gatherIntelligence(target); await refresh(); }
-        catch (err) { setError(target + ": " + (err?.message || err)); }
-        finally { setBusy(""); }
-    };
-
     const handleDeploy = async (selected) => {
         setChoosing(false); setError("");
         const target = selected?.[0]?.name;
         try {
             const next = deploySpy(world, target, { date: gameDate, playerPolity: playerCountry });
             await commitSpies(next);
-            await handleGather(target);
         } catch (err) { setError(err?.message || String(err)); }
     };
 
@@ -1030,7 +1021,9 @@ const SpyView = ({ playerCountry, gameDate, countries, loadingCountries }) => {
     }
 
     const targets = Object.keys(intercepts);
-    const candidates = countries.filter((c) => c.name !== playerCountry && !spies.some((s) => s.target === c.name));
+    const sameCountry = (a, b) => String(a ?? "").trim().toLowerCase() === String(b ?? "").trim().toLowerCase();
+    const candidates = countries.filter((c) =>
+        !sameCountry(c.name, playerCountry) && !spies.some((s) => sameCountry(s.target, c.name)));
     const storyOf = (spy) => (storyDraft[spy.id] !== undefined ? storyDraft[spy.id] : spy.coverStory);
     const inputStyle = { width: "100%", boxSizing: "border-box", padding: "0.45rem 0.6rem", borderRadius: "8px", border: "1px solid rgba(255,255,255,0.12)", background: "rgba(0,0,0,0.25)", color: "white", fontSize: "0.76rem", fontFamily: "sans-serif" };
     const full = spies.length >= MAX_ACTIVE_SPIES;
@@ -1071,9 +1064,6 @@ const SpyView = ({ playerCountry, gameDate, countries, loadingCountries }) => {
             {spy.deployedAt ? "since " + spy.deployedAt : "in place"} · their service {intelligenceOf(world, spy.target)}/100
             </div>
             </div>
-            <button onClick={() => handleGather(spy.target)} disabled={busy === spy.target} style={{ ...spyBtn(true), opacity: busy === spy.target ? 0.6 : 1 }}>
-            {busy === spy.target ? "Gathering…" : "Gather"}
-            </button>
             <button onClick={() => handleRecall(spy)} style={spyBtn(false)}>Recall</button>
             </div>
         ))}

--- a/src/Game/GameUI/main.jsx
+++ b/src/Game/GameUI/main.jsx
@@ -170,6 +170,23 @@ const Main = ({
     return () => clearInterval(iv);
   }, [hasNoGames]);
 
+  // Spy reports, on the same rhythm and with the same guards: a roll each
+  // minute the tab is visible, at odds that work out to roughly one report
+  // every twenty minutes per deployed agent. Agents also report after every
+  // time skip (refreshSpyIntercepts, in the jump itself); this is what makes
+  // them tick while the player is simply playing, and it is why there is no
+  // Gather button — an agent is a trickle of intelligence, not a thing to farm.
+  useEffect(() => {
+    if (hasNoGames) return undefined;
+    const iv = setInterval(() => {
+      if (document.visibilityState !== "visible") return;
+      import("../AI/gameplay.js")
+        .then(({ maybeGatherIntelligence }) => maybeGatherIntelligence())
+        .catch(() => {});
+    }, 60000);
+    return () => clearInterval(iv);
+  }, [hasNoGames]);
+
   useEffect(() => {
     if (isAdvisorOpen) setShouldLoadAdvisor(true);
   }, [isAdvisorOpen]);

--- a/src/runtime/spycraft.js
+++ b/src/runtime/spycraft.js
@@ -94,10 +94,14 @@ export const deploySpy = (world, target, { date = "", playerPolity = "", owner =
   const name = String(target ?? "").trim();
   const who = String(owner ?? "").trim();
   if (!name) throw new Error("Choose a country to deploy to.");
-  if (who && name === who) throw new Error("You cannot spy on yourself.");
+  // Case- and padding-insensitive: the picker offers DISPLAY names while the
+  // game's country is stored verbatim, and an exact comparison let a player
+  // deploy an agent into their own capital when the two differed at all.
+  const same = (a, b) => a.trim().toLowerCase() === b.trim().toLowerCase();
+  if (who && same(name, who)) throw new Error("You cannot spy on yourself.");
   const spies = normalizeSpies(world?.spies);
   const mine = spies.filter((spy) => spy.owner === who && isLive(spy));
-  if (mine.some((spy) => spy.target === name)) throw new Error(`A spy is already deployed in ${name}.`);
+  if (mine.some((spy) => same(spy.target, name))) throw new Error(`A spy is already deployed in ${name}.`);
   if (mine.length >= MAX_ACTIVE_SPIES) {
     throw new Error(`Your service can run at most ${MAX_ACTIVE_SPIES} spies at once. Recall one first.`);
   }

--- a/src/runtime/spycraft.test.js
+++ b/src/runtime/spycraft.test.js
@@ -41,6 +41,17 @@ test("deploying a spy: limits, duplicates, self, and ownership", () => {
   assert.equal(foreignSpies(withForeign, P).length, 1);
 });
 
+test("you cannot spy on your own country, however it is spelled", () => {
+  // The picker shows display names; the game stores its country verbatim. An
+  // exact comparison let the two drift apart and a player plant an agent at home.
+  for (const spelling of ["France", "france", "  FRANCE  "]) {
+    assert.throws(() => deploySpy({}, spelling, { playerPolity: P }), /yourself/, spelling);
+  }
+  // And the same tolerance for a second agent in one country.
+  const world = { spies: deploySpy({}, "Germany", { playerPolity: P }) };
+  assert.throws(() => deploySpy(world, "  germany ", { playerPolity: P }), /already deployed/);
+});
+
 test("recall keeps the record, frees the slot, and a redeploy gets a new id", () => {
   let world = { spies: deploySpy({}, "Germany", { playerPolity: P }) };
   const [first] = activeSpies(world, P);


### PR DESCRIPTION
Four changes to how agents work, plus one bug of mine found on the way.

## Agents report by themselves — the Gather button is gone

An agent now reports **after every time skip** (which it already did) and on a **slow real-time roll**: one chance a minute while the tab is visible, working out to roughly **one report every twenty minutes per agent**. Same rhythm and same guards as the idle-diplomacy drip — it skips while a jump, game-master command or catalyst is in flight, never overlaps itself, and is silent on failure.

A button made intelligence something to farm; a trickle is the point. Deploying no longer gathers immediately either — the agent has to get to work first.

## No spying on yourself

The picker excluded the player by **exact string**, while the list holds *display* names and the game stores its country verbatim — so any difference in case or padding let a player plant an agent in their own capital. Both the picker and `deploySpy` now compare case- and padding-insensitively, and so does the "already deployed there" check.

## No reporting on your own diplomacy

A spy reports what the target says to **others**; the player's dealings with them are already in the player's inbox. That filter existed but compared raw strings, so a display-name mismatch let it through. It now uses the same normalized polity key the rest of the codebase does.

## The bug found on the way

The intercept id was built with `.replace(/s+/g, "-")` — a **missing backslash** from an earlier edit of mine — so every letter `s` in a country's name became a dash. Ids round-tripped consistently so nothing broke, but `"United States"` was being written as `united -tate-`. Fixed.

## Verification

Suite 187/187; `build` and `build:web` clean. A new test covers the self-spy guard across three spellings (`France`, `france`, `  FRANCE  `) and the duplicate-target check.

**Not verified here:** the twenty-minute roll firing in a real session, and a real `spyIntercept` generation (needs an AI key). The timer is a copy of the idle-diplomacy drip that already ships, and the roll is a plain `Math.random()` against `1/20` per minute.
