### PR TITLE
fix(map): keep province borders thin and show them only at close zoom

### DIFF
--- a/docs/game-map.md
+++ b/docs/game-map.md
@@ -171,10 +171,10 @@ The crossfade band is z5.5–6.5 because the seed geometry was extracted at tile
 | Layer | Paint driver | Behaviour |
 |---|---|---|
 | `regions-fill` | `stockRegionsFillPaint` | `match GID_1 → ownerColorCss(owner)` for every non-drawn, non-edited region; opacity `TILE_FILL_FADE` (0 unless `customActive`) |
-| `regions-outline` | `regionsOutlinePaint` | black hairline; width `interp 3→0.2, 8→0.6, 12→1.0`; opacity fades in `5.5→0, 6.5→0.6, 8→0.7` (only when the tile fills do — below that the seed hairlines carry it); excludes `editedStockIds` |
+| `regions-outline` | `buildProvinceOutlinePaint` | Stock-world province hairlines only (`worldKnown && !customActive`); hidden through z6.5, then fade in; excludes `editedStockIds`. Shares the scenario-grid style below. |
 | `custom-regions-fill-far` | `["get","_fillColor"]` | seed-GeoJSON fill for GADM regions, `maxzoom 7`, opacity `FAR_FILL_FADE` |
 | `custom-regions-fill` | `["get","_fillColor"]` | author-drawn/edited geometry, opacity constant `0.72` at all zooms |
-| `custom-regions-local-outline` | — | the province grid: faint from z4.2, ramping to a proper grid by z14 (`customActive && worldKnown`) |
+| `custom-regions-local-outline` | `buildProvinceOutlinePaint` | Scenario province grid (`customActive && worldKnown`): hidden through z6.5; opacity `6.5→0, 7.5→0.25, 10→0.38, 12→0.45`; width `6.5→0.25, 8→0.4, 12→0.5` CSS px, capped above z12. Country/frontier strokes stay visible, and fill-based province selection is unchanged. |
 
 `_fillColor` is carried by the dissolved polity surfaces (`enrichedPolitySurfaceData`). The authored regions source is the URL itself — nothing on the UI thread parses or clones the regions file — and live ownership reaches it through `setFeatureState` (`fillColor`), so an ownership change is a tiny state diff rather than a GeoJSON replacement.
 

--- a/src/Game/Map/Nations.jsx
+++ b/src/Game/Map/Nations.jsx
@@ -37,6 +37,7 @@ import {
 import { translateLabel } from "../../runtime/translator.js";
 import { MAP_SETTING_KEYS, useMapSetting } from "../../runtime/mapSettings.js";
 import { useWorldState } from "./useWorldState.js";
+import { buildProvinceOutlinePaint, PROVINCE_OUTLINE_MIN_ZOOM } from "./provinceOutlineStyle.js";
 import { V_NEXT_MARKER_SHAPE_LAYER_IDS } from "./vnext/presentationPolicy.js";
 import { resolveContextualPolityLabels } from "./vnext/polityNaming.js";
 
@@ -1417,17 +1418,10 @@ const WorldMap = ({ isGlobe = false }) => {
     "line-width": ["interpolate", ["linear"], ["zoom"], 3, 0.62, 8, 0.96, 12, 1.25],
     "line-opacity": showStockCountries ? 0.82 : 0,
   };
-  // Region hairlines serve both map kinds, but nothing renders pre-worldKnown.
-  // Tile hairlines fade in alongside the tile fills. The seed hairlines stay
-  // underneath for a little longer as a safety net: if a vector tile is late,
-  // the fallback fill should not turn into one borderless slab while panning.
-  const regionsOutlinePaint = {
-    "line-color": "rgba(7, 10, 14, 0.88)",
-    "line-width": ["interpolate", ["linear"], ["zoom"], 3, 0.22, 6, 0.32, 8, 0.48, 12, 0.78],
-    "line-opacity": worldKnown && !customActive
-      ? ["interpolate", ["linear"], ["zoom"], 6.8, 0, 7.4, 0.08, 8.2, 0.16, 10, 0.28, 12, 0.42]
-      : 0,
-  };
+  // Scenario geometry owns its grid; never stack stock outlines on top of it.
+  // Both paths use the same close-zoom hairline policy, and stay hidden until
+  // the world is known. Political frontiers remain visible independently.
+  const regionsOutlinePaint = buildProvinceOutlinePaint(worldKnown && !customActive);
 
   // Scenario-authored label styling (world.labelFont/labelTextColor/
   // labelHaloColor). The style has no glyphs endpoint, so MapLibre v5 draws
@@ -1630,7 +1624,7 @@ const WorldMap = ({ isGlobe = false }) => {
         <Layer
           id="regions-outline"
           type="line"
-          minzoom={8.25}
+          minzoom={PROVINCE_OUTLINE_MIN_ZOOM}
           source-layer="regions"
           filter={editedStockIds.length ? ["!", ["in", ["get", "GID_1"], ["literal", editedStockIds]]] : ["all"]}
           paint={regionsOutlinePaint}
@@ -1678,47 +1672,14 @@ const WorldMap = ({ isGlobe = false }) => {
             "fill-outline-color": CUSTOM_FILL_COLOR,
           }}
         />
-        {/* Provinces are a local interaction grid, not part of the political
-            silhouette. R18 brings them in at regional zoom instead of waiting
-            for an already-close camera. The first appearance is deliberately
-            faint, then ramps smoothly into a proper province grid.
-            This is the one canonical scenario-geometry outline layer. */}
+        {/* Only the province strokes disappear at overview zoom. Keep the
+            source and fills mounted so province selection still works. */}
         <Layer
           id="custom-regions-local-outline"
           type="line"
-          minzoom={4.20}
+          minzoom={PROVINCE_OUTLINE_MIN_ZOOM}
           layout={{ "line-cap": "round", "line-join": "round" }}
-          paint={{
-            "line-color": "rgba(8, 12, 18, 0.90)",
-            "line-width": [
-              "interpolate", ["linear"], ["zoom"],
-              4.20, 0.14,
-              4.75, 0.17,
-              5.25, 0.21,
-              6.0, 0.27,
-              7.0, 0.35,
-              8.0, 0.45,
-              10, 0.61,
-              12, 0.79,
-              14, 0.96,
-            ],
-            "line-opacity": customActive && worldKnown
-              ? [
-                  "interpolate", ["linear"], ["zoom"],
-                  4.20, 0.00,
-                  4.45, 0.045,
-                  4.85, 0.075,
-                  5.25, 0.11,
-                  5.75, 0.16,
-                  6.25, 0.22,
-                  7.0, 0.30,
-                  8.0, 0.39,
-                  10, 0.49,
-                  12, 0.58,
-                  14, 0.67,
-                ]
-              : 0,
-          }}
+          paint={buildProvinceOutlinePaint(customActive && worldKnown)}
         />
       </Source>
       )}

--- a/src/Game/Map/provinceOutlineStyle.js
+++ b/src/Game/Map/provinceOutlineStyle.js
@@ -1,0 +1,31 @@
+/*! Open Historia — province outline presentation © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+
+// Provinces are local detail, not the political silhouette. Keep the overview
+// free of the administrative grid, then fade it in as country labels yield to
+// local detail. A zero-opacity first stop avoids a pop at the layer's minzoom.
+// Share the policy between stock tiles and scenario geometry so switching map
+// kinds cannot bring back the early, heavy grid. Country/frontier layers and
+// the fill layers used for hit-testing deliberately do not use this policy.
+export const PROVINCE_OUTLINE_MIN_ZOOM = 6.5;
+
+const PROVINCE_OUTLINE_WIDTH = [
+  "interpolate", ["linear"], ["zoom"],
+  PROVINCE_OUTLINE_MIN_ZOOM, 0.25,
+  8, 0.4,
+  12, 0.5,
+];
+const PROVINCE_OUTLINE_OPACITY = [
+  "interpolate", ["linear"], ["zoom"],
+  PROVINCE_OUTLINE_MIN_ZOOM, 0,
+  7.5, 0.25,
+  10, 0.38,
+  12, 0.45,
+];
+
+export const buildProvinceOutlinePaint = (active) => ({
+  "line-color": "rgba(8, 12, 18, 0.90)",
+  // MapLibre measures line-width in CSS pixels; cap it at a hairline even at
+  // maximum zoom, rather than letting the province grid rival state borders.
+  "line-width": PROVINCE_OUTLINE_WIDTH,
+  "line-opacity": active ? PROVINCE_OUTLINE_OPACITY : 0,
+});

--- a/src/Game/Map/provinceOutlineStyle.test.js
+++ b/src/Game/Map/provinceOutlineStyle.test.js
@@ -1,0 +1,58 @@
+/*! Open Historia — province outline regression tests © 2026 Nicholas Krol, MIT (see src/Editor/LICENSE). */
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createPropertyExpression, latest, validateStyleMin } from "@maplibre/maplibre-gl-style-spec";
+import { buildProvinceOutlinePaint, PROVINCE_OUTLINE_MIN_ZOOM } from "./provinceOutlineStyle.js";
+
+// Evaluate the real paint expressions with MapLibre, not a second implementation
+// of interpolation: invalid camera expressions should fail here, not at runtime.
+const evaluate = (paint, property, zoom) => {
+  const compiled = createPropertyExpression(paint[property], latest.paint_line[property]);
+  assert.equal(compiled.result, "success", JSON.stringify(compiled.value));
+  return compiled.value.evaluate({ zoom });
+};
+
+test("province paint is valid for both GeoJSON and stock vector layers", () => {
+  const errors = validateStyleMin({
+    version: 8,
+    sources: {
+      authored: { type: "geojson", data: { type: "FeatureCollection", features: [] } },
+      stock: { type: "vector", tiles: ["https://example.com/{z}/{x}/{y}.pbf"] },
+    },
+    layers: [
+      { id: "authored", type: "line", source: "authored", minzoom: PROVINCE_OUTLINE_MIN_ZOOM, paint: buildProvinceOutlinePaint(true) },
+      { id: "stock", type: "line", source: "stock", "source-layer": "regions", minzoom: PROVINCE_OUTLINE_MIN_ZOOM, paint: buildProvinceOutlinePaint(true) },
+    ],
+  });
+  assert.deepEqual(errors, []);
+});
+
+test("overview has no province strokes, including the start of the fade", () => {
+  const paint = buildProvinceOutlinePaint(true);
+  assert.equal(PROVINCE_OUTLINE_MIN_ZOOM, 6.5);
+  for (const zoom of [0, 2.25, 3.5, 4.2, 5, 6, 6.49, 6.5]) {
+    assert.equal(evaluate(paint, "line-opacity", zoom), 0, `zoom ${zoom}`);
+  }
+});
+
+test("local grid fades in smoothly and stays subpixel through maximum zoom", () => {
+  const paint = buildProvinceOutlinePaint(true);
+  let previous = 0;
+  for (let zoom = PROVINCE_OUTLINE_MIN_ZOOM; zoom <= 24; zoom += 0.05) {
+    const opacity = evaluate(paint, "line-opacity", zoom);
+    const width = evaluate(paint, "line-width", zoom);
+    assert.ok(opacity >= previous && opacity <= 0.45);
+    assert.ok(opacity - previous < 0.02, `no opacity jump at ${zoom}`);
+    assert.ok(width >= 0.25 && width <= 0.5, `hairline at ${zoom}`);
+    previous = opacity;
+  }
+  assert.equal(evaluate(paint, "line-opacity", 7.5), 0.25);
+  assert.equal(evaluate(paint, "line-width", 16), 0.5);
+});
+
+test("inactive or not-yet-known worlds never show province strokes", () => {
+  const paint = buildProvinceOutlinePaint(false);
+  for (const zoom of [0, 3.5, 6.5, 8, 12, 16, 24]) {
+    assert.equal(evaluate(paint, "line-opacity", zoom), 0);
+  }
+});


### PR DESCRIPTION
## Why
The reported screen recording shows province boundaries competing with country shapes at overview scale. The request is a presentation change: make province borders thin and show them only when zoomed in.

This targets **`beta`** and is based on its current map renderer (`51154f7`), as requested. `alpha` has a different rendering path; this PR does not import the beta renderer into alpha.

## Changes
- Hide the province grid through **zoom 6.5**, instead of introducing scenario outlines at z4.2.
- Fade in smoothly from zero opacity; use **0.25–0.5 CSS-pixel** hairlines, capped at 0.5 even at maximum zoom.
- Share the paint/zoom policy between scenario GeoJSON and the stock-region outline path while preserving their existing activation gates and edited-region exclusions.
- Leave country/frontier layers, fills, ownership, geometry and click-query layers unchanged.
- Add MapLibre-expression regression tests and update the map documentation.

## Visual comparison
**Left: before · Right: after. Top: overview (z5.5) · Bottom: local detail (z8).**

![Province borders before and after at overview and local zoom](https://raw.githubusercontent.com/Mininaut/open-historia/84480335631c1fba293665ce73309d06074d73a4/province-borders-comparison.png)

These are actual Chromium/MapLibre captures of `Nations.jsx`, using a geographic subset of the shipped default scenario around Turkey/Syria and a plain background. This is a map-layer verification harness, **not** the reporter's historical save or a full-game screenshot. The before panels restore only the beta baseline province paint/minzoom; all other layers, geometry, colors and camera positions are identical. Screenshot binaries are kept on a separate evidence branch in the fork, outside this code PR.

## Validation
- `npm test`: **1004 passed, 0 failed** on the final full run. An earlier resource-contended run hit the existing AI-relay timing assertion; both its isolated rerun and the final full run passed.
- `npx eslint src/Game/Map/Nations.jsx src/Game/Map/provinceOutlineStyle.js src/Game/Map/provinceOutlineStyle.test.js`: **0 errors**, one existing `regionClaimants` hook-dependency warning.
- New tests validate stock/GeoJSON layer styles with MapLibre and evaluate the real camera expressions across overview, fade, local and maximum zoom, including inactive-world gating.
- Browser: compared z5.5/z8 rendering and confirmed the normal fill-query layers still resolve a province (`TUR.61_1`) at overview zoom with the grid hidden.
- `git diff --check`: passed.
- Full-repository lint and the production build were attempted but did **not** finish within the available time/memory budget (1 GiB environment). They are not claimed as passing. Full-game/mobile/globe verification remains for CI or a better-provisioned device.
