### PR TITLE
A turn can no longer be written into a campaign it did not come from

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -51,6 +51,8 @@ import {
 import { dedupeGeneratedEvents } from "../../runtime/eventDedup.js";
 import { difficultyDirective } from "../../runtime/difficulty.js";
 import { MAP_SETTING_KEYS, getMapSetting } from "../../runtime/mapSettings.js";
+import { assertCampaignUnchanged } from "../../runtime/campaignGuard.js";
+import { getLibraryState } from "../../runtime/library.js";
 
 const CHAT_HINT_PATTERNS = [
   /\bchat\b/i,
@@ -767,6 +769,18 @@ const mergePolityCatalog = (countryCatalog, world) => {
 // clobbered (or worse, interleave with the rollback snapshot). Every simulation
 // entry point wraps itself in beginSimulation/endSimulation; the drip checks
 // the counter before starting AND before writing, and simply skips its turn.
+// Which campaign is in front of the player right now. A turn stamps this when
+// it reads its state and checks it again before writing, because the runtime
+// endpoints follow the active campaign and a switch mid-turn would otherwise
+// land the whole turn on the campaign that was switched to (campaignGuard.js).
+const activeCampaignId = () => {
+  try {
+    return String(getLibraryState()?.activeGameId ?? "").trim();
+  } catch {
+    return "";
+  }
+};
+
 let activeSimulations = 0;
 const beginSimulation = () => { activeSimulations += 1; };
 const endSimulation = () => { activeSimulations = Math.max(0, activeSimulations - 1); };
@@ -1535,6 +1549,7 @@ const applySimulationResult = async ({
   baseEvents,
   baseGame,
   baseWorld,
+  campaignId = "",
   result,
 }) => {
   const generatedEvents = normalizeArray(result.events)
@@ -1731,6 +1746,11 @@ const applySimulationResult = async ({
   } catch {
     chatsToWrite = nextChats;
   }
+
+  // Last moment before anything is persisted. Everything above is pure, so a
+  // turn generated for a campaign the player has since left is simply lost here
+  // rather than written over whichever campaign they opened instead.
+  assertCampaignUnchanged(campaignId, activeCampaignId());
 
   await Promise.all([
     writeActionsState(nextActions),
@@ -2200,6 +2220,8 @@ export const advanceActiveCatalyst = async (choiceText) => {
   beginSimulation();
   try {
   const bundle = await readGameStateBundle({ force: true });
+  // Stamped at the read, not at the write minutes later.
+  const campaignId = activeCampaignId();
   const baseColors = await readJson(JSON_URLS.colors, { defaultValue: {}, force: true });
   const world = normalizeWorldState(bundle.world);
   const catalyst = world.activeCatalyst;
@@ -2297,6 +2319,7 @@ export const advanceActiveCatalyst = async (choiceText) => {
   });
 
   return applySimulationResult({
+    campaignId,
     baseActions: bundle.actions,
     baseChats: bundle.chats,
     baseColors,
@@ -2351,6 +2374,8 @@ export const simulateTimelineJump = async ({ days, mode = "jump", signal } = {})
   beginSimulation();
   try {
   const bundle = await readGameStateBundle({ force: true });
+  // Stamped at the read, not at the write minutes later.
+  const campaignId = activeCampaignId();
   const baseColors = await readJson(JSON_URLS.colors, { defaultValue: {}, force: true });
   // Fractional days are allowed so sub-day skips (e.g. 6h = 0.25) work; the game
   // date only advances in whole days, so a sub-day skip keeps the same date.
@@ -2428,6 +2453,7 @@ export const simulateTimelineJump = async ({ days, mode = "jump", signal } = {})
   };
 
   return applySimulationResult({
+    campaignId,
     baseActions: bundle.actions,
     baseChats: bundle.chats,
     baseColors,
@@ -2448,6 +2474,8 @@ export const applyGameMasterCommand = async (requestText) => {
   beginSimulation();
   try {
   const bundle = await readGameStateBundle({ force: true });
+  // Stamped at the read, not at the write minutes later.
+  const campaignId = activeCampaignId();
   const baseColors = await readJson(JSON_URLS.colors, { defaultValue: {}, force: true });
   const variables = await buildTemplateVariables(bundle, { gameMasterRequest: requestText });
   const { generation, payload } = await runJsonTask("gameMaster", {
@@ -2481,6 +2509,7 @@ export const applyGameMasterCommand = async (requestText) => {
   }
 
   return applySimulationResult({
+    campaignId,
     baseActions: bundle.actions,
     baseChats: bundle.chats,
     baseColors,

--- a/src/runtime/campaignGuard.js
+++ b/src/runtime/campaignGuard.js
@@ -1,0 +1,41 @@
+/*! Open Historia — campaign write guard © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// A turn reads a campaign's whole state when it starts, spends minutes in the
+// model, and writes it back at the end — through the runtime endpoints, which
+// switching campaigns in the library has already repointed at the new save. So a
+// turn that outlives the switch lands on whichever campaign is open when it
+// finishes, overwriting it.
+//
+// Reported 2026-09-04: a Modern Day jump was still generating when the player
+// opened a 1911 campaign, and six months of 2016 — clock, world, events, chats,
+// colours — were written over it. The 1911 campaign's own progress was gone, and
+// the campaign that generated the turn was left at its starting state.
+//
+// The rule is one comparison, kept here rather than inline so it can be tested
+// without loading the simulation: stamp the campaign a turn belongs to when its
+// state is read, and refuse to write if that is no longer the campaign in front
+// of the player. Refusing costs the player the generation; writing costs them a
+// campaign.
+//
+// An unknown id on either side (no library state yet, a headless caller) means
+// "cannot tell", and a guard that cannot tell must not block an ordinary turn.
+
+const clean = (value) => String(value ?? "").trim();
+
+export const campaignChanged = (startedIn, current) => {
+  const from = clean(startedIn);
+  const to = clean(current);
+  return Boolean(from) && Boolean(to) && from !== to;
+};
+
+export const campaignSwitchMessage = (startedIn, current, what = "turn") =>
+  `This ${what} was generated for the campaign "${clean(startedIn)}", but "${clean(current)}" is open now, `
+  + "so nothing was written. Switching campaigns while a turn is generating would otherwise overwrite the "
+  + "campaign you switched to. Finish or cancel a turn before switching.";
+
+// Throws when the campaign has changed, and is a no-op otherwise.
+export const assertCampaignUnchanged = (startedIn, current, what = "turn") => {
+  if (!campaignChanged(startedIn, current)) return;
+  const error = new Error(campaignSwitchMessage(startedIn, current, what));
+  error.campaignSwitched = true;
+  throw error;
+};

--- a/src/runtime/campaignGuard.test.js
+++ b/src/runtime/campaignGuard.test.js
@@ -1,0 +1,49 @@
+/*! Open Historia — campaign write guard tests © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+// Run: node --test src/runtime/campaignGuard.test.js
+//
+// Reported 2026-09-04: a Modern Day jump was still generating when the player
+// opened a 1911 campaign. The turn finished, wrote through the runtime endpoints
+// the switch had repointed, and six months of 2016 landed on the 1911 save —
+// destroying it, and leaving the campaign that generated the turn at its start.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { assertCampaignUnchanged, campaignChanged, campaignSwitchMessage } from "./campaignGuard.js";
+
+test("the same campaign is never blocked", () => {
+  assert.equal(campaignChanged("modern-day-session-3", "modern-day-session-3"), false);
+  assert.doesNotThrow(() => assertCampaignUnchanged("modern-day-session-3", "modern-day-session-3"));
+});
+
+test("a turn that outlived a campaign switch is refused", () => {
+  assert.equal(campaignChanged("modern-day-session-3", "the-great-war-session"), true);
+  assert.throws(
+    () => assertCampaignUnchanged("modern-day-session-3", "the-great-war-session"),
+    (error) => error.campaignSwitched === true,
+  );
+});
+
+test("the refusal says which campaigns and that nothing was written", () => {
+  const message = campaignSwitchMessage("modern-day-session-3", "the-great-war-session");
+  assert.match(message, /modern-day-session-3/);
+  assert.match(message, /the-great-war-session/);
+  assert.match(message, /nothing was written/);
+});
+
+test("an unknown campaign on either side never blocks an ordinary turn", () => {
+  // No library state yet, or a caller that cannot say — a guard that cannot tell
+  // must not cost the player a finished turn.
+  for (const [from, to] of [["", "x"], ["x", ""], ["", ""], [null, undefined]]) {
+    assert.equal(campaignChanged(from, to), false, `${JSON.stringify(from)} -> ${JSON.stringify(to)}`);
+    assert.doesNotThrow(() => assertCampaignUnchanged(from, to));
+  }
+});
+
+test("surrounding whitespace is not a different campaign", () => {
+  assert.equal(campaignChanged(" modern-day-session-3 ", "modern-day-session-3"), false);
+});
+
+test("the wording can name what was refused", () => {
+  assert.match(campaignSwitchMessage("a", "b", "game-master change"), /This game-master change was generated/);
+});


### PR DESCRIPTION
A turn can no longer be written into a campaign it did not come from

Reported: the Projects board showed two campaigns' projects at once. The board
was the symptom. The cause was that a Modern Day jump was still generating when
the player opened a 1911 campaign — and when the turn finished it wrote itself
into whichever campaign was open by then. Six months of 2016 events, the clock,
the world, the chats and the colours landed on the 1911 save and overwrote it;
the campaign that actually generated the turn was left at its starting state
with nothing.

A turn reads a campaign's whole state when it starts, spends minutes in the
model, then writes it back through the runtime endpoints — and switching
campaigns repoints those endpoints at the new save. Nothing checked that the
campaign was still the one the turn began in. The pre-game backstory path has
carried exactly that check for a while ("the player may have switched games
while this generated"), so the hazard was known there and never generalised.

So the campaign a turn belongs to is now stamped when its state is read — the
jump in simulateTimelineJump, the catalyst in advanceActiveCatalyst — and
checked at the single choke point every turn type writes through, immediately
before the first write. Everything above that point is pure, so a turn whose
campaign has moved on is simply lost rather than written over the campaign the
player switched to. Refusing costs a generation; writing costs a campaign.

A held turn resumed later carries its original stamp, so finishing one after
switching is refused too, and the error says which campaign it was for and that
nothing was written.

The guard is deliberately permissive where it cannot tell: an unknown campaign
id on either side (no library state yet, a headless caller) never blocks an
ordinary turn.

Tests: src/runtime/campaignGuard.test.js — the same campaign is never blocked, a
turn that outlived a switch is refused, the message names both campaigns and
says nothing was written, an unknown id on either side never blocks, and
whitespace is not a different campaign.
