### PR TITLE
Map: one label per country, whatever the AI has called it

### DIFF
--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -21,7 +21,7 @@ import {
   resolveCountryDisplayName,
 } from "../../runtime/assets.js";
 import { resolveRegionName } from "../../runtime/regionNameFixes.js";
-import { toCountryName } from "../../runtime/ownerNames.js";
+import { buildOwnerAliasMap, canonicalOwnerName, toCountryName } from "../../runtime/ownerNames.js";
 import { loadCountryLabelCollections, loadRegionLabelGeometry } from "../../runtime/countryLabels.js";
 import { translateLabel } from "../../runtime/translator.js";
 import { loadRegionSeed, emptyRegionSeed } from "../../runtime/regionSeed.js";
@@ -272,34 +272,53 @@ const MIN_CLUSTER_AREA = 1.5; // in lng/lat degrees^2 — skips tiny extra islan
 // mop-up in the label builder heals whatever this still misses. Owner-agnostic
 // (geometry only) so it can be memoized per world and reused across ownership
 // changes.
+// Which regions touch. The z0 label tile simplifies every region on its own,
+// so two neighbours almost never share a vertex there: the shared-vertex test
+// this used to be found 193 of 218 countries in several pieces (Russia in 38),
+// and every piece got its own label. Bounding boxes that overlap, or come within
+// a fifth of a degree, are what "touching" means at that resolution - it keeps
+// Siberia one territory and still leaves a colony across a sea on its own.
+const ADJACENCY_GAP_DEGREES = 0.2;
 const buildRegionAdjacency = (regionsFC) => {
   const features = regionsFC?.features ?? [];
-  const firstSeen = new Map(); // packed vertex -> first feature index
   const neighbors = features.map(() => null);
+  const boxes = features.map((feature, index) => {
+    const geometry = feature?.geometry;
+    const polys = geometry?.type === "Polygon"
+      ? [geometry.coordinates]
+      : geometry?.type === "MultiPolygon" ? geometry.coordinates : [];
+    let west = Infinity;
+    let south = Infinity;
+    let east = -Infinity;
+    let north = -Infinity;
+    for (const poly of polys) {
+      for (const ring of poly ?? []) {
+        for (const pt of ring ?? []) {
+          if (!Array.isArray(pt)) continue;
+          west = Math.min(west, pt[0]);
+          east = Math.max(east, pt[0]);
+          south = Math.min(south, pt[1]);
+          north = Math.max(north, pt[1]);
+        }
+      }
+    }
+    return Number.isFinite(west) ? { index, west, south, east, north } : null;
+  }).filter(Boolean);
+  boxes.sort((a, b) => a.west - b.west);
   const link = (a, b) => {
     (neighbors[a] ??= new Set()).add(b);
     (neighbors[b] ??= new Set()).add(a);
   };
-  for (let index = 0; index < features.length; index += 1) {
-    const geometry = features[index]?.geometry;
-    const polys = geometry?.type === "Polygon"
-      ? [geometry.coordinates]
-      : geometry?.type === "MultiPolygon" ? geometry.coordinates : [];
-    for (const poly of polys) {
-      for (const ring of poly ?? []) {
-        if (!ring) continue;
-        for (let v = 0; v < ring.length; v += 1) {
-          const pt = ring[v];
-          // 1e-4° grid, packed into one number (fits 2^53).
-          const key = Math.round((pt[0] + 180) * 1e4) * 4194304 + Math.round((pt[1] + 90) * 1e4);
-          const seen = firstSeen.get(key);
-          if (seen === undefined) firstSeen.set(key, index);
-          else if (seen !== index) link(seen, index);
-        }
-      }
+  const gap = ADJACENCY_GAP_DEGREES;
+  for (let i = 0; i < boxes.length; i += 1) {
+    const a = boxes[i];
+    for (let j = i + 1; j < boxes.length; j += 1) {
+      const b = boxes[j];
+      if (b.west > a.east + gap) break;
+      if (b.south > a.north + gap || b.north < a.south - gap) continue;
+      link(a.index, b.index);
     }
   }
-  firstSeen.clear();
   return neighbors;
 };
 
@@ -372,6 +391,10 @@ const buildOwnerLabelCollection = (
   const countryNameByCode = new Map(); // gid0 -> modern country name (fallback labels)
   const ownerByIndex = new Array(allFeatures.length).fill("");
   const entryByIndex = new Array(allFeatures.length).fill(null);
+  // A polity renamed by the AI is one polity, however a region's owner spells
+  // it: "Russian Federation" folds back onto the "Russia" token here exactly as
+  // it does when the world is read, so the country gets one label, not two.
+  const aliasMap = buildOwnerAliasMap(polityOverrides);
 
   for (let index = 0; index < allFeatures.length; index += 1) {
     const props = allFeatures[index].properties || {};
@@ -382,7 +405,7 @@ const buildOwnerLabelCollection = (
     // Captured-region override stores the AI's owner CODE ("ESP"); the seed stores the NAME
     // ("Spain"). Canonicalize so both share one cluster + label instead of the code splitting
     // off as a phantom new country.
-    const owner = toCountryName(rawOwner);
+    const owner = canonicalOwnerName(rawOwner, aliasMap);
     if (!owner) continue;
 
     let entry = precomputedMetrics ? precomputedMetrics[index] : null;

--- a/src/runtime/gameState.js
+++ b/src/runtime/gameState.js
@@ -3,7 +3,7 @@ import { JSON_URLS, readJson, writeJson } from "./assets.js";
 import { enqueueContentStrings } from "./translator.js";
 import { normalizeTagList } from "./countryTags.js";
 import { dedupeEventLog } from "./eventDedup.js";
-import { toCountryName } from "./ownerNames.js";
+import { buildOwnerAliasMap, createOwnerResolver, toCountryName } from "./ownerNames.js";
 
 export const GAME_DEFAULTS = {
   country: "",
@@ -984,19 +984,25 @@ export const normalizeWorldState = (world) => {
       .filter(([, value]) => value),
   );
 
+  // Canonicalise on READ too, so a save written before this migrated - or one
+  // whose owners were split across a polity's token and its display name by a
+  // build that predates this - resolves to the same owner identity as
+  // everything computed now. See ownerNames.js for why a name is an identity.
+  const resolveOwner = createOwnerResolver(buildOwnerAliasMap(polityOverrides));
+
   const regionOwnershipOverrides = Object.fromEntries(
     Object.entries(nextWorld.regionOwnershipOverrides ?? {})
-      // Canonicalise on READ too, so a save written before this migrated still
-      // resolves to the same owner identity as everything computed now.
-      .map(([regionId, ownerCode]) => [normalizeOptionalString(regionId), toCountryName(normalizeOptionalString(ownerCode))])
+      .map(([regionId, ownerCode]) => [normalizeOptionalString(regionId), resolveOwner(ownerCode)])
       .filter(([regionId, ownerCode]) => regionId && ownerCode),
   );
 
   const regionClaimants = Object.fromEntries(
     Object.entries(nextWorld.regionClaimants ?? {})
+      // Claimants share the owner namespace - they are compared against owners
+      // to paint a disputed region's stripes.
       .map(([regionId, claimants]) => [
         normalizeOptionalString(regionId),
-        normalizeArray(claimants).map((name) => normalizeOptionalString(name)).filter(Boolean).slice(0, 4),
+        normalizeArray(claimants).map((name) => resolveOwner(name)).filter(Boolean).slice(0, 4),
       ])
       .filter(([regionId, claimants]) => regionId && claimants.length),
   );
@@ -1272,20 +1278,60 @@ export const readGameStateBundle = async ({ force = false } = {}) => {
   };
 };
 
+// The polity registry as it will stand once this event's changes land, used only
+// to build the alias map. An event's transfers routinely arrive with the rename
+// that names their winner ("Third Reich" takes Austria in the event that renames
+// Germany), so the new name has to be known before the transfers are read, or
+// that one turn's regions land under a second, phantom owner.
+const previewPolityOverrides = (polityOverrides, polityChanges) => {
+  const preview = { ...polityOverrides };
+  for (const { change, code } of polityChanges) {
+    const existing = preview[code] ?? { aliases: [], code, color: "", name: "", note: "" };
+    preview[code] = {
+      ...existing,
+      ...(change.aliases?.length > 0 ? { aliases: change.aliases } : {}),
+      ...(change.name ? { name: change.name } : {}),
+    };
+  }
+  return preview;
+};
+
 export const applyEventImpactsToWorld = ({ colors = {}, events = [], world }) => {
   const nextColors = cloneValue(colors) ?? {};
   const nextWorld = normalizeWorldState(world);
+  // Every owner written below goes through here first. The model reads the story
+  // it just wrote, so the turn after a polity is renamed it hands back the NEW
+  // name - and storing that verbatim splits one country into two owners, one of
+  // which has none of the country's colour, tags, reputation or stats, and the
+  // map labels both (see ownerNames.js). Rebuilt after each event's polity
+  // changes, since a rename in one event is a name the next event can already
+  // be using.
+  let resolveOwner = createOwnerResolver(buildOwnerAliasMap(nextWorld.polityOverrides));
 
   for (const event of normalizeEvents(events)) {
-    for (const transfer of event.impacts.regionTransfers) {
-      nextWorld.regionOwnershipOverrides[transfer.regionId] = transfer.toCode;
+    // Resolve this event's polity changes first - both to fold the renames they
+    // make into the alias map before any owner is read through it, and so a
+    // change addressed to a polity's current display name lands on that polity
+    // rather than creating a second one beside it.
+    const polityChanges = event.impacts.polityChanges.map((change) => ({
+      change,
+      code: resolveOwner(change.code) || change.code,
+    }));
+    if (polityChanges.length > 0) {
+      resolveOwner = createOwnerResolver(buildOwnerAliasMap(
+        previewPolityOverrides(nextWorld.polityOverrides, polityChanges),
+      ));
     }
 
-    for (const change of event.impacts.polityChanges) {
-      nextWorld.polityOverrides[change.code] = {
-        ...(nextWorld.polityOverrides[change.code] ?? {
+    for (const transfer of event.impacts.regionTransfers) {
+      nextWorld.regionOwnershipOverrides[transfer.regionId] = resolveOwner(transfer.toCode) || transfer.toCode;
+    }
+
+    for (const { change, code } of polityChanges) {
+      nextWorld.polityOverrides[code] = {
+        ...(nextWorld.polityOverrides[code] ?? {
           aliases: [],
-          code: change.code,
+          code,
           color: "",
           name: "",
           note: "",
@@ -1301,7 +1347,7 @@ export const applyEventImpactsToWorld = ({ colors = {}, events = [], world }) =>
         const hexMatch = /^#?([a-f0-9]{6})$/i.exec(normalizedColor);
         if (hexMatch) {
           const hex = hexMatch[1];
-          nextColors[change.code] = [
+          nextColors[code] = [
             Number.parseInt(hex.slice(0, 2), 16),
             Number.parseInt(hex.slice(2, 4), 16),
             Number.parseInt(hex.slice(4, 6), 16),
@@ -1313,17 +1359,17 @@ export const applyEventImpactsToWorld = ({ colors = {}, events = [], world }) =>
       // defector — becomes the polity's authoritative value.
       if (Number.isFinite(change.intelligence)) {
         if (!nextWorld.intelligence || typeof nextWorld.intelligence !== "object") nextWorld.intelligence = {};
-        nextWorld.intelligence[change.code] = change.intelligence;
+        nextWorld.intelligence[code] = change.intelligence;
       }
 
       // Reputation the AI set this turn becomes the polity's authoritative value.
       if (Number.isFinite(change.reputation)) {
-        nextWorld.internationalReputation[change.code] = change.reputation;
+        nextWorld.internationalReputation[code] = change.reputation;
         // Keep the persisted sheet's reputation index in sync with the authoritative value.
-        if (nextWorld.countryStats?.[change.code]?.indices) {
-          nextWorld.countryStats[change.code] = {
-            ...nextWorld.countryStats[change.code],
-            indices: { ...nextWorld.countryStats[change.code].indices, internationalReputation: change.reputation },
+        if (nextWorld.countryStats?.[code]?.indices) {
+          nextWorld.countryStats[code] = {
+            ...nextWorld.countryStats[code],
+            indices: { ...nextWorld.countryStats[code].indices, internationalReputation: change.reputation },
           };
         }
       }
@@ -1333,8 +1379,8 @@ export const applyEventImpactsToWorld = ({ colors = {}, events = [], world }) =>
       // the nested groups and mirror the reputation index into the authoritative store.
       if (change.stats && typeof change.stats === "object") {
         if (!nextWorld.countryStats || typeof nextWorld.countryStats !== "object") nextWorld.countryStats = {};
-        const prev = nextWorld.countryStats[change.code] && typeof nextWorld.countryStats[change.code] === "object"
-          ? nextWorld.countryStats[change.code]
+        const prev = nextWorld.countryStats[code] && typeof nextWorld.countryStats[code] === "object"
+          ? nextWorld.countryStats[code]
           : {};
         const merged = { ...prev, ...change.stats };
         for (const group of ["indices", "economy", "gdpBreakdown"]) {
@@ -1342,10 +1388,10 @@ export const applyEventImpactsToWorld = ({ colors = {}, events = [], world }) =>
             merged[group] = { ...(prev[group] || {}), ...change.stats[group] };
           }
         }
-        nextWorld.countryStats[change.code] = merged;
+        nextWorld.countryStats[code] = merged;
         const rep = Number(merged.indices?.internationalReputation);
         if (Number.isFinite(rep)) {
-          nextWorld.internationalReputation[change.code] = Math.max(0, Math.min(100, Math.round(rep)));
+          nextWorld.internationalReputation[code] = Math.max(0, Math.min(100, Math.round(rep)));
         }
       }
 
@@ -1357,18 +1403,26 @@ export const applyEventImpactsToWorld = ({ colors = {}, events = [], world }) =>
         if (!nextWorld.countryTags || typeof nextWorld.countryTags !== "object") {
           nextWorld.countryTags = {};
         }
-        if (change.tags.length) nextWorld.countryTags[change.code] = change.tags;
-        else delete nextWorld.countryTags[change.code];
+        if (change.tags.length) nextWorld.countryTags[code] = change.tags;
+        else delete nextWorld.countryTags[code];
       }
     }
 
     if (event.impacts.unitOps?.length) {
-      nextWorld.units = applyUnitOps(nextWorld.units, event.impacts.unitOps);
+      // A battalion's owner is the same namespace: spawned under a display name
+      // it would fly a phantom country's colours beside its own army.
+      nextWorld.units = applyUnitOps(nextWorld.units, event.impacts.unitOps.map((op) =>
+        (op.op === "spawn" && op.unit?.ownerCode
+          ? { ...op, unit: { ...op.unit, ownerCode: resolveOwner(op.unit.ownerCode) } }
+          : op)));
     }
 
     if (event.impacts.markerOps?.length) {
       const before = normalizeMarkers(nextWorld.markers);
-      nextWorld.markers = applyMarkerOps(nextWorld.markers, event.impacts.markerOps);
+      nextWorld.markers = applyMarkerOps(nextWorld.markers, event.impacts.markerOps.map((op) =>
+        (op.op === "build" && op.marker?.ownerCode
+          ? { ...op, marker: { ...op.marker, ownerCode: resolveOwner(op.marker.ownerCode) } }
+          : op)));
       // A rename that matched no existing structure is a STOCK-map city rename (stock
       // cities live in PMTiles, not world.markers) — record it as an override layer so
       // the label layer can show the new name (see Cities.jsx / cityRenames).

--- a/src/runtime/gameState.ownerIdentity.test.js
+++ b/src/runtime/gameState.ownerIdentity.test.js
@@ -1,0 +1,229 @@
+/*! Open Historia — owner identity (rename / annexation) tests © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// Run: node --test src/runtime/gameState.ownerIdentity.test.js
+//
+// A polity is identified by its owner TOKEN, and a rename changes only the label
+// hung on that token (polityOverrides[token].name). The turn after a rename the
+// model reads back the story it just wrote and answers with the NEW name, so
+// unless every inbound owner is folded to the token, one country splits into two
+// owners — half of them with none of its colour, tags, reputation or stats.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { applyEventImpactsToWorld, normalizeWorldState } from "./gameState.js";
+import { buildOwnerAliasMap, canonicalOwnerName } from "./ownerNames.js";
+
+const RENAMED = { Germany: { code: "Germany", name: "Third Reich", aliases: ["the Reich"] } };
+
+const event = (impacts) => ({ date: "1936-03-07", title: "Test", description: "test", impacts });
+
+// ---- Group A: the alias map ------------------------------------------------
+
+test("a renamed polity's display name and aliases resolve to its token", () => {
+  const aliases = buildOwnerAliasMap(RENAMED);
+  assert.equal(canonicalOwnerName("Third Reich", aliases), "Germany");
+  assert.equal(canonicalOwnerName("the reich", aliases), "Germany");
+  assert.equal(canonicalOwnerName("Germany", aliases), "Germany");
+});
+
+test("punctuation and diacritics do not hide an identity", () => {
+  // The model spells a name back the way it remembers it — an accent dropped or
+  // an apostrophe added must not mint a second country.
+  const aliases = buildOwnerAliasMap({
+    "Roman Empire": { code: "Roman Empire", name: "Imperium Rōmānum", aliases: ["S.P.Q.R."] },
+  });
+
+  assert.equal(canonicalOwnerName("imperium romanum", aliases), "Roman Empire");
+  assert.equal(canonicalOwnerName("SPQR", aliases), "Roman Empire");
+});
+
+test("a GADM code still canonicalises to its country name", () => {
+  assert.equal(canonicalOwnerName("ESP", buildOwnerAliasMap({})), "Spain");
+});
+
+test("an unknown polity is returned untouched", () => {
+  assert.equal(canonicalOwnerName("Roman Empire", buildOwnerAliasMap(RENAMED)), "Roman Empire");
+});
+
+test("a real country's name is never redirected to another polity", () => {
+  // The disputed-territory case: a scenario polity NAMED "India" must not
+  // swallow the actual India's territory.
+  const aliases = buildOwnerAliasMap({ Z01: { code: "Z01", name: "India" } });
+  assert.equal(canonicalOwnerName("India", aliases), "India");
+});
+
+test("a name another polity already answers to is never redirected", () => {
+  const aliases = buildOwnerAliasMap({
+    "Roman Empire": { code: "Roman Empire", name: "Byzantium" },
+    Byzantium: { code: "Byzantium", name: "Eastern Rome" },
+  });
+  assert.equal(canonicalOwnerName("Byzantium", aliases), "Byzantium");
+  assert.equal(canonicalOwnerName("Eastern Rome", aliases), "Byzantium");
+});
+
+test("a name two polities both answer to identifies neither", () => {
+  const aliases = buildOwnerAliasMap({
+    North: { code: "North", aliases: ["the Union"] },
+    South: { code: "South", aliases: ["the Union"] },
+  });
+  assert.equal(canonicalOwnerName("the Union", aliases), "the Union");
+});
+
+// ---- Group B: the read path repairs saves already split ---------------------
+
+test("ownership already stored under an era name folds back to the token", () => {
+  const world = normalizeWorldState({
+    polityOverrides: RENAMED,
+    regionOwnershipOverrides: { "DEU.1_1": "Germany", "POL.11_1": "Third Reich", "FRA.1_1": "the Reich" },
+  });
+
+  assert.deepEqual(world.regionOwnershipOverrides, {
+    "DEU.1_1": "Germany",
+    "POL.11_1": "Germany",
+    "FRA.1_1": "Germany",
+  });
+});
+
+test("claimants share the owner namespace and fold with it", () => {
+  const world = normalizeWorldState({
+    polityOverrides: RENAMED,
+    regionClaimants: { "POL.11_1": ["Third Reich", "Poland"] },
+  });
+
+  assert.deepEqual(world.regionClaimants["POL.11_1"], ["Germany", "Poland"]);
+});
+
+// ---- Group C: the write path never splits a polity in two ------------------
+
+test("a transfer to the new name lands on the renamed polity, not beside it", () => {
+  const { world } = applyEventImpactsToWorld({
+    world: { polityOverrides: RENAMED, regionOwnershipOverrides: {} },
+    events: [event({ regionTransfers: [{ regionId: "AUT.9_1", toCode: "Third Reich" }] })],
+  });
+
+  assert.equal(world.regionOwnershipOverrides["AUT.9_1"], "Germany");
+});
+
+test("a rename and a conquest under the new name in the same turn agree", () => {
+  const { world } = applyEventImpactsToWorld({
+    world: { polityOverrides: {}, regionOwnershipOverrides: { "DEU.1_1": "Germany" } },
+    events: [
+      event({ polityChanges: [{ code: "Germany", name: "Third Reich" }] }),
+      event({ regionTransfers: [{ regionId: "AUT.9_1", toCode: "Third Reich" }] }),
+    ],
+  });
+
+  assert.deepEqual(Object.keys(world.polityOverrides), ["Germany"]);
+  assert.equal(world.regionOwnershipOverrides["AUT.9_1"], "Germany");
+  assert.equal(world.regionOwnershipOverrides["DEU.1_1"], "Germany");
+});
+
+test("a rename and the conquest it names, in ONE event, agree", () => {
+  // The transfers of an event are applied before its polity changes, so the new
+  // name has to be known before the transfers are read.
+  const { world } = applyEventImpactsToWorld({
+    world: { polityOverrides: {}, regionOwnershipOverrides: { "DEU.1_1": "Germany" } },
+    events: [event({
+      polityChanges: [{ code: "Germany", name: "Third Reich" }],
+      regionTransfers: [{ regionId: "AUT.9_1", fromCode: "Austria", toCode: "Third Reich" }],
+    })],
+  });
+
+  assert.deepEqual(Object.keys(world.polityOverrides), ["Germany"]);
+  assert.equal(world.regionOwnershipOverrides["AUT.9_1"], "Germany");
+});
+
+test("a polity created and given land in ONE event keeps its own identity", () => {
+  const { world } = applyEventImpactsToWorld({
+    world: { polityOverrides: {}, regionOwnershipOverrides: { "DEU.2_1": "Germany" } },
+    events: [event({
+      polityChanges: [{ code: "Free Bavaria", name: "Free Bavaria" }],
+      regionTransfers: [{ regionId: "DEU.2_1", fromCode: "Germany", toCode: "Free Bavaria" }],
+    })],
+  });
+
+  assert.equal(world.regionOwnershipOverrides["DEU.2_1"], "Free Bavaria");
+  assert.deepEqual(Object.keys(world.polityOverrides), ["Free Bavaria"]);
+});
+
+test("a later change addressed to the display name updates the same polity", () => {
+  const { colors, world } = applyEventImpactsToWorld({
+    colors: {},
+    world: { polityOverrides: RENAMED },
+    events: [event({
+      polityChanges: [{
+        code: "Third Reich",
+        color: "#804040",
+        reputation: 12,
+        tags: ["authoritarian"],
+        stats: { leader: "A. N. Other" },
+      }],
+    })],
+  });
+
+  assert.deepEqual(Object.keys(world.polityOverrides), ["Germany"]);
+  assert.equal(world.polityOverrides.Germany.name, "Third Reich");
+  assert.equal(world.internationalReputation.Germany, 12);
+  assert.deepEqual(world.countryTags.Germany, ["authoritarian"]);
+  assert.equal(world.countryStats.Germany.leader, "A. N. Other");
+  assert.deepEqual(colors.Germany, [128, 64, 64]);
+  assert.equal("Third Reich" in world.countryTags, false);
+});
+
+test("a battalion raised under the new name flies the right country's flag", () => {
+  const { world } = applyEventImpactsToWorld({
+    world: { polityOverrides: RENAMED },
+    events: [event({
+      unitOps: [{
+        op: "spawn",
+        unit: { name: "1st Army", type: "infantry", ownerCode: "Third Reich", strength: 100, lng: 13.4, lat: 52.5 },
+      }],
+    })],
+  });
+
+  assert.equal(world.units.length, 1);
+  assert.equal(world.units[0].ownerCode, "Germany");
+});
+
+test("a structure built under the new name belongs to the same polity", () => {
+  const { world } = applyEventImpactsToWorld({
+    world: { polityOverrides: RENAMED },
+    events: [event({
+      markerOps: [{ op: "build", marker: { name: "Westwall", kind: "fortification", ownerCode: "Third Reich", lng: 7.1, lat: 49.2 } }],
+    })],
+  });
+
+  assert.equal(world.markers[0].ownerCode, "Germany");
+});
+
+test("a genuinely new polity is still created, not folded into an existing one", () => {
+  const { world } = applyEventImpactsToWorld({
+    world: { polityOverrides: RENAMED },
+    events: [event({ polityChanges: [{ code: "Free Bavaria", name: "Free Bavaria" }] })],
+  });
+
+  assert.deepEqual(Object.keys(world.polityOverrides).sort(), ["Free Bavaria", "Germany"]);
+});
+
+// ---- Group D: annexation ---------------------------------------------------
+
+test("annexation moves every region and leaves the loser landless, not deleted", () => {
+  const { world } = applyEventImpactsToWorld({
+    world: {
+      polityOverrides: { Belgium: { code: "Belgium", name: "Kingdom of Belgium" } },
+      countryTags: { Belgium: ["neutral"] },
+      regionOwnershipOverrides: { "BEL.1_1": "Belgium", "BEL.2_1": "Belgium" },
+    },
+    events: [event({
+      regionTransfers: [
+        { regionId: "BEL.1_1", fromCode: "Belgium", toCode: "Germany" },
+        { regionId: "BEL.2_1", fromCode: "Kingdom of Belgium", toCode: "Germany" },
+      ],
+    })],
+  });
+
+  assert.deepEqual(Object.values(world.regionOwnershipOverrides), ["Germany", "Germany"]);
+  // The polity survives as a stateless actor (isPolityLandless), keeping its
+  // registry entry and everything keyed to it.
+  assert.equal(world.polityOverrides.Belgium.name, "Kingdom of Belgium");
+  assert.deepEqual(world.countryTags.Belgium, ["neutral"]);
+});

--- a/src/runtime/ownerNames.js
+++ b/src/runtime/ownerNames.js
@@ -26,3 +26,119 @@ export const isCountryCode = (token) => {
   const raw = String(token ?? "").trim();
   return Boolean(raw) && Boolean(COUNTRY_NAMES[raw] || COUNTRY_NAMES[raw.toUpperCase()]);
 };
+
+// ---------------------------------------------------------------------------
+// Display names vs identity
+//
+// A polity is renamed by writing polityOverrides[token].name — the KEY never
+// moves, so "Germany" stays the identity while "Third Reich" becomes the label.
+// That only holds if every inbound owner is folded back to the token: a model
+// that writes a transfer to "Third Reich" (the name it just read in the story)
+// would otherwise mint a second owner beside the first, and the world splits in
+// two — half the regions keyed "Germany" with the country's colour, tags,
+// reputation and stat sheet, half keyed "Third Reich" with none of them and a
+// procedural fallback colour on the map.
+//
+// Hence one shared alias map, built from the polity registry and applied
+// wherever an owner enters the world state (gameState.normalizeWorldState and
+// applyEventImpactsToWorld) or is compared against one (the AI's region-transfer
+// resolver).
+// ---------------------------------------------------------------------------
+
+// Case-, diacritic- and punctuation-insensitive identity for an owner token, so
+// "Côte d'Ivoire", "cote divoire" and "COTE D'IVOIRE" are one polity. Separators
+// are dropped rather than folded to a space: the model spells a name back the way
+// it remembers it, and an apostrophe it left out must not make a new country.
+export const ownerIdentityKey = (value) =>
+  String(value ?? "")
+    .normalize("NFD")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "");
+
+// Every real country's name is an identity of its own and can never be redirected
+// to some other polity — the guard that stops a scenario whose polity happens to
+// be NAMED "India" from swallowing the actual India's territory.
+const COUNTRY_NAME_KEYS = new Set(Object.values(COUNTRY_NAMES).map(ownerIdentityKey));
+
+// polity display name / alias -> the token that polity is keyed by. Names that
+// identify someone already (another polity's key, a real country) and names two
+// polities both answer to are left out: an ambiguous alias identifies nobody, and
+// redirecting one is worse than not resolving it.
+export const buildOwnerAliasMap = (polityOverrides) => {
+  const rows = [];
+  const identities = new Set();
+
+  for (const [key, polity] of Object.entries(polityOverrides ?? {})) {
+    if (!polity || typeof polity !== "object") {
+      continue;
+    }
+
+    const token = String(polity.code ?? "").trim() || String(key ?? "").trim();
+    const tokenKey = ownerIdentityKey(token);
+    if (!tokenKey) {
+      continue;
+    }
+
+    identities.add(tokenKey);
+    rows.push({
+      names: [polity.name, ...(Array.isArray(polity.aliases) ? polity.aliases : [])],
+      token,
+      tokenKey,
+    });
+  }
+
+  const aliases = new Map();
+  for (const row of rows) {
+    for (const name of row.names) {
+      const nameKey = ownerIdentityKey(name);
+      if (!nameKey || nameKey === row.tokenKey || identities.has(nameKey) || COUNTRY_NAME_KEYS.has(nameKey)) {
+        continue;
+      }
+
+      const claimed = aliases.get(nameKey);
+      // Two polities answering to one name: blank it rather than pick a winner.
+      aliases.set(nameKey, claimed !== undefined && claimed !== row.token ? "" : row.token);
+    }
+  }
+
+  for (const [key, token] of aliases) {
+    if (!token) {
+      aliases.delete(key);
+    }
+  }
+
+  return aliases;
+};
+
+// The single inbound canonicalisation: a GADM code becomes its country name, and
+// a polity's display name or alias becomes the token it is keyed by. Anything
+// else is returned untouched, so this is always safe to apply.
+export const canonicalOwnerName = (token, aliasMap) => {
+  const name = toCountryName(token);
+  if (!name || !aliasMap?.size) {
+    return name;
+  }
+
+  return aliasMap.get(ownerIdentityKey(name)) || name;
+};
+
+// Owners repeat across thousands of regions, so fold each distinct string once.
+export const createOwnerResolver = (aliasMap) => {
+  const cache = new Map();
+
+  return (value) => {
+    const raw = String(value ?? "").trim();
+    if (!raw) {
+      return "";
+    }
+
+    const cached = cache.get(raw);
+    if (cached !== undefined) {
+      return cached;
+    }
+
+    const resolved = canonicalOwnerName(raw, aliasMap);
+    cache.set(raw, resolved);
+    return resolved;
+  };
+};


### PR DESCRIPTION
Map: one label per country, whatever the AI has called it

Two things put several labels on one country, and both showed on Fault Lines:

- The owner labels are clustered by which regions touch, and "touch" was a
  shared vertex on the coarse z0 regions tile. That tile simplifies every
  region on its own, so neighbours almost never share a vertex there: measured
  on the stock tile, 193 of 218 countries came out in several "contiguous
  territories" (Russia in 38, India in 27, China in 19) and every territory
  above the size bar got its own RUSSIA. Touching is now decided by bounding
  boxes that overlap or come within a fifth of a degree, which keeps Siberia
  one territory (Russia 1, Canada 1, Brazil 1; the United States 3 - mainland,
  Alaska, Hawaii) and still leaves a colony across a sea on its own.

- When the AI renames a polity (polityChanges name "Russian Federation" on the
  "Russia" token), the next turn's model reads that name back and hands it in
  on region transfers, unit spawns and later polity changes. Stored verbatim,
  that minted a second owner token beside the first, with its own colour and
  its own giant label next to the original's. Every owner that enters the
  world now folds through the polity registry's names and aliases back to the
  token it belongs to (src/runtime/ownerNames.js, from the beta branch), on
  read and on write, and the label builder folds the same way - so a save
  already split by an earlier build heals when it is next read, and one
  country is one label.

Tests: the 18 owner-identity tests from beta, unchanged.
