### PR TITLE
Espionage events are built, then thrown away

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -1535,7 +1535,6 @@ const applySimulationResult = async ({
   // directive in buildTemplateVariables).
   const priorEvents = normalizeEvents(baseEvents);
   const freshEvents = dedupeGeneratedEvents(priorEvents, generatedEvents);
-  const nextEvents = [...priorEvents, ...freshEvents];
   const nextGame = normalizeGameData({
     ...baseGame,
     gameDate: normalizeString(result.stopDate) || baseGame.gameDate,
@@ -1645,9 +1644,29 @@ const applySimulationResult = async ({
   worldWithImpacts.spies = espionage.spies;
   // A spy in the world needs a seal for what it will report under.
   if (!isSeal(worldWithImpacts.spySeal) && espionage.spies.length) worldWithImpacts.spySeal = newSeal();
+  const espionageEventIds = [];
   for (const event of espionage.events) {
     const entry = normalizeEventEntry({ ...event, id: "espionage-" + nextGame.round + "-" + freshEvents.length }, freshEvents.length);
-    if (entry) freshEvents.push(entry);
+    if (entry) {
+      freshEvents.push(entry);
+      espionageEventIds.push(entry.id);
+    }
+  }
+  // Built HERE rather than beside freshEvents above, because the loop that just
+  // ran appends to it. `[...priorEvents, ...freshEvents]` is a copy, so a snapshot
+  // taken before the loop cannot see an exposure or a discovery — and that copy is
+  // what writeEventsState persists and what this function returns.
+  const nextEvents = [...priorEvents, ...freshEvents];
+  // Same reason, for this turn's own record: simulationHistory is built as an
+  // argument to applyEventImpactsToWorld, which has to run BEFORE espionage
+  // resolves on its output, so its eventIds snapshot also predates the loop.
+  // time.jsx renders a turn's events from exactly this list.
+  if (espionageEventIds.length && worldWithImpacts.simulationHistory?.[0]) {
+    const [turnEntry, ...olderTurns] = worldWithImpacts.simulationHistory;
+    worldWithImpacts.simulationHistory = [
+      { ...turnEntry, eventIds: [...turnEntry.eventIds, ...espionageEventIds] },
+      ...olderTurns,
+    ];
   }
   let nextWorld = worldWithImpacts;
 


### PR DESCRIPTION
## What's wrong

`applySimulationResult` (`src/Game/AI/gameplay.js`) snapshots the turn's event list near the top of the function:

```js
const nextEvents = [...priorEvents, ...freshEvents];   // :1538
```

That is a **copy**. About a hundred lines further down, espionage resolves and appends its events to `freshEvents`:

```js
for (const event of espionage.events) {
  const entry = normalizeEventEntry({ ...event, id: "espionage-" + ... });
  if (entry) freshEvents.push(entry);                   // :1650
}
```

The copy taken at :1538 cannot see those pushes, and it is what gets persisted:

```js
writeEventsState(nextEvents),                            // :1704
```

It is also what the function returns (`events: nextEvents`), so nothing downstream can recover them either.

## What the player sees

Nothing — which is the problem. This is not "the events are lost on reload"; they are **never written anywhere**, so a rolled-up spy ring, an uncovered agent and a suspected double agent produce no narrative at all.

It hides well because the *world* is updated in place a few lines earlier:

```js
worldWithImpacts.spies = espionage.spies;
```

So the Spy tab looks entirely correct — the agent really is `exposed`, the foreign agent really is `discovered` — while the event log has no idea any of it happened. The state and the story disagree, and only the story is missing.

## Second instance, same cause

`simulationHistory[0].eventIds` (:1625) is built as an argument to `applyEventImpactsToWorld`, which has to run *before* espionage (espionage resolves on its output). So that snapshot also predates the append. `time.jsx` renders a turn's events from exactly this list, so even once the events are persisted they would be missing from that turn's own record.

## The fix

Build `nextEvents` **after** the espionage loop instead of before it, and fold the new ids into the turn entry.

For any turn that produces no espionage events the two arrays are identical, so there is no behaviour change on the overwhelming majority of turns — this only starts mattering once a spy is actually in the field.

The `simulationHistory` entry is replaced rather than mutated in place, because the array is shared with the object `applyEventImpactsToWorld` returned.

## Testing

`npm test` — **204/204 pass** (unchanged from `main`, which is also 204/204 in the same environment).

Ordering was checked explicitly: no reference to `nextEvents` exists between its old declaration site and the new one, so moving it cannot break an intervening read.