### PR TITLE
Espionage: assemble the turn's events in one place, and stop cheats rolling spy dice

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -5,6 +5,7 @@ import { getGameplayTool, validateGameplayPayload } from "./gameplaySchemas.js";
 import { toCountryName } from "../../runtime/ownerNames.js";
 import { activeSpies, espionageBrief, normalizeIntercepts, normalizeSpies, resolveEspionage } from "../../runtime/spycraft.js";
 import { echoesExistingMessage, renderOpenChatsForPrompt } from "../../runtime/chatEcho.js";
+import { buildTurnEvents } from "../../runtime/turnEvents.js";
 import { isSeal, newSeal, openExchange, sealExchange } from "../../runtime/spySeal.js";
 import {
   buildActionHistoryText,
@@ -28,7 +29,6 @@ import {
   readInterceptsState,
   writeInterceptsState,
   normalizeActionEntry,
-  normalizeEventEntry,
   normalizeActions,
   normalizeChatEntry,
   normalizeChats,
@@ -1617,60 +1617,59 @@ const applySimulationResult = async ({
       lastJumpMode: normalizeString(result.mode),
       lastJumpSummary: normalizeString(result.summary),
       lastJumpTargetDate: nextGame.gameDate,
-      simulationHistory: [
-        {
-          catalyst: result.catalyst ? cloneValue(result.catalyst) : null,
-          date: nextGame.gameDate,
-          eventIds: freshEvents.map((event) => event.id),
-          fallbackReason: normalizeString(result.generation?.fallbackReason),
-          fromDate: baseGame.gameDate,
-          mode: normalizeString(result.mode) || "jump",
-          plannedActions: plannedActionSnapshot,
-          round: nextGame.round,
-          summary: normalizeString(result.summary),
-          source: result.generation?.source || "ai",
-          toDate: nextGame.gameDate,
-        },
-        ...normalizeWorldState(baseWorld).simulationHistory,
-      ].slice(0, 12),
+      // This turn's history record is NOT built here. Its eventIds have to list
+      // the espionage events too, and those do not exist until resolveEspionage
+      // has run on THIS call's output — so building it here made the id list a
+      // snapshot taken one step too early. It is prepended below instead, once,
+      // off the finished list. baseWorld's own history rides through and comes
+      // back normalized.
     },
   });
-  const espionage = resolveEspionage(worldWithImpacts, {
-    round: nextGame.round,
-    date: nextGame.gameDate,
-    playerPolity: normalizeString(baseGame.country),
-    candidates: espionageCandidates,
-  });
+  // Espionage is elapsed time, not an edit: it rolls detection, turning and
+  // foreign deployment for the round, seeded on the round number. A game-master
+  // command is the player rewriting the world by hand, so it must not also
+  // advance the spy war — a cheat would burn that round's roll and quietly get
+  // an agent caught, in a turn the player never meant as a passage of time.
+  // Jumps, auto-jumps and catalyst stages are all genuinely elapsed time.
+  const espionage = normalizeString(result.mode) === "game-master"
+    ? { spies: worldWithImpacts.spies, events: [] }
+    : resolveEspionage(worldWithImpacts, {
+      round: nextGame.round,
+      date: nextGame.gameDate,
+      playerPolity: normalizeString(baseGame.country),
+      candidates: espionageCandidates,
+    });
   worldWithImpacts.spies = espionage.spies;
   // A spy in the world needs a seal for what it will report under.
   if (!isSeal(worldWithImpacts.spySeal) && espionage.spies.length) worldWithImpacts.spySeal = newSeal();
-  const espionageEventIds = [];
-  for (const event of espionage.events) {
-    const entry = normalizeEventEntry({ ...event, id: "espionage-" + nextGame.round + "-" + freshEvents.length }, freshEvents.length);
-    if (entry) {
-      freshEvents.push(entry);
-      espionageEventIds.push(entry.id);
-    }
-  }
-  // Built HERE rather than beside freshEvents above, because the loop that just
-  // ran appends to it. `[...priorEvents, ...freshEvents]` is a copy, so a snapshot
-  // taken before the loop cannot see an exposure or a discovery — and that copy is
-  // what writeEventsState persists and what this function returns.
-  const nextEvents = [...priorEvents, ...freshEvents];
-  // Same reason, for this turn's own record: simulationHistory is built as an
-  // argument to applyEventImpactsToWorld, which has to run BEFORE espionage
-  // resolves on its output, so its eventIds snapshot also predates the loop.
-  // time.jsx renders a turn's events from exactly this list.
-  if (espionageEventIds.length && worldWithImpacts.simulationHistory?.[0]) {
-    const [turnEntry, ...olderTurns] = worldWithImpacts.simulationHistory;
-    worldWithImpacts.simulationHistory = [
-      { ...turnEntry, eventIds: [...turnEntry.eventIds, ...espionageEventIds] },
-      ...olderTurns,
-    ];
-  }
+
+  // The turn's finished event list and the ids its record points at, built
+  // together off one array now that espionage has had its say (turnEvents.js).
+  const { turnEvents, nextEvents, eventIds } = buildTurnEvents({
+    priorEvents,
+    freshEvents,
+    espionageEvents: espionage.events,
+    round: nextGame.round,
+  });
+  worldWithImpacts.simulationHistory = [
+    {
+      catalyst: result.catalyst ? cloneValue(result.catalyst) : null,
+      date: nextGame.gameDate,
+      eventIds,
+      fallbackReason: normalizeString(result.generation?.fallbackReason),
+      fromDate: baseGame.gameDate,
+      mode: normalizeString(result.mode) || "jump",
+      plannedActions: plannedActionSnapshot,
+      round: nextGame.round,
+      summary: normalizeString(result.summary),
+      source: result.generation?.source || "ai",
+      toDate: nextGame.gameDate,
+    },
+    ...worldWithImpacts.simulationHistory,
+  ].slice(0, 12);
   let nextWorld = worldWithImpacts;
 
-  for (const event of freshEvents) {
+  for (const event of turnEvents) {
     for (const createdChat of event.impacts.createdChats) {
       const nextChat = await buildGeneratedChat(createdChat, event.id, worldWithImpacts, {
         fallbackTitle: event.title,

--- a/src/runtime/spycraft.js
+++ b/src/runtime/spycraft.js
@@ -176,8 +176,14 @@ export const foreignDeployChance = (polityIntelligence, { hostile = false, hosti
 export const resolveEspionage = (world, { round = 0, date = "", playerPolity = "", candidates = [] } = {}) => {
   const player = String(playerPolity ?? "").trim();
   let spies = normalizeSpies(world?.spies);
+  // NARRATIVE ONLY — these events must never carry `impacts`. resolveEspionage
+  // runs on the world applyEventImpactsToWorld has already produced, so an
+  // impact attached here would join the turn's event list AFTER the only pass
+  // that applies impacts: persisted, rendered and fed to the model, while
+  // changing nothing in the world. The "relations are strained" line below is
+  // the obvious candidate for wanting one — route that through a generated
+  // event's polityChanges, or give applySimulationResult a second impact pass.
   const events = [];
-  const notices = [];
   const roll = (key) => draw(`${round}:${key}`);
   const intel = (polity) => intelligenceOf(world, polity);
 
@@ -190,7 +196,6 @@ export const resolveEspionage = (world, { round = 0, date = "", playerPolity = "
       if (roll(`${spy.id}:detect`) < detectionChance(targetIntel, ownerIntel)) {
         if (spy.target === player) {
           // The player decides: expel or turn. It stops reporting meanwhile.
-          notices.push({ kind: "discovered", spyId: spy.id, owner: spy.owner });
           events.push({
             date, kind: "world", source: "espionage",
             title: `Counter-intelligence uncovers a ${spy.owner} agent`,
@@ -207,7 +212,6 @@ export const resolveEspionage = (world, { round = 0, date = "", playerPolity = "
           title: `Spy ring rolled up in ${spy.target}`,
           description: `${spy.target} has expelled an agent working for ${spy.owner}, and made the arrest public. Relations with ${spy.owner} are strained.`,
         });
-        notices.push({ kind: "exposed", spyId: spy.id, target: spy.target });
         return { ...spy, status: "exposed", exposedAt: date };
       }
       return spy;
@@ -216,7 +220,6 @@ export const resolveEspionage = (world, { round = 0, date = "", playerPolity = "
     // Turned, and the owner's own service may notice the reports are wrong.
     if (spy.status === "turned" && !spy.suspected && spy.owner === player) {
       if (roll(`${spy.id}:suspect`) < suspicionChance(ownerIntel, targetIntel)) {
-        notices.push({ kind: "suspected", spyId: spy.id, target: spy.target });
         events.push({
           date, kind: "world", source: "espionage",
           title: `Doubts about the agent in ${spy.target}`,
@@ -245,7 +248,7 @@ export const resolveEspionage = (world, { round = 0, date = "", playerPolity = "
     }
   }
 
-  return { spies, events, notices };
+  return { spies, events };
 };
 
 // ---- redaction ----------------------------------------------------------------

--- a/src/runtime/spycraft.test.js
+++ b/src/runtime/spycraft.test.js
@@ -129,7 +129,7 @@ test("a caught foreign agent waits for the PLAYER's decision and stops reporting
   for (let round = 1; round <= 60 && !caught; round += 1) {
     const out = resolveEspionage(world, { round, date: "d", playerPolity: P });
     world = { ...world, spies: out.spies };
-    if (out.notices.some((n) => n.kind === "discovered")) caught = out;
+    if (normalizeSpies(out.spies).some((s) => s.status === "discovered")) caught = out;
   }
   assert.ok(caught, "a 0-vs-100 agent is caught");
   const [spy] = foreignSpies(world, P);

--- a/src/runtime/turnEvents.js
+++ b/src/runtime/turnEvents.js
@@ -1,0 +1,57 @@
+/*! Open Historia — turn event assembly © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// A turn produces its events in two passes: the simulator's, and then
+// espionage's — which cannot run until the first pass has been applied to the
+// world, because it reads the intelligence ratings that pass may have changed.
+//
+// Two things are derived from the finished list: what gets persisted, and the
+// id list the turn's history record points at. Both must come from the SAME,
+// COMPLETE list. Deriving either one before espionage has appended is how every
+// exposure and discovery went missing — the state said an agent was rolled up
+// and the timeline had never heard of it.
+//
+// So both are built here, together, from one array. There is no intermediate
+// list for a caller to snapshot too early, which is the only real guard against
+// that mistake coming back.
+
+import { normalizeEventEntry } from "./gameState.js";
+
+export const buildTurnEvents = ({
+  priorEvents = [],
+  freshEvents = [],
+  espionageEvents = [],
+  round = 0,
+} = {}) => {
+  const turnEvents = [...freshEvents];
+
+  for (const event of espionageEvents) {
+    // Espionage events are narrative only (see resolveEspionage in spycraft.js).
+    // Impacts attached here would be appended AFTER the turn's only pass over
+    // impacts has run, so they would persist, render and reach the model while
+    // changing nothing in the world. Say so rather than dropping them in silence.
+    if (event?.impacts && Object.keys(event.impacts).length > 0) {
+      console.warn(
+        "[ai] espionage event impacts are ignored — route a world change through a generated event instead:",
+        event?.title,
+      );
+    }
+    // The position in the list doubles as the id suffix, so several agents
+    // resolving in the same round still get distinct ids.
+    const entry = normalizeEventEntry(
+      { ...event, id: `espionage-${round}-${turnEvents.length}` },
+      turnEvents.length,
+    );
+    // normalizeEventEntry returns null for an entry with nothing to show. Such a
+    // one must not leave a dangling id in the turn record either.
+    if (entry) turnEvents.push(entry);
+  }
+
+  return {
+    // The turn's own events, simulator's and espionage's, in order.
+    turnEvents,
+    // The whole log as it will be persisted.
+    nextEvents: [...priorEvents, ...turnEvents],
+    // What this turn's history record points at (time.jsx renders a turn from
+    // exactly this list).
+    eventIds: turnEvents.map((event) => event.id),
+  };
+};

--- a/src/runtime/turnEvents.test.js
+++ b/src/runtime/turnEvents.test.js
@@ -1,0 +1,114 @@
+/*! Open Historia — turn event assembly tests © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// Run: node --test src/runtime/turnEvents.test.js
+//
+// The bug these guard against left no trace: espionage events were built, the
+// world was updated to match, and the events were dropped on the floor because
+// the lists that carry them had already been copied. Nothing failed, nothing
+// logged — the timeline was simply silent about a rolled-up spy ring.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildTurnEvents } from "./turnEvents.js";
+
+const prior = (id) => ({ id, title: `prior ${id}`, description: "", date: "1911-01-01" });
+const fresh = (id) => ({ id, title: `fresh ${id}`, description: "", date: "1911-06-01" });
+const espionage = (title) => ({ date: "1911-06-02", kind: "world", source: "espionage", title, description: "d" });
+
+test("espionage events reach the persisted log", () => {
+  const { nextEvents } = buildTurnEvents({
+    priorEvents: [prior("p1")],
+    freshEvents: [fresh("f1")],
+    espionageEvents: [espionage("Spy ring rolled up in Germany")],
+    round: 4,
+  });
+
+  assert.equal(nextEvents.length, 3, "prior + fresh + espionage");
+  assert.ok(
+    nextEvents.some((event) => event.title === "Spy ring rolled up in Germany"),
+    "the exposure is in the list that gets written",
+  );
+});
+
+test("espionage events reach the turn's own record", () => {
+  const { eventIds, turnEvents } = buildTurnEvents({
+    priorEvents: [prior("p1")],
+    freshEvents: [fresh("f1"), fresh("f2")],
+    espionageEvents: [espionage("Doubts about the agent in Germany")],
+    round: 4,
+  });
+
+  // time.jsx renders a turn by looking each id up in the event log, so an id
+  // missing here means the event exists but never appears in that turn.
+  assert.deepEqual(eventIds, turnEvents.map((event) => event.id));
+  assert.equal(eventIds.length, 3);
+  assert.ok(eventIds.some((id) => id.startsWith("espionage-4-")), "the espionage id is recorded");
+});
+
+test("prior events stay first and keep their order", () => {
+  const { nextEvents } = buildTurnEvents({
+    priorEvents: [prior("p1"), prior("p2")],
+    freshEvents: [fresh("f1")],
+    espionageEvents: [espionage("Counter-intelligence uncovers a Germany agent")],
+    round: 2,
+  });
+
+  assert.deepEqual(nextEvents.slice(0, 2).map((event) => event.id), ["p1", "p2"]);
+  assert.equal(nextEvents[2].id, "f1");
+});
+
+test("a turn with no espionage is exactly prior + fresh", () => {
+  const { nextEvents, turnEvents, eventIds } = buildTurnEvents({
+    priorEvents: [prior("p1")],
+    freshEvents: [fresh("f1"), fresh("f2")],
+    espionageEvents: [],
+    round: 7,
+  });
+
+  assert.deepEqual(nextEvents.map((event) => event.id), ["p1", "f1", "f2"]);
+  assert.deepEqual(turnEvents.map((event) => event.id), ["f1", "f2"]);
+  assert.deepEqual(eventIds, ["f1", "f2"]);
+});
+
+test("several agents resolving in one round get distinct ids", () => {
+  const { eventIds } = buildTurnEvents({
+    freshEvents: [fresh("f1")],
+    espionageEvents: [espionage("one"), espionage("two"), espionage("three")],
+    round: 9,
+  });
+
+  const spyIds = eventIds.filter((id) => id.startsWith("espionage-"));
+  assert.equal(spyIds.length, 3);
+  assert.equal(new Set(spyIds).size, 3, "ids are unique within the round");
+  assert.ok(spyIds.every((id) => id.startsWith("espionage-9-")), "ids are namespaced by round");
+});
+
+test("an unusable espionage event leaves no dangling id", () => {
+  // normalizeEventEntry drops an entry with nothing to show; the record must not
+  // then point at an event that was never added.
+  const { turnEvents, eventIds, nextEvents } = buildTurnEvents({
+    freshEvents: [fresh("f1")],
+    espionageEvents: [{ date: "1911-06-02", kind: "world" }, espionage("real one")],
+    round: 3,
+  });
+
+  assert.equal(turnEvents.length, 2, "only the usable espionage event is added");
+  assert.equal(eventIds.length, 2);
+  assert.deepEqual(eventIds, nextEvents.map((event) => event.id));
+});
+
+test("the caller's arrays are not mutated", () => {
+  // The original defect was aliasing: a list handed out earlier, then appended
+  // to. Building a new list instead is what makes an early copy impossible.
+  const priorEvents = [prior("p1")];
+  const freshEvents = [fresh("f1")];
+
+  buildTurnEvents({
+    priorEvents,
+    freshEvents,
+    espionageEvents: [espionage("Spy ring rolled up in Germany")],
+    round: 1,
+  });
+
+  assert.equal(priorEvents.length, 1);
+  assert.equal(freshEvents.length, 1, "freshEvents is left as the simulator produced it");
+});


### PR DESCRIPTION
Follow-up to #691, addressing the review findings on it. Stacked on that branch, so **merge #691 first** — this PR's diff is only the follow-up work.

#691 is right and this does not undo it: espionage events really were built and dropped, and it fixed that. This takes the same area a step further, and picks up three things next to it.

## Assemble the turn's events in one place

#691 fixed the two derived lists individually: `nextEvents` moved below the espionage loop, and the turn record's `eventIds` got patched afterwards by destructuring `simulationHistory[0]` and rebuilding it. That works, but it leaves `eventIds` written in two places and leaves `freshEvents` as a mutable array handed to `applyEventImpactsToWorld` and appended to afterwards — the exact shape that caused the bug, still there for a third derived list to trip over.

New `src/runtime/turnEvents.js` builds both outputs together, from one array, after espionage has had its say:

```js
const { turnEvents, nextEvents, eventIds } = buildTurnEvents({
  priorEvents, freshEvents, espionageEvents: espionage.events, round: nextGame.round,
});
```

The turn record is no longer constructed as an argument to `applyEventImpactsToWorld` — that call never needed it, and building it there is precisely what made its `eventIds` a snapshot taken one step too early. It is prepended once, afterwards, off the finished list, and the patch-up block goes away. `freshEvents` is now only ever read.

Event ids and ordering are unchanged: the id is still `espionage-<round>-<position>` off the same running length, so existing saves and their turn records are unaffected.

## Cover it

`src/runtime/turnEvents.test.js`, 7 tests. The suite was 204/204 both before and after #691, which is to say nothing exercised this at all. They cover espionage events reaching the persisted log and the turn record, prior events keeping their place, the no-espionage turn being byte-identical to before, id uniqueness within a round, an unusable event leaving no dangling id, and — the one that matters most — that neither input array is mutated, which is the aliasing shape the original bug had.

`applySimulationResult` isn't exported and pulls in the whole AI stack, so testing it directly wasn't practical. Extracting the assembly is what made it testable, which is part of why it is worth extracting.

## Cheats shouldn't roll the spy dice

`applySimulationResult` is the shared path for `simulateTimelineJump`, `advanceActiveCatalyst` **and** `applyGameMasterCommand`. Espionage resolved unconditionally on all three, so a game-master command — the player editing the world by hand from the Cheats panel — was burning that round's seeded detection roll and could quietly get an agent caught in a turn nobody meant as a passage of time. Before #691 that was invisible, because the events were being dropped; with them persisted it would start showing up in the timeline as a side effect of an unrelated cheat.

Espionage now skips `mode === "game-master"` only. Jumps, auto-jumps and catalyst stages are all genuinely elapsed time and still resolve. Spy state is untouched on that path rather than reassigned.

Flagging this as the judgement call in the PR: if you would rather cheats keep advancing the spy war, this is the one hunk to drop.

## Two smaller things

**Espionage events must not carry impacts.** They are appended after the turn's only pass over impacts, so anything attached to one would persist, render and reach the model while changing nothing in the world. The `Spy ring rolled up` event's own text says "Relations with X are strained" while applying no reputation change, which is an active invitation to add one. Now said plainly where someone would add it, with a `console.warn` if one ever does.

**`resolveEspionage` no longer returns `notices`.** It was built every round — three `notices.push` calls — and consumed by nothing anywhere in the tree; the same built-then-discarded shape as the bug #691 fixed, four lines away. The one test that used it as a convenience signal now checks the spy's actual status instead, which is the state that matters.

## Verified

- `node --test` — **211/211 pass** (204 before, plus the 7 new).
- `npx eslint .` — 0 errors. The one warning is pre-existing in `src/runtime/web/util.js` and untouched here.
- Read through for behaviour parity on a turn with no espionage: same events, same ids, same order, same record.

One nuance worth knowing: because the turn record is now attached after `applyEventImpactsToWorld` instead of passing through it, it skips that call's `normalizeWorldState` and is normalized on write instead. The only field that differs is `catalyst`, which is cloned either way and which nothing reads back off a history entry.
