### PR TITLE
List the beta installer workflow in the Actions tab

### DIFF
--- a/.github/workflows/desktop-beta.yml
+++ b/.github/workflows/desktop-beta.yml
@@ -33,6 +33,11 @@ on:
         description: Release tag to publish the beta installers to
         required: false
         default: desktop-beta
+      publish:
+        description: Publish to that release (clear to build the installers only)
+        required: false
+        type: boolean
+        default: true
   push:
     tags:
       - "desktop-beta-v*"
@@ -144,12 +149,17 @@ jobs:
             release/*.deb
           if-no-files-found: error
 
-      # Clearing the tag field on a dispatch run builds the installers and stops.
-      # They are still uploaded as run artifacts above, so this is how you get a
-      # build to try without offering it to anyone. Same escape hatch, and the same
-      # condition, as the stable workflow.
+      # Unticking `publish` builds the installers and stops. They are still uploaded
+      # as run artifacts above, so this is how you get a build to try without
+      # offering it to anyone.
+      #
+      # A separate boolean rather than the stable workflow's `inputs.tag != ''`,
+      # which does not work: an omitted or empty value falls back to the input's
+      # DEFAULT, so inputs.tag is never empty and that condition is always true.
+      # Measured, not assumed - run 33929212744 was dispatched with `-f tag=` and
+      # published anyway, with TAG=desktop-beta in its log.
       - name: Attach to the beta release
-        if: github.event_name == 'push' || inputs.tag != ''
+        if: github.event_name == 'push' || inputs.publish
         env:
           GH_TOKEN: ${{ github.token }}
           # A FIXED tag, never the branch and never the tag that was pushed — and

--- a/.github/workflows/desktop-beta.yml
+++ b/.github/workflows/desktop-beta.yml
@@ -1,0 +1,217 @@
+# Builds the desktop installers from the `beta` integration branch for Windows,
+# macOS and Linux and publishes them to the `desktop-beta` pre-release.
+#
+# It is the same pipeline as desktop-installer.yml with two additions — the channel
+# stamp and a different electron-builder config — and together those are what make
+# the beta a separate application: it installs BESIDE the official Open Historia
+# rather than over it, keeps its own saves, and updates itself from its own release
+# instead of being walked onto the stable build. Nothing here touches the stable
+# release or its `desktop-stable` tag.
+#
+# Two ways to start it, the same two the stable workflow offers:
+#
+#   * Actions → Desktop beta installers → Run workflow → `beta`. GitHub only
+#     lists a workflow_dispatch entry if the file is on the DEFAULT branch, so a
+#     copy of this file is kept on `main` purely to make the entry appear — the
+#     copy on the branch you select is the one that actually runs. Same
+#     arrangement as desktop-seventhdread-beta.yml and android-apk-beta.yml.
+#     Clearing the tag field builds the installers without publishing them.
+#   * push a tag matching `desktop-beta-v*` at a commit on `beta`. A tag push
+#     runs the workflow file from the tagged tree, so this works whatever is on
+#     `main`.
+#
+# The tag pattern deliberately does not match the stable `desktop-v*` trigger in
+# desktop-installer.yml: a tag that matched both would publish a beta build to the
+# `desktop-stable` release. `desktop-beta` — the release tag itself — matches
+# neither, so creating it below cannot start another run.
+name: Desktop beta installers
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to publish the beta installers to
+        required: false
+        default: desktop-beta
+  push:
+    tags:
+      - "desktop-beta-v*"
+
+# The release is created and its assets uploaded from here.
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false # one platform failing must not throw away the other two
+      matrix:
+        include:
+          # Each installer must be built on its own OS: electron-builder shells out
+          # to platform tooling (NSIS on Windows, hdiutil for the .dmg), and a macOS
+          # build simply cannot be produced anywhere but macOS.
+          - os: windows-latest
+            args: --win
+          - os: macos-latest
+            args: --mac
+          - os: ubuntu-latest
+            args: --linux
+    runs-on: ${{ matrix.os }}
+    steps:
+      # A dispatch run picks its own branch from a dropdown, and `main` is in that
+      # dropdown too — a run from there would package the released code, call it the
+      # beta and publish it. A tag run is exempt: its ref is the tag, not a branch,
+      # and the tag pattern is what says which line it came from.
+      - name: Refuse to dispatch this from anything but beta
+        if: github.event_name == 'workflow_dispatch' && github.repository == 'Open-Historia/open-historia' && github.ref_name != 'beta'
+        shell: bash
+        run: |
+          echo "::error::Run this with 'Use workflow from: beta'."
+          exit 1
+
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      # Building a .dmg mounts a volume and then detaches it, and Spotlight starts
+      # indexing that volume the moment it appears — `hdiutil detach` then fails
+      # with exit 16 and takes the whole macOS build with it. (Same reason as the
+      # stable workflow.)
+      - name: Stop Spotlight indexing the build volume
+        if: runner.os == 'macOS'
+        run: sudo mdutil -a -i off || true
+
+      - name: Install dependencies
+        run: npm ci
+
+      # The map archives are NOT packaged — they are ~170MB and the app downloads
+      # them on first launch — so nothing here fetches them.
+      - name: Stamp the build id
+        shell: bash
+        run: |
+          echo "{\"build\":\"${{ github.run_id }}\"}" > electron/build-id.json
+          cat electron/build-id.json
+
+      # What makes the packaged app behave as the beta at RUNTIME: its own Chromium
+      # profile, its own save library, its own update feed, its window title. The
+      # installer config below only decides how it is installed and what it is
+      # called. Both are needed — neither implies the other.
+      - name: Stamp the release channel
+        run: node scripts/stamp-channel.mjs beta
+
+      # package.json ships 0.0.0, and electron-updater compares semver: a build whose
+      # version never changes is one it will never offer as an update, and one Windows
+      # will not cleanly install over. run_number is shared by all three jobs in a
+      # run, so one run is one version on every platform, and it only ever goes up.
+      - name: Stamp the app version
+        shell: bash
+        run: |
+          node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('package.json','utf8'));p.version='0.0.${{ github.run_number }}';fs.writeFileSync('package.json',JSON.stringify(p,null,2))"
+          node -p "'version: '+require('./package.json').version"
+
+      # server/betaPackaging.test.js is in here, and it is the only thing that
+      # catches the beta's two update feeds drifting onto different tags, or
+      # latest.json below naming a file electron-builder does not produce. Both
+      # fail silently at runtime, so they have to fail loudly here.
+      - name: Run the tests
+        run: npm test
+
+      - name: Build the client
+        run: npm run build
+
+      # --config is what separates this from the stable workflow: its own appId,
+      # productName, icon, artifact names and update feed. It REPLACES package.json's
+      # `build` block rather than extending it.
+      - name: Build the installer
+        run: npx electron-builder ${{ matrix.args }} --config electron-builder.beta.yml --publish never
+        env:
+          # No code-signing certificate. Without this electron-builder tries to
+          # discover one and fails the build rather than skipping signing.
+          CSC_IDENTITY_AUTO_DISCOVERY: false
+
+      - name: Upload as a build artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: open-historia-beta-${{ matrix.os }}
+          # Only the finished installers; release/ also holds the unpacked app tree.
+          path: |
+            release/*.exe
+            release/*-mac-*.zip
+            release/*.AppImage
+            release/*.deb
+          if-no-files-found: error
+
+      # Clearing the tag field on a dispatch run builds the installers and stops.
+      # They are still uploaded as run artifacts above, so this is how you get a
+      # build to try without offering it to anyone. Same escape hatch, and the same
+      # condition, as the stable workflow.
+      - name: Attach to the beta release
+        if: github.event_name == 'push' || inputs.tag != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          # A FIXED tag, never the branch and never the tag that was pushed — and
+          # this is the ONE place this workflow deliberately does not do what the
+          # stable one does. desktop-installer.yml publishes a tag push to the tag
+          # that was pushed; here that would leave the build at `desktop-beta-v5`,
+          # which neither of the beta's two update feeds reads: both hardcode
+          # `desktop-beta` (BETA_UPDATE_MANIFEST in electron/main.cjs and `publish`
+          # in electron-builder.beta.yml), so testers would simply never be offered
+          # it. The input exists only for one-off builds that deliberately go
+          # somewhere private, and it deliberately does not reach either of those.
+          TAG: ${{ inputs.tag || 'desktop-beta' }}
+        shell: bash
+        run: |
+          # --prerelease so GitHub labels it, and never marks it "Latest" over the
+          # stable release in the same repo. Three jobs race here, so creating it
+          # tolerates "already exists"; --clobber lets a re-run replace assets.
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            printf '%s\n' \
+              '**Beta build of Open Historia.** Not the official release — that is the one marked `Latest` on this page.' \
+              '' \
+              'It installs **alongside** the official app as *Open Historia Beta*, with its own Start Menu entry and a BETA-badged icon. Both can stay installed; uninstalling one leaves the other.' \
+              '' \
+              '**Your official games are not touched.** The beta keeps its own saves, scenarios and settings, so nothing you play here can reach a campaign in the official app — and nothing you have played there shows up here. That is on purpose: this branch is far enough ahead that a save the beta writes would come back from the official app with the new systems stripped out of it.' \
+              '' \
+              'It does share one thing: the downloaded world map, so there is no second 170MB download if you already have the official app installed.' \
+              '' \
+              '- Windows: `Open-Historia-Beta-Setup.exe`' \
+              '- macOS: `Open-Historia-Beta-mac-arm64.zip` (Apple Silicon) or `-x64` (Intel) — unsigned, so right-click → Open the first time.' \
+              '- Linux: `Open-Historia-Beta-x86_64.AppImage`, or `Open-Historia-Beta-amd64.deb`' \
+              '' \
+              'It updates itself from this page, never onto the official build.' \
+              '' \
+              '**Do not run both at once** if you can help it — they are separate apps with separate saves, but they will both want the same map files.' \
+              '' \
+              'Feedback: [open an issue](https://github.com/Open-Historia/open-historia/issues).' \
+              > notes.md
+            # --target pins the tag to the commit this run built. Without it the tag
+            # would be created on the repository's DEFAULT branch — main — which is
+            # the one place a beta release must never point.
+            gh release create "$TAG" --prerelease --target "$GITHUB_SHA" \
+              --title "Open Historia Beta" \
+              --notes-file notes.md || true
+          fi
+          shopt -s nullglob
+          # latest*.yml is what electron-updater actually reads (the `publish` block
+          # in electron-builder.beta.yml points it at this tag). Omit them and the
+          # beta ships with a feed URL that resolves to nothing: the banner still
+          # appears — that comes from latest.json below — but pressing update fails
+          # and falls back to a manual download, with no failing build to notice.
+          # The .blockmap only makes the download differential; missing, it degrades.
+          files=(release/*.exe release/*.exe.blockmap release/*-mac-*.zip release/*.AppImage release/*.deb release/latest*.yml)
+          # Only the Windows job writes latest.json, so three racing jobs cannot each
+          # publish a different view of the same release. The filenames here must
+          # match the artifactNames in electron-builder.beta.yml exactly — a mismatch
+          # breaks the update banner silently, which is what
+          # server/betaPackaging.test.js exists to catch.
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            B="https://github.com/${{ github.repository }}/releases/download/$TAG"
+            printf '{\n  "build": "%s",\n  "notes": "%s",\n  "windows": "%s/Open-Historia-Beta-Setup.exe",\n  "mac": "%s/Open-Historia-Beta-mac-arm64.zip",\n  "linux": "%s/Open-Historia-Beta-x86_64.AppImage"\n}\n' \
+              "${{ github.run_id }}" "A newer Open Historia beta build is available." "$B" "$B" "$B" > latest.json
+            cat latest.json
+            files+=(latest.json)
+          fi
+          gh release upload "$TAG" "${files[@]}" --clobber


### PR DESCRIPTION
Adds `.github/workflows/desktop-beta.yml` to `main` so the beta desktop build can be started from **Actions → Desktop beta installers → Run workflow**, the same way `Desktop installers` is started today.

GitHub only lists a `workflow_dispatch` entry if the file is on the default branch. Until now the beta build could only be triggered by pushing a `desktop-beta-v*` tag, because a tag push runs the workflow from the tagged tree whatever is on `main`.

**This copy never builds anything from main.** A dispatch run executes the file from the branch chosen in the dropdown, not this one; and the workflow's first step refuses a dispatch from any ref but `beta` — `main` is in that dropdown too, and a run from there would package the released code and publish it as the beta. The file is byte-identical to the copy on `beta`, so the two cannot quietly disagree about what a run does.

Same arrangement, and the same reason, as `desktop-seventhdread-beta.yml` and `android-apk-beta.yml`, which already sit on `main` for exactly this.

### Blast radius

- Nothing on `main` is built, changed or published.
- The trigger `desktop-beta-v*` cannot match `desktop-installer.yml`'s `desktop-v*`.
- The workflow's release tag is `desktop-beta` (a pre-release), never `desktop-stable`.
- It asks for `contents: write` because it publishes to that pre-release.