### PR TITLE
Stats: support landless polities

### DIFF
--- a/server/countryStats.test.js
+++ b/server/countryStats.test.js
@@ -1,12 +1,15 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
+import { validateGameplayPayload } from "../src/Game/AI/gameplaySchemas.js";
+
 import {
   aggregateTerritorialEconomy,
   captureCountryStatsHistory,
   countryStatsTrackingMonthsElapsed,
   finalizeCountryStatSheet,
   guardCountryStatContinuity,
+  isCompleteCountryStatSheet,
   mergeCountryStatPatch,
   normalizeCountryStatSheet,
   normalizeCountryStatsTracking,
@@ -107,6 +110,142 @@ test("legacy sheets without a ledger stay readable with their declared totals", 
   assert.equal(normalizeCountryStatSheet(null), null);
   assert.equal(normalizeCountryStatSheet("text"), null);
   assert.equal(finalizeCountryStatSheet({ population: { total: 5 } }).statsSchemaVersion, 0);
+});
+
+test("an explicit non-territorial stat sheet can be complete without fabricated land, population or GDP", () => {
+  const sheet = finalizeCountryStatSheet({
+    territorialScope: "nonterritorial",
+    capital: "No fixed territorial capital",
+    continent: "Transnational",
+    government: "Non-territorial polity",
+    leader: "Test Leader",
+    stability: 50,
+    indices: {
+      sovereignty: 40,
+      foodAutonomy: 0,
+      energyAutonomy: 0,
+      economicIndependence: 35,
+      internalSecurity: 55,
+      internationalReputation: 20,
+    },
+    territorialComponents: [],
+    economy: {
+      gdpGrowth: 0,
+      currency: "EUR",
+      inflation: 0,
+      unemployment: 0,
+      publicDebt: 0,
+      budgetBalance: 0,
+    },
+    gdpBreakdown: { agriculture: 0, industry: 0, services: 100 },
+  });
+
+  assert.equal(sheet.statsSchemaVersion, 1);
+  assert.equal(sheet.territorialScope, "nonterritorial");
+  assert.deepEqual(sheet.territorialComponents, []);
+  assert.equal(sheet.population, undefined);
+  assert.equal(sheet.economy.gdp, undefined);
+  assert.equal(isCompleteCountryStatSheet(sheet), true);
+  assert.deepEqual(validateGameplayPayload("countryStatSheet", sheet), { valid: true, error: "" });
+
+  const distributedEconomy = finalizeCountryStatSheet({
+    ...sheet,
+    territorialComponents: [
+      { geography: "Distributed operations", group: "integrated", population: 2500, gdpPerCapita: 40000 },
+    ],
+  });
+  assert.equal(distributedEconomy.population.total, 2500);
+  assert.equal(distributedEconomy.economy.gdp, 100000000);
+  assert.equal(distributedEconomy.economy.gdpPerCapita, 40000);
+  assert.equal(isCompleteCountryStatSheet(distributedEconomy), true);
+});
+
+test("an empty territorial ledger is still invalid unless native code marks the polity non-territorial", () => {
+  const malformed = finalizeCountryStatSheet({
+    statsSchemaVersion: 1,
+    territorialScope: "mapped",
+    capital: "Nowhere",
+    continent: "Europe",
+    government: "Republic",
+    leader: "Test Leader",
+    stability: 50,
+    indices: {
+      sovereignty: 50,
+      foodAutonomy: 50,
+      energyAutonomy: 50,
+      economicIndependence: 50,
+      internalSecurity: 50,
+      internationalReputation: 50,
+    },
+    territorialComponents: [],
+    economy: {
+      gdpGrowth: 0,
+      currency: "EUR",
+      inflation: 0,
+      unemployment: 0,
+      publicDebt: 0,
+      budgetBalance: 0,
+    },
+    gdpBreakdown: { agriculture: 1, industry: 1, services: 98 },
+  });
+
+  assert.equal(isCompleteCountryStatSheet(malformed), false);
+  const validation = validateGameplayPayload("countryStatSheet", malformed);
+  assert.equal(validation.valid, false);
+  assert.match(validation.error, /may be empty only when .*nonterritorial/);
+});
+
+test("the canonical stat mutation boundary preserves an explicit empty non-territorial ledger", () => {
+  const landless = finalizeCountryStatSheet({
+    territorialScope: "nonterritorial",
+    capital: "No fixed territorial capital",
+    continent: "Transnational",
+    government: "Non-territorial polity",
+    leader: "Test Leader",
+    stability: 50,
+    indices: {
+      sovereignty: 40,
+      foodAutonomy: 0,
+      energyAutonomy: 0,
+      economicIndependence: 35,
+      internalSecurity: 55,
+      internationalReputation: 20,
+    },
+    territorialComponents: [],
+    economy: {
+      gdpGrowth: 0,
+      currency: "EUR",
+      inflation: 0,
+      unemployment: 0,
+      publicDebt: 0,
+      budgetBalance: 0,
+    },
+    gdpBreakdown: { agriculture: 0, industry: 0, services: 100 },
+  });
+
+  const persisted = mergeCountryStatPatch(
+    null,
+    landless,
+    { replaceComponents: true, continuity: { assessedDate: "2026-09-07" } },
+  );
+
+  assert.equal(persisted.territorialScope, "nonterritorial");
+  assert.deepEqual(persisted.territorialComponents, []);
+  assert.equal(persisted.statsSchemaVersion, 1);
+  assert.equal(isCompleteCountryStatSheet(persisted), true);
+  assert.deepEqual(validateGameplayPayload("countryStatSheet", persisted), { valid: true, error: "" });
+
+  // An ordinary mapped actor with an explicit empty replacement ledger must stay
+  // explicit too, so canonical validation can reject it instead of hiding the bug
+  // by silently converting [] back into an omitted/unknown field.
+  const mapped = mergeCountryStatPatch(
+    null,
+    { ...landless, territorialScope: "mapped", territorialComponents: [] },
+    { replaceComponents: true },
+  );
+  assert.equal(mapped.territorialScope, "mapped");
+  assert.deepEqual(mapped.territorialComponents, []);
+  assert.equal(isCompleteCountryStatSheet(mapped), false);
 });
 
 test("a stat patch scales the ledger to aggregate targets and records event continuity", () => {

--- a/src/Game/AI/countryStatsWorkerKernel.js
+++ b/src/Game/AI/countryStatsWorkerKernel.js
@@ -990,15 +990,16 @@ export const buildTargetStatsTerritorialBasisKernel = ({ bundle, code, scenarioC
     return {
       context: [
         `Target: ${target}`,
-        "Accounting mode: LEGAL SOVEREIGNTY",
-        "No legally sovereign map regions were resolved for this polity.",
+        "Accounting mode: NON-TERRITORIAL",
+        "No legally sovereign national map regions were resolved for this polity.",
         controlledRegionCount > 0
           ? `The polity controls ${controlledRegionCount} region(s), but native statehood safeguards did NOT classify those holdings as a de-facto national administrative basis. Ordinary occupation therefore remains excluded from national population/GDP.`
           : "No de-facto controlled mapped regions were resolved either.",
-        "Do not silently substitute modern borders. If this is a landless polity, estimate only what the campaign canon actually supports.",
+        "Do not silently substitute modern borders. This is an explicit NON-TERRITORIAL Stats basis: estimate a distributed/non-map population or economy only when campaign canon supports one; otherwise return no quantitative scope.",
       ].join("\n"),
       plan: [],
-      mode,
+      macroPlan: [],
+      mode: "nonterritorial",
       referenceContext: "",
     };
   }

--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -918,10 +918,11 @@ const decodeCountryStatMacroEstimates = (value, macroPlan = []) => {
     return { estimates: nativePlan.map((entry) => estimates.get(entry.index)), error: "" };
   }
 
-  // Compatibility fallback for landless/custom scenarios with no native map basis.
-  // In that rare path, accept the old group~geography~population~gdpPerCapita rows
-  // and return them as ready-made components rather than inventing macro geography.
-  if (!text) return { estimates: [], components: [], error: "" };
+  // Compatibility fallback for a valid non-territorial polity with no native map
+  // basis. Campaign-supported distributed people/organizations may still provide old
+  // group~geography~population~gdpPerCapita rows. NONE explicitly means there is no
+  // defensible quantitative population/GDP scope; that is valid and must not invent land.
+  if (!text || text.toLowerCase() === "none") return { estimates: [], components: [], error: "" };
   const components = [];
   for (const rawLine of text.split(/\r?\n/)) {
     const parts = rawLine.trim().split("~").map((part) => part.trim());
@@ -1769,7 +1770,7 @@ BOUNDED REGIONAL METHOD — REQUIRED:
 - Return territorialMacroComponentsText with EXACTLY ONE row for EVERY [M#] macro bucket, in this exact transport format: index~group~population~gdpPerCapita
 - Example rows: 1~core~32000000~4200 OR 2~overseas/dependent~4200000~900
 - index MUST be the supplied macro integer. Do not return province-by-province rows. Do not add, omit, split, or merge macro buckets.
-- Compatibility only: if the authoritative basis explicitly says no mapped macro buckets exist, territorialMacroComponentsText may instead use group~geography~population~gdpPerCapita rows for the genuinely supported landless/custom scope.
+- NON-TERRITORIAL COMPATIBILITY: if the authoritative basis explicitly says NON-TERRITORIAL and no mapped macro buckets exist, territorialMacroComponentsText may use group~geography~population~gdpPerCapita rows ONLY for a genuinely campaign-supported distributed people, organization, workforce, exile community, or other non-map economic/demographic scope. If no defensible quantitative scope exists, return exactly NONE. Never invent a fake province, population, or GDP merely to satisfy the schema.
 - Allowed group values: core | integrated | overseas/dependent.
 - Estimate each macro bucket from its representative places, spatial center, scenario canon, and any prior macro baseline. Prefer checkable regional magnitudes over a single historical whole-country headline total.
 - Do NOT force the macro-bucket sum to a remembered country/empire headline. A historical headline is usable only as a cross-check when its territorial definition exactly matches the live macro scope; otherwise the regional estimates win.
@@ -2115,12 +2116,16 @@ This live instruction supersedes older frozen country-stat prompts and all earli
           territorialComponentsText: _territorialComponentsText,
           ...statFields
         } = parsed;
+        const plannedComponentCount = normalizeArray(variables?.statsTerritorialPlan).length;
+        const territorialScope = normalizeString(variables?.statsTerritorialBasisMode) === "nonterritorial"
+          ? "nonterritorial"
+          : "mapped";
         parsed = finalizeCountryStatSheet({
           ...statFields,
+          territorialScope,
           territorialComponents: components,
         });
 
-        const plannedComponentCount = normalizeArray(variables?.statsTerritorialPlan).length;
         const finalizedComponentCount = normalizeArray(parsed?.territorialComponents).length;
         if (!statsCoverageError && plannedComponentCount > 0 && finalizedComponentCount !== plannedComponentCount) {
           statsCoverageError =
@@ -8098,15 +8103,16 @@ const buildTargetStatsTerritorialBasis = async (bundle, code, normalizedWorld = 
     return {
       context: [
         `Target: ${target}`,
-        "Accounting mode: LEGAL SOVEREIGNTY",
-        "No legally sovereign map regions were resolved for this polity.",
+        "Accounting mode: NON-TERRITORIAL",
+        "No legally sovereign national map regions were resolved for this polity.",
         controlledRegionCount > 0
           ? `The polity controls ${controlledRegionCount} region(s), but native statehood safeguards did NOT classify those holdings as a de-facto national administrative basis. Ordinary occupation therefore remains excluded from national population/GDP.`
           : "No de-facto controlled mapped regions were resolved either.",
-        "Do not silently substitute modern borders. If this is a landless polity, estimate only what the campaign canon actually supports.",
+        "Do not silently substitute modern borders. This is an explicit NON-TERRITORIAL Stats basis: estimate a distributed/non-map population or economy only when campaign canon supports one; otherwise return no quantitative scope.",
       ].join("\n"),
       plan: [],
-      mode,
+      macroPlan: [],
+      mode: "nonterritorial",
       referenceContext: "",
     };
   }
@@ -8714,7 +8720,9 @@ export const generateCountryStatSheet = async ({ code, name, forceReassess = fal
   // migration. Fresh baselines and explicit hard audits get an auditable nominal
   // anchor; established campaign ledgers remain canon and are never silently pulled
   // back toward real history merely because this feature was added later.
-  const economicCalibrationRequested = Boolean(!previousComplete || forceReassess);
+  const economicCalibrationRequested = Boolean(
+    territorialBasisMode !== "nonterritorial" && (!previousComplete || forceReassess)
+  );
 
   // Legacy 7A.1 sheets can be complete while carrying no continuity fingerprint.
   // On a mapped polity we MUST NOT stamp today's border fingerprint onto that old

--- a/src/Game/AI/gameplaySchemas.js
+++ b/src/Game/AI/gameplaySchemas.js
@@ -2246,7 +2246,7 @@ export const COUNTRY_STAT_GENERATION_SCHEMA = {
       type: "string",
       minLength: 1,
       description:
-        "Bounded regional territorial estimate. With a native macro plan, return exactly one row per [M#] macro bucket as index~group~population~gdpPerCapita. Native code expands each macro row back across every exact live-map component. Compatibility fallback without a native macro plan may use group~geography~population~gdpPerCapita. group is core, integrated, or overseas/dependent; population is an integer; gdpPerCapita is a positive NOMINAL output-per-capita number in constant 2026-EUR accounting terms; never PPP/international dollars.",
+        "Bounded regional territorial estimate. With a native macro plan, return exactly one row per [M#] macro bucket as index~group~population~gdpPerCapita. Native code expands each macro row back across every exact live-map component. For an explicitly NON-TERRITORIAL basis, compatibility rows may use group~geography~population~gdpPerCapita when campaign canon supports a real distributed people/organization/economy; return the literal NONE when no defensible quantitative scope exists. group is core, integrated, or overseas/dependent; population is an integer; gdpPerCapita is a positive NOMINAL output-per-capita number in constant 2026-EUR accounting terms; never PPP/international dollars.",
     },
     economy: {
       type: "object",
@@ -2335,9 +2335,15 @@ export const COUNTRY_STAT_SHEET_SCHEMA = {
       required: ["sovereignty", "foodAutonomy", "energyAutonomy", "economicIndependence", "internalSecurity", "internationalReputation"],
       additionalProperties: false,
     },
+    territorialScope: {
+      type: "string",
+      enum: ["mapped", "nonterritorial"],
+      description:
+        "Native accounting scope. mapped means territorialComponents must contain the authoritative live-map ledger. nonterritorial means this valid polity has no mapped national territorial basis; compatibility components may still represent a campaign-supported distributed people/organization/economy, or the array may be empty when no defensible quantitative scope exists.",
+    },
     population: {
       type: "object",
-      description: "Derived population aggregates. The runtime recomputes these from territorialComponents.",
+      description: "Derived population aggregates. The runtime recomputes these from territorialComponents when a quantitative component ledger exists.",
       properties: {
         total: { type: "integer", minimum: 0 },
         coreIntegrated: { type: "integer", minimum: 0 },
@@ -2347,9 +2353,9 @@ export const COUNTRY_STAT_SHEET_SCHEMA = {
     },
     territorialComponents: {
       type: "array",
-      minItems: 1,
+      minItems: 0,
       description:
-        "One demographic/economic component for every authoritative territorial geography in the live-map basis. There is deliberately no fixed component cap: map granularity must never delete population/GDP. Generation expands bounded regional macro estimates into this exact canonical ledger natively; the model does not author these rows one-by-one.",
+        "For mapped scope, one demographic/economic component for every authoritative territorial geography in the live-map basis. There is deliberately no fixed component cap: map granularity must never delete population/GDP. For explicit nonterritorial scope, this may contain campaign-supported distributed/non-map quantitative components or be empty when no defensible population/GDP basis exists.",
       items: {
         type: "object",
         properties: {
@@ -3057,6 +3063,9 @@ export const validateGameplayPayload = (taskKey, value) => {
   if (taskKey === "countryStatSheet") {
     const blankError = findBlankString(value);
     if (blankError) return { valid: false, error: blankError };
+    if (value.territorialComponents.length === 0 && value.territorialScope !== "nonterritorial") {
+      return { valid: false, error: "$.territorialComponents may be empty only when $.territorialScope is nonterritorial." };
+    }
     const breakdown = value.gdpBreakdown;
     if (breakdown.agriculture + breakdown.industry + breakdown.services !== 100) {
       return { valid: false, error: "$.gdpBreakdown percentages must sum to 100." };

--- a/src/runtime/countryStats.js
+++ b/src/runtime/countryStats.js
@@ -15,8 +15,13 @@ export const COUNTRY_STATS_COMPONENT_GROUPS = Object.freeze([
   "integrated",
   "overseas/dependent",
 ]);
+export const COUNTRY_STATS_TERRITORIAL_SCOPES = Object.freeze([
+  "mapped",
+  "nonterritorial",
+]);
 
 const COMPONENT_GROUP_SET = new Set(COUNTRY_STATS_COMPONENT_GROUPS);
+const TERRITORIAL_SCOPE_SET = new Set(COUNTRY_STATS_TERRITORIAL_SCOPES);
 const INDEX_KEYS = Object.freeze([
   "sovereignty",
   "foodAutonomy",
@@ -391,8 +396,12 @@ export const normalizeCountryStatSheet = (value) => {
   const breakdown = normalizeBreakdown(value.gdpBreakdown);
   if (breakdown) out.gdpBreakdown = breakdown;
 
+  const territorialScope = clean(value.territorialScope).toLowerCase();
+  if (TERRITORIAL_SCOPE_SET.has(territorialScope)) out.territorialScope = territorialScope;
+
+  const hasExplicitComponents = Array.isArray(value.territorialComponents);
   const components = normalizeTerritorialComponents(value.territorialComponents);
-  if (components.length) out.territorialComponents = components;
+  if (components.length || hasExplicitComponents) out.territorialComponents = components;
 
   const continuity = normalizeCountryStatContinuity(value.continuity);
   if (continuity) out.continuity = continuity;
@@ -400,7 +409,7 @@ export const normalizeCountryStatSheet = (value) => {
   const declaredVersion = Number(value.statsSchemaVersion);
   out.statsSchemaVersion = Number.isInteger(declaredVersion) && declaredVersion > 0
     ? declaredVersion
-    : components.length
+    : components.length || territorialScope === "nonterritorial"
       ? COUNTRY_STATS_SCHEMA_VERSION
       : 0;
 
@@ -428,12 +437,16 @@ export const finalizeCountryStatSheet = (value) => {
   const breakdown = normalizeBreakdown(value.gdpBreakdown);
   if (breakdown) out.gdpBreakdown = breakdown;
 
+  const territorialScope = clean(value.territorialScope).toLowerCase();
+  if (TERRITORIAL_SCOPE_SET.has(territorialScope)) out.territorialScope = territorialScope;
+
   const economy = normalizeEconomy(value.economy) || {};
+  const hasExplicitComponents = Array.isArray(value.territorialComponents);
   const components = normalizeTerritorialComponents(value.territorialComponents);
   const aggregate = aggregateTerritorialEconomy(components);
   const continuity = normalizeCountryStatContinuity(value.continuity);
 
-  if (components.length) out.territorialComponents = components;
+  if (components.length || hasExplicitComponents) out.territorialComponents = components;
   if (continuity) out.continuity = continuity;
 
   if (aggregate) {
@@ -460,7 +473,11 @@ export const finalizeCountryStatSheet = (value) => {
     if (population) out.population = population;
     if (Object.keys(economy).length) out.economy = economy;
     const declaredVersion = Number(value.statsSchemaVersion);
-    out.statsSchemaVersion = Number.isInteger(declaredVersion) && declaredVersion > 0 ? declaredVersion : 0;
+    out.statsSchemaVersion = Number.isInteger(declaredVersion) && declaredVersion > 0
+      ? declaredVersion
+      : territorialScope === "nonterritorial"
+        ? COUNTRY_STATS_SCHEMA_VERSION
+        : 0;
   }
 
   return out;
@@ -797,11 +814,26 @@ export const mergeCountryStatPatch = (
     ...economyPatch,
   };
 
+  // Preserve the explicit territorial accounting contract through the single
+  // mutation boundary. This matters for valid landless/non-territorial actors:
+  // `territorialComponents: []` is meaningful canonical state, not the same as
+  // an omitted/unknown ledger. A mapped polity can still fail closed later if
+  // its explicit replacement ledger is empty.
+  const patchTerritorialScope = clean(patch.territorialScope).toLowerCase();
+  if (TERRITORIAL_SCOPE_SET.has(patchTerritorialScope)) {
+    merged.territorialScope = patchTerritorialScope;
+  }
+
+  const baseHasExplicitComponents = Array.isArray(base.territorialComponents);
+  const patchHasExplicitComponents = Array.isArray(patch.territorialComponents);
+  let preserveExplicitComponentLedger = baseHasExplicitComponents;
+
   let components = normalizeTerritorialComponents(base.territorialComponents);
-  if (Array.isArray(patch.territorialComponents)) {
+  if (patchHasExplicitComponents) {
     components = replaceComponents
       ? normalizeTerritorialComponents(patch.territorialComponents)
       : mergeComponentsByGeography(components, patch.territorialComponents);
+    if (replaceComponents) preserveExplicitComponentLedger = true;
   }
 
   // Aggregate population edits are supported for GM/editor convenience. The
@@ -869,7 +901,9 @@ export const mergeCountryStatPatch = (
     }
   }
 
-  if (components.length) merged.territorialComponents = components;
+  if (components.length || preserveExplicitComponentLedger) {
+    merged.territorialComponents = components;
+  }
 
   return finalizeCountryStatSheet(merged);
 };
@@ -1055,9 +1089,11 @@ export const isCompleteCountryStatSheet = (value) => {
   if (!["capital", "continent", "government", "leader"].every((key) => clean(sheet[key]))) return false;
   if (!Number.isFinite(Number(sheet.stability))) return false;
   if (!INDEX_KEYS.every((key) => Number.isFinite(Number(sheet.indices?.[key])))) return false;
-  if (!Array.isArray(sheet.territorialComponents) || sheet.territorialComponents.length < 1) return false;
-  if (!(Number(sheet.population?.total) > 0)) return false;
-  if (!(Number(sheet.economy?.gdp) > 0) || !(Number(sheet.economy?.gdpPerCapita) > 0)) return false;
+  if (!Array.isArray(sheet.territorialComponents)) return false;
+  const nonterritorial = sheet.territorialScope === "nonterritorial";
+  if (!nonterritorial && sheet.territorialComponents.length < 1) return false;
+  if (!nonterritorial && !(Number(sheet.population?.total) > 0)) return false;
+  if (!nonterritorial && (!(Number(sheet.economy?.gdp) > 0) || !(Number(sheet.economy?.gdpPerCapita) > 0))) return false;
   if (!["gdpGrowth", "inflation", "unemployment", "publicDebt", "budgetBalance"].every(
     (key) => Number.isFinite(Number(sheet.economy?.[key])),
   )) return false;


### PR DESCRIPTION
# summary

Adds support for valid landless / non-territorial polities in Country Stats.

Previously, opening or generating Stats for a polity that owned no territorial regions could fail validation with:

`$.territorialComponents is required`

This can occur legitimately because OpenHistoria allows playable actors that do not own map territory, such as organizations, companies, governments-in-exile, or other non-territorial entities.

# changes

- Adds explicit handling for non-territorial Stats scope.
- Allows a valid landless polity to persist `territorialComponents: []`.
- Prevents fake territory, population, or GDP from being invented just to satisfy the schema.
- Preserves empty non-territorial component ledgers through the Stats merge/persistence path.
- Keeps normal mapped polities fail-closed if their territorial component ledger is unexpectedly empty.
- Allows non-territorial actors with supported economic/population data to still expose those values.
- Adds regression coverage for landless and mapped-polity behavior.

## testing

- `node --test server/countryStats.test.js`
- live-tested with a playable landless United Nations polity.

efore the fix, the Stats panel failed with:

`$.territorialComponents is required`

After the fix, the same polity opens normally and displays unavailable territory-derived values as `---`.