### PR TITLE
Show the model the intelligence rating, so it can actually move

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -4,7 +4,7 @@ import { logAi } from "../../runtime/logClient.js";
 import { normalizePromptPack } from "./gameplayPrompts.js";
 import { getGameplayTool, validateGameplayPayload } from "./gameplaySchemas.js";
 import { toCountryName } from "../../runtime/ownerNames.js";
-import { activeSpies, espionageBrief, normalizeIntercepts, normalizeSpies, resolveEspionage } from "../../runtime/spycraft.js";
+import { activeSpies, espionageBrief, intelligenceOf, normalizeIntercepts, normalizeSpies, resolveEspionage } from "../../runtime/spycraft.js";
 import { echoesExistingMessage, renderOpenChatsForPrompt } from "../../runtime/chatEcho.js";
 import { isSeal, newSeal, openExchange, sealExchange } from "../../runtime/spySeal.js";
 import {
@@ -373,11 +373,50 @@ const buildPlayerPolityReputationText = async (bundle) => {
   return `International reputation: ${clamped}/100 (${band}).`;
 };
 
+// The intelligence rating the AI evolves (world.intelligence), surfaced for the
+// same reason reputation is: a number the model never sees is a number it never
+// moves. Field report: a player built spy academies and researched the tech for
+// a dozen turns and the rating never budged. The plumbing was fine — schema
+// field, normalizer, applyEventImpactsToWorld, the Stats panel's own bar all
+// read and write it — but the ONLY mention of it anywhere in a jump prompt was
+// one clause in the actions menu telling the model to change it "only when
+// something changed it", with no current value to change FROM. Across a dozen
+// real saves not one event had ever set it, while reputation (which does get a
+// block like this) moved normally.
+//
+// Unrated is "ordinary", not "none": every polity runs a service whether or not
+// the AI has ever put a number on it (spycraft.js DEFAULT_INTELLIGENCE).
+const buildPlayerPolityIntelligenceText = (bundle) => {
+  const playerCode = normalizeString(bundle.game.country);
+  if (!playerCode) {
+    return "";
+  }
+  const world = bundle.world && typeof bundle.world === "object" ? bundle.world : {};
+  const rating = intelligenceOf(world, playerCode);
+  const band = rating >= 75 ? "formidable" : rating >= 55 ? "capable" : rating >= 35 ? "ordinary" : "weak";
+  const lines = [`${playerCode}'s intelligence service: ${rating}/100 (${band}).`];
+
+  // Only services the AI has actually rated. Every other polity is ordinary by
+  // definition, and listing two hundred identical defaults would bury the few
+  // that carry a real judgement.
+  const rated = Object.entries(world.intelligence ?? {})
+    .map(([code, value]) => [normalizeString(code), Number(value)])
+    .filter(([code, value]) => code && code !== playerCode && Number.isFinite(value))
+    .sort((left, right) => right[1] - left[1])
+    .slice(0, 8);
+  if (rated.length > 0) {
+    lines.push(`Other rated services: ${rated.map(([code, value]) => `${code} ${Math.round(value)}/100`).join(", ")}.`);
+  }
+
+  return lines.join("\n");
+};
+
 const buildTemplateVariables = async (bundle, options = {}) => {
   const variables = await buildPromptContext(bundle, options);
   return {
     ...variables,
     playerPolityReputationContext: await buildPlayerPolityReputationText(bundle),
+    playerPolityIntelligenceContext: buildPlayerPolityIntelligenceText(bundle),
     unitsSummary:
       variables.unitsSummary +
       buildMilitaryFeasibilityText(bundle.world, buildActionHistoryText(bundle.actions)),
@@ -497,6 +536,15 @@ const runJsonTask = async (taskKey, {
     const reputationContext = normalizeString(variables.playerPolityReputationContext);
     if (reputationContext) {
       systemPrompt = `${systemPrompt}\n\n[International Reputation]\n${reputationContext}\nLow international reputation should reduce trade, trust, and coalition support, and should make nearby rivals more likely to sanction, isolate, or form balancing alliances. High reputation should improve access, trust, and coalition-building. When events this turn change how the world regards a polity, record the new value by including a "reputation" field (an integer 0-100) on that polity's impacts.polityChanges entry: aggression, broken treaties, and atrocities lower it; cooperation, aid, and honored commitments raise it. Only include reputation when it actually changes.`;
+    }
+  }
+
+  // Espionage's counterpart to the reputation block above. Without it the rating
+  // is invisible to the model and therefore frozen for the whole campaign.
+  if (["actions", "jumpForward", "autoJumpForward", "catalystCreation", "catalystExecutor"].includes(taskKey)) {
+    const intelligenceContext = normalizeString(variables.playerPolityIntelligenceContext);
+    if (intelligenceContext) {
+      systemPrompt = `${systemPrompt}\n\n[Intelligence Services]\n${intelligenceContext}\nThis rating is how much of other polities' private diplomacy a service can read and how well it protects its own, and it moves the same way international reputation does. When this turn's events actually change what a service is capable of, record the new ABSOLUTE value (an integer 0-100) in an "intelligence" field on that polity's impacts.polityChanges entry. Concrete investment the player has ordered and that this turn actually delivers raises it a few points at a time — a training academy opening its doors, a new bureau or directorate standing up, a funding increase taking effect, a recruitment or codebreaking programme bearing fruit; a purge, a mass defection, a network rolled up by a rival, or deep cuts lower it. An intention is not a capability: do not move it for an order that has only just been given, do not restate it when nothing changed, and do not jump it by tens of points for a single measure.`;
     }
   }
 

--- a/src/Game/AI/intelligenceRating.test.js
+++ b/src/Game/AI/intelligenceRating.test.js
@@ -36,9 +36,17 @@ const event = (impacts) => ({
   impacts,
 });
 
+// A polity change carries an `operation` discriminator on some branches and not
+// on others, and every version of the schema rejects unknown fields — so ask
+// this build which shape it takes rather than hard-coding one and failing for a
+// reason that has nothing to do with the rating under test.
+const OPERATION = validateGameplayPayload("jumpForward", jumpPayload([
+  { operation: "update", code: "United States of America" },
+])).valid ? { operation: "update" } : {};
+
 test("the tool schema accepts an intelligence rating on a polity change", () => {
   const result = validateGameplayPayload("jumpForward", jumpPayload([
-    { code: "United States of America", intelligence: 72, note: "New academy" },
+    { ...OPERATION, code: "United States of America", intelligence: 72, note: "New academy" },
   ]));
   assert.equal(result.valid, true, result.error);
 });

--- a/src/Game/AI/intelligenceRating.test.js
+++ b/src/Game/AI/intelligenceRating.test.js
@@ -1,0 +1,96 @@
+/*! Open Historia — intelligence-rating pipeline tests © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// Run: node --test src/Game/AI/intelligenceRating.test.js
+//
+// Reported: a player built spy training academies and researched the tech for a
+// dozen turns and the 🕵 Intelligence service bar never moved. Every link below
+// was already sound — the model was simply never shown the current rating, so it
+// never emitted a change (gameplay.js buildPlayerPolityIntelligenceText now does
+// for intelligence what the reputation block has always done for reputation).
+// These tests pin the mechanical chain that fix depends on, end to end: the tool
+// schema must accept the field, the normalizer must keep it, applying the event
+// must store it, and the espionage maths must read it back.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { validateGameplayPayload } from "./gameplaySchemas.js";
+import { applyEventImpactsToWorld, normalizeWorldState } from "../../runtime/gameState.js";
+import { DEFAULT_INTELLIGENCE, intelligenceOf } from "../../runtime/spycraft.js";
+
+const jumpPayload = (polityChanges) => ({
+  events: [{
+    date: "2014-04-01",
+    title: "The academy opens",
+    description: "The first class is sworn in at the new intelligence academy.",
+    impacts: { polityChanges },
+  }],
+  stopDate: "2014-04-30",
+  summary: "A quarter of quiet institution-building.",
+  clearActions: true,
+});
+
+const event = (impacts) => ({
+  date: "2014-04-01",
+  title: "The academy opens",
+  description: "The first class is sworn in.",
+  impacts,
+});
+
+test("the tool schema accepts an intelligence rating on a polity change", () => {
+  const result = validateGameplayPayload("jumpForward", jumpPayload([
+    { code: "United States of America", intelligence: 72, note: "New academy" },
+  ]));
+  assert.equal(result.valid, true, result.error);
+});
+
+test("an emitted rating reaches world.intelligence and the espionage maths", () => {
+  const { world } = applyEventImpactsToWorld({
+    world: { polityOverrides: {}, intelligence: {} },
+    events: [event({ polityChanges: [{ code: "United States of America", intelligence: 72 }] })],
+  });
+
+  assert.equal(world.intelligence["United States of America"], 72);
+  assert.equal(intelligenceOf(world, "United States of America"), 72);
+});
+
+test("the rating survives the save round trip that persists it", () => {
+  const { world } = applyEventImpactsToWorld({
+    world: { polityOverrides: {}, intelligence: {} },
+    events: [event({ polityChanges: [{ code: "United States of America", intelligence: 72 }] })],
+  });
+
+  // What writeWorldState/readWorldState do to it between turns.
+  const reloaded = normalizeWorldState(JSON.parse(JSON.stringify(world)));
+  assert.equal(intelligenceOf(reloaded, "United States of America"), 72);
+});
+
+test("a rating addressed to a polity's display name lands on the polity", () => {
+  // The turn after a rename the model answers with the new name; the rating must
+  // follow the token like every other owner-keyed field (see ownerNames.js).
+  const { world } = applyEventImpactsToWorld({
+    world: {
+      polityOverrides: { Russia: { code: "Russia", name: "Russian Federation" } },
+      intelligence: {},
+    },
+    events: [event({ polityChanges: [{ code: "Russian Federation", intelligence: 80 }] })],
+  });
+
+  assert.deepEqual(world.intelligence, { Russia: 80 });
+});
+
+test("an unrated polity is ordinary rather than absent", () => {
+  // The prompt block reports this number, so it may never read as 0/100 for a
+  // country the AI has simply never had a reason to rate.
+  const world = normalizeWorldState({ intelligence: {} });
+  assert.equal(intelligenceOf(world, "Ukraine"), DEFAULT_INTELLIGENCE);
+  assert.ok(DEFAULT_INTELLIGENCE > 0);
+});
+
+test("a polity change that says nothing about intelligence leaves the rating alone", () => {
+  const { world } = applyEventImpactsToWorld({
+    world: { polityOverrides: {}, intelligence: { "United States of America": 72 } },
+    events: [event({ polityChanges: [{ code: "United States of America", reputation: 40 }] })],
+  });
+
+  assert.equal(intelligenceOf(world, "United States of America"), 72);
+});


### PR DESCRIPTION
Show the model the intelligence rating, so it can actually move

Reported: a player built spy training academies, researched the tech, and the
Stats panel's 🕵 Intelligence service bar never moved for the whole campaign.

Every link in the chain was already sound. polityChangeSchema declares an
`intelligence` field, normalizePolityChange keeps it, applyEventImpactsToWorld
writes world.intelligence[code], normalizeWorldState carries it through the
save round trip, and the Stats panel reads that same store. Emitting a change
by hand lands it and it persists.

The model was simply never shown the number. `intelligence` appears nowhere in
promptContext.js, nowhere in defaultPrompts.json, and nowhere in a game's
frozen prompt pack; the espionage brief lists agents, turned agents and
intercepts but no capability rating. The only mention anywhere was one clause
in the injected actions menu telling the model to set it "only when something
changed it" — with no current value to change from, and no reminder that it is
a live number the simulation expects it to evolve. So it never did: across a
dozen real saves, not one event has ever set intelligence, and every
world.intelligence is empty. International reputation, which does get a
context block fed back into every jump, moves normally in those same saves.

So intelligence now gets what reputation has: buildPlayerPolityIntelligenceText
reports the player's current rating with a band (and any other services the AI
has actually rated — unrated polities are ordinary by definition and would just
bury the few that carry a judgement), and an [Intelligence Services] block
injected on the same tasks as the reputation one explains how it moves:
concrete investment that this turn actually delivers raises it a few points,
purges and rolled-up networks lower it, and an intention is not a capability.

Injected at call time, so existing campaigns with frozen prompt packs get it
too, and a save whose rating has been stuck at the default starts moving on the
next jump.

Tests: src/Game/AI/intelligenceRating.test.js pins the mechanical chain the fix
depends on — the schema accepts the field, an emitted rating reaches
world.intelligence and the espionage maths, it survives the save round trip, a
rating addressed to a renamed polity's display name lands on the polity, an
unrated polity reads as ordinary rather than absent, and a polity change that
says nothing about intelligence leaves the rating alone.
