### PR TITLE
Guide pages: describe the game that actually ships

### DIFF
--- a/public/ai-setup/index.html
+++ b/public/ai-setup/index.html
@@ -14,23 +14,23 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#0b1020" />
   <link rel="icon" type="image/jpeg" href="/logo.png" />
-  <title>Connect an AI to Open Historia — Setup Guide for Gemini, OpenAI, DeepSeek, Ollama &amp; More</title>
+  <title>Connect an AI to Open Historia — Setup Guide for Gemini, OpenAI, Anthropic, Ollama &amp; More</title>
   <link rel="canonical" href="https://openhistoria.com/ai-setup/" />
-  <meta name="description" content="Connect any AI provider to Open Historia for AI-powered diplomacy, events, and strategic advice. Covers Gemini, OpenAI, DeepSeek, Anthropic Claude, Ollama, LM Studio, and OpenAI-compatible APIs." />
+  <meta name="description" content="Connect the AI that runs Open Historia's world: Gemini (default, free key), OpenAI, Anthropic Claude, local models through Ollama, LM Studio or llama.cpp, and OpenAI-compatible APIs such as DeepSeek, Groq and OpenRouter. What local models need, and troubleshooting." />
 
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Open Historia" />
   <meta property="og:url" content="https://openhistoria.com/ai-setup/" />
-  <meta property="og:title" content="Connect an AI to Open Historia — Setup Guide for Gemini, OpenAI, DeepSeek, Ollama &amp; More" />
-  <meta property="og:description" content="Connect any AI provider to Open Historia for AI-powered diplomacy, events, and strategic advice. Gemini, OpenAI, DeepSeek, Claude, Ollama, LM Studio, and OpenAI-compatible APIs." />
+  <meta property="og:title" content="Connect an AI to Open Historia — Setup Guide for Gemini, OpenAI, Anthropic, Ollama &amp; More" />
+  <meta property="og:description" content="Connect the AI that runs Open Historia's world: Gemini, OpenAI, Anthropic Claude, local models, and OpenAI-compatible APIs such as DeepSeek, Groq and OpenRouter." />
   <meta property="og:image" content="https://raw.githubusercontent.com/Open-Historia/open-historia/main/public/loading_screen.jpg" />
   <meta property="og:image:type" content="image/jpeg" />
   <meta property="og:image:width" content="1280" />
   <meta property="og:image:height" content="720" />
 
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Connect an AI to Open Historia — Setup for Gemini, OpenAI, DeepSeek &amp; More" />
-  <meta name="twitter:description" content="Connect any AI provider to Open Historia for AI-powered diplomacy, events, and strategic advice. Gemini, OpenAI, DeepSeek, Claude, Ollama, and more." />
+  <meta name="twitter:title" content="Connect an AI to Open Historia — Setup for Gemini, OpenAI, Anthropic &amp; More" />
+  <meta name="twitter:description" content="Connect the AI that runs Open Historia's world: Gemini, OpenAI, Anthropic Claude, local models, and OpenAI-compatible APIs." />
   <meta name="twitter:image" content="https://raw.githubusercontent.com/Open-Historia/open-historia/main/public/loading_screen.jpg" />
 
   <link rel="stylesheet" href="/guides.css" />
@@ -40,31 +40,31 @@
     "@context": "https://schema.org",
     "@type": "HowTo",
     "name": "How to Connect an AI to Open Historia",
-    "description": "Step-by-step guide to connect an AI provider (Gemini, OpenAI, DeepSeek, Anthropic Claude, Ollama, LM Studio, or any OpenAI-compatible API) to Open Historia for AI-powered diplomacy, events, and strategic advisor.",
+    "description": "Step-by-step guide to connect an AI provider (Gemini, OpenAI, Anthropic Claude, a local model through Ollama, LM Studio or llama.cpp, or any OpenAI-compatible API) to Open Historia. The AI runs the game's world, so this is required to play.",
     "step": [
       {
         "@type": "HowToStep",
         "position": "1",
         "name": "Choose an AI provider",
-        "text": "Pick from Google Gemini, OpenAI, Anthropic Claude, DeepSeek, a local LLM (Ollama, LM Studio, llama.cpp), or any OpenAI-compatible cloud API."
+        "text": "Pick Google Gemini (the default, with a free key), OpenAI, Anthropic Claude, a local model (Ollama, LM Studio, llama.cpp), or any OpenAI-compatible cloud API such as DeepSeek, Groq or OpenRouter."
       },
       {
         "@type": "HowToStep",
         "position": "2",
-        "name": "Get credentials or set up the backend",
-        "text": "For cloud providers, get an API key. For local LLMs, install the backend and load a model."
+        "name": "Get credentials or start the backend",
+        "text": "For cloud providers, create an API key. For local models, install the backend, download a model with a large context window, and start its server."
       },
       {
         "@type": "HowToStep",
         "position": "3",
-        "name": "Configure Open Historia's AI settings",
-        "text": "Open the in-game settings, select your AI provider, and enter the API key or endpoint URL."
+        "name": "Configure Open Historia",
+        "text": "Open a game, open Settings, and under AI select the provider, then enter the API key, and for compatible providers the endpoint URL and model name."
       },
       {
         "@type": "HowToStep",
         "position": "4",
-        "name": "Start playing with AI",
-        "text": "AI diplomacy, events, and advisor features activate immediately once the provider is connected."
+        "name": "Play",
+        "text": "Time skips, diplomacy chats, the advisor, and intelligence briefings all use the provider you connected, from the next request on."
       }
     ]
   }
@@ -99,204 +99,176 @@
     <img class="logo" src="/logo.png" alt="Open Historia logo" width="64" height="64" />
 
     <h1>Connect your AI</h1>
-    <p class="tagline">Unlock AI-powered diplomacy, dynamically generated historical events, and a strategic advisor by connecting any AI provider — from free local models to premium cloud APIs.</p>
+    <p class="tagline">Open Historia's world is simulated by a language model you supply — from a free Gemini key to a model running on your own hardware. This guide covers every option.</p>
 
-    <h2>What AI Powers in Open Historia</h2>
+    <h2>What the AI Does in Open Historia</h2>
     <div class="feature-grid">
-      <div class="feature-tag">AI Diplomacy — negotiate with any nation via natural language chat</div>
-      <div class="feature-tag">AI Intelligence Briefings — get summaries of any country's status</div>
-      <div class="feature-tag">AI-Generated Events — dynamic events shaped by your decisions and the world state</div>
-      <div class="feature-tag">AI Advisor — consult for strategic guidance, economic analysis, and war planning</div>
-      <div class="feature-tag">AI Combat Resolution — battles resolved by the AI based on troop strength, terrain, and strategy</div>
+      <div class="feature-tag">Time skips — resolves your actions, plays every other nation, writes the events, moves borders and fronts</div>
+      <div class="feature-tag">Diplomacy — leaders answer you in character in natural-language chat</div>
+      <div class="feature-tag">Advisor — situation summaries, economic analysis, and war planning</div>
+      <div class="feature-tag">Intelligence — briefings on any nation, and what your spies intercept</div>
+    </div>
+    <div class="card">
+      <p><strong>This is not optional.</strong> There is no scripted simulation underneath: without a connected provider you can look at the map and use the map editor, but time cannot advance and nobody will answer your messages.</p>
     </div>
 
     <h2>How It Works</h2>
     <div class="card">
-      <p>Open Historia supports <strong>five types of AI providers</strong> from a single settings panel. You can switch between them at any time:</p>
+      <p>Open Historia supports <strong>five provider types</strong> from a single settings panel, and you can switch between them at any time:</p>
       <ul>
-        <li><strong>Gemini</strong> — Google's native API, with a generous free tier</li>
-        <li><strong>OpenAI</strong> — official GPT-4o, GPT-4.1, and o-series models</li>
+        <li><strong>Gemini</strong> — Google's native API (Google AI Studio); the default</li>
+        <li><strong>OpenAI</strong> — the official OpenAI API</li>
         <li><strong>Anthropic</strong> — Claude via the Messages API</li>
-        <li><strong>OpenAI Compatible</strong> — any API that speaks the <code>/v1/chat/completions</code> protocol (Ollama, LM Studio, llama.cpp, DeepSeek, Groq, Together.ai, OpenRouter, and more)</li>
-        <li><strong>Anthropic Compatible</strong> — any self-hosted proxy that speaks the Anthropic Messages API</li>
+        <li><strong>OpenAI Compatible</strong> — anything that speaks the <code>/v1/chat/completions</code> protocol: Ollama, LM Studio, llama.cpp, vLLM, DeepSeek, Groq, Together, OpenRouter, and more</li>
+        <li><strong>Anthropic Compatible</strong> — a self-hosted proxy or gateway that speaks the Anthropic Messages API</li>
       </ul>
-      <p>For providers that don't send CORS headers from the browser (OpenAI, OpenAI Compatible, Anthropic Compatible), the game's Express server includes a <code>/api/ai/relay</code> endpoint that proxies requests securely. Gemini and Anthropic's native APIs support direct browser access and don't use the relay.</p>
+      <p>Your key is stored in the app and sent only to the provider you chose — Open Historia has no server of its own in the loop. Requests go straight from the game to the provider. In the desktop app and on a self-hosted install, a provider that refuses browser requests (local servers such as llama.cpp and LM Studio usually send no CORS headers) is automatically reached through the game server's own same-origin relay instead, so those just work. <strong>On openhistoria.com there is no relay:</strong> the provider must accept requests from the website. Cloud APIs do; a local Ollama needs to be told to allow the site's origin (see Ollama below).</p>
+      <p>To configure a provider: open a game, open <strong>Settings</strong>, and under <strong>AI</strong> pick the provider and fill in its fields.</p>
     </div>
 
     <h2>Provider Setup Options</h2>
 
-    <h3>Google Gemini (Free Tier Available)</h3>
+    <h3>Google Gemini (Default — Free Key Available)</h3>
     <div class="card">
-      <p>Gemini is the default provider and the easiest way to get started. Google offers a <strong>free tier</strong> on <a href="https://aistudio.google.com" target="_blank" rel="noopener">Google AI Studio</a> that's more than enough for solo play.</p>
+      <p>Gemini is the default provider and the quickest way to get started. <a href="https://aistudio.google.com" target="_blank" rel="noopener">Google AI Studio</a> issues keys with a free usage tier that is enough to try the game.</p>
       <div class="step">
         <strong>Get an API key</strong>
-        <p>Go to <a href="https://aistudio.google.com/apikey" target="_blank" rel="noopener">Google AI Studio</a>, sign in with a Google account, and click "Create API Key." It's free — no billing setup required.</p>
-      </div>
-      <div class="step">
-        <strong>Set the model</strong>
-        <p>The default <code>gemini-2.5-flash-lite</code> works great out of the box. You can switch to <code>gemini-2.5-flash</code> or <code>gemini-2.5-pro</code> for stronger reasoning (check rate limits on the free tier).</p>
+        <p>Go to <a href="https://aistudio.google.com/apikey" target="_blank" rel="noopener">Google AI Studio</a>, sign in with a Google account, and click "Create API key".</p>
       </div>
       <div class="step">
         <strong>Configure in Open Historia</strong>
-        <p>In the game's settings, select <strong>Gemini</strong> as the provider and paste your API key. No endpoint URL needed.</p>
+        <p>In Settings, select <strong>Gemini</strong> and paste your key. No endpoint URL is needed. The default model is <code>gemini-3.5-flash-lite</code>; you can enter any Gemini model id your key can use — a larger Flash or Pro model gives stronger reasoning at a higher cost and tighter rate limits.</p>
       </div>
     </div>
 
-    <h3>OpenAI (GPT-4o, GPT-4.1, o-series)</h3>
+    <h3>OpenAI</h3>
     <div class="card">
-      <p>Use <a href="https://platform.openai.com" target="_blank" rel="noopener">OpenAI's official API</a> for GPT-4o, GPT-4.1, or o-series reasoning models. Requires a paid API account with pre-loaded credits.</p>
+      <p>Use <a href="https://platform.openai.com" target="_blank" rel="noopener">OpenAI's API</a> with a paid API account.</p>
       <div class="step">
         <strong>Get an API key</strong>
-        <p>Sign up at <a href="https://platform.openai.com" target="_blank" rel="noopener">platform.openai.com</a>, add a payment method, and create an API key under "API Keys."</p>
-      </div>
-      <div class="step">
-        <strong>Choose a model</strong>
-        <p><code>gpt-4.1-mini</code> is fast and inexpensive, <code>gpt-4.1</code> handles complex diplomacy, and <code>o4-mini</code> excels at strategic reasoning.</p>
+        <p>Sign up at <a href="https://platform.openai.com" target="_blank" rel="noopener">platform.openai.com</a>, add a payment method, and create a key under "API keys".</p>
       </div>
       <div class="step">
         <strong>Configure in Open Historia</strong>
-        <p>Select <strong>OpenAI</strong> as the provider, paste your API key, and optionally specify a model. The endpoint is pre-configured.</p>
+        <p>Select <strong>OpenAI</strong> and paste your key. The endpoint is fixed. Leave the model blank and the game picks from the models your key can access, or type a specific model id.</p>
       </div>
     </div>
 
     <h3>Anthropic Claude</h3>
     <div class="card">
-      <p>Use <a href="https://anthropic.com" target="_blank" rel="noopener">Anthropic's Claude</a> via the Messages API. Known for nuanced writing and strong instruction-following — excellent for immersive diplomacy and rich event generation.</p>
+      <p>Use <a href="https://anthropic.com" target="_blank" rel="noopener">Anthropic's Claude</a> via the Messages API — strong instruction-following and writing, which shows in diplomacy and event narration.</p>
       <div class="step">
         <strong>Get an API key</strong>
-        <p>Sign up at <a href="https://console.anthropic.com" target="_blank" rel="noopener">console.anthropic.com</a> and generate an API key.</p>
-      </div>
-      <div class="step">
-        <strong>Choose a model</strong>
-        <p><code>claude-sonnet-4-20250514</code> offers the best balance of quality and speed. <code>claude-haiku-3-5-20241022</code> is faster and cheaper.</p>
+        <p>Sign up at <a href="https://console.anthropic.com" target="_blank" rel="noopener">console.anthropic.com</a> and generate a key.</p>
       </div>
       <div class="step">
         <strong>Configure in Open Historia</strong>
-        <p>Select <strong>Anthropic</strong> as the provider and paste your API key. Direct browser access — no relay needed.</p>
+        <p>Select <strong>Anthropic</strong> and paste your key. The default model is <code>claude-haiku-4-5</code>, the fast and inexpensive option; enter a Sonnet model id for richer writing at a higher cost.</p>
       </div>
     </div>
 
     <h3>DeepSeek</h3>
     <div class="card">
-      <p><a href="https://deepseek.com" target="_blank" rel="noopener">DeepSeek</a> offers powerful models at very low cost. Their API is OpenAI-compatible, so it works through the "OpenAI Compatible" provider option.</p>
+      <p><a href="https://deepseek.com" target="_blank" rel="noopener">DeepSeek</a> offers capable models at low cost. Its API is OpenAI-compatible, so it works through the <strong>OpenAI Compatible</strong> provider.</p>
       <div class="step">
         <strong>Get an API key</strong>
-        <p>Register at <a href="https://platform.deepseek.com" target="_blank" rel="noopener">platform.deepseek.com</a>, top up credits (minimum $2), and create an API key.</p>
-      </div>
-      <div class="step">
-        <strong>Set the endpoint</strong>
-        <p>DeepSeek's API base URL is <code>https://api.deepseek.com/v1</code>. The model <code>deepseek-chat</code> covers most needs; <code>deepseek-reasoner</code> is available for complex strategic reasoning.</p>
+        <p>Register at <a href="https://platform.deepseek.com" target="_blank" rel="noopener">platform.deepseek.com</a>, add credit, and create a key.</p>
       </div>
       <div class="step">
         <strong>Configure in Open Historia</strong>
-        <p>Select <strong>OpenAI Compatible</strong> as the provider. Set the endpoint to <code>https://api.deepseek.com/v1</code>, enter your API key, and set the model to <code>deepseek-chat</code>.</p>
+        <p>Select <strong>OpenAI Compatible</strong>. Set the endpoint to <code>https://api.deepseek.com/v1</code>, enter your key, and set the model to <code>deepseek-chat</code> (or <code>deepseek-reasoner</code> for a reasoning model).</p>
       </div>
     </div>
 
-    <h3>Local LLMs (Free &amp; Private)</h3>
+    <h3>Local Models (Free &amp; Private)</h3>
     <div class="card">
-      <p>Run models entirely on your own hardware. No API keys, no internet required after download, completely private. Use the <strong>OpenAI Compatible</strong> provider in settings.</p>
+      <p>Run a model entirely on your own hardware: no API key, no internet after the download, and nothing leaves your machine. Use the <strong>OpenAI Compatible</strong> provider and point it at your local server.</p>
+      <p><strong>What the game needs from a local model.</strong> A time skip sends the model a large description of the world — on a mature save it runs to tens of thousands of tokens — and expects a long, precisely structured JSON answer back. Pick a model that follows instructions well, and run it with a large context window (32k tokens or more; the default context of many local setups is far smaller and the request will be refused as too long). Small models of around 3B parameters usually cannot complete a time skip; mid-sized instruct models (roughly 7B–14B and up) are the practical floor, and larger is better. Diplomacy chat and the advisor are far less demanding.</p>
     </div>
 
-    <h4>Ollama (Recommended for Easiest Setup)</h4>
+    <h4>Ollama (Easiest Setup)</h4>
     <div class="card">
-      <p><a href="https://ollama.com" target="_blank" rel="noopener">Ollama</a> is the simplest way to run LLMs locally. Works on Windows, macOS, and Linux.</p>
+      <p><a href="https://ollama.com" target="_blank" rel="noopener">Ollama</a> is the simplest way to run models locally on Windows, macOS, and Linux.</p>
       <div class="step">
-        <strong>Install Ollama</strong>
-        <p>Download from <a href="https://ollama.com" target="_blank" rel="noopener">ollama.com</a> and install.</p>
-      </div>
-      <div class="step">
-        <strong>Pull a model</strong>
-        <p><code>ollama pull llama3.2</code> — or any model you prefer. Recommended: <code>llama3.2</code> (lightweight), <code>mistral</code> (balanced), <code>qwen2.5</code> (strong reasoning).</p>
+        <strong>Install Ollama and pull a model</strong>
+        <p>Download from <a href="https://ollama.com" target="_blank" rel="noopener">ollama.com</a>, install, then pull an instruct model of your choice with <code>ollama pull &lt;model&gt;</code>. Raise its context window — for example by setting <code>OLLAMA_CONTEXT_LENGTH=32768</code> before starting Ollama, or with a <code>num_ctx</code> parameter in the model's settings.</p>
       </div>
       <div class="step">
         <strong>Configure in Open Historia</strong>
-        <p>Select <strong>OpenAI Compatible</strong>, set the endpoint to <code>http://localhost:11434/v1</code>. No API key needed for local use.</p>
+        <p>Select <strong>OpenAI Compatible</strong>. The endpoint defaults to <code>http://localhost:11434/v1</code>, which is Ollama's. Enter the model name you pulled; no API key is needed.</p>
+      </div>
+      <div class="step">
+        <strong>Playing on openhistoria.com?</strong>
+        <p>The website's requests come from a different origin, and Ollama refuses those unless told otherwise. Start Ollama with <code>OLLAMA_ORIGINS=https://openhistoria.com</code>. The desktop app needs no such setup.</p>
       </div>
     </div>
 
-    <h4>LM Studio (GUI-Focused)</h4>
+    <h4>LM Studio (GUI)</h4>
     <div class="card">
-      <p><a href="https://lmstudio.ai" target="_blank" rel="noopener">LM Studio</a> provides a graphical interface for downloading and running models. Great for Windows and macOS users who prefer a GUI.</p>
+      <p><a href="https://lmstudio.ai" target="_blank" rel="noopener">LM Studio</a> provides a graphical interface for downloading and running models.</p>
       <div class="step">
-        <strong>Install LM Studio</strong>
-        <p>Download from <a href="https://lmstudio.ai" target="_blank" rel="noopener">lmstudio.ai</a>.</p>
-      </div>
-      <div class="step">
-        <strong>Download a model</strong>
-        <p>Use the built-in model browser to search and download a model (e.g., Llama 3.2, Mistral 7B, Phi-3).</p>
-      </div>
-      <div class="step">
-        <strong>Start the local server</strong>
-        <p>Go to the "Local Server" tab, load your model, and click "Start Server." The default URL is <code>http://localhost:1234/v1</code>.</p>
+        <strong>Download a model and start the server</strong>
+        <p>Use the built-in model browser to download an instruct model, load it with a large context length, then start the local server from the Developer tab. The default address is <code>http://localhost:1234/v1</code>.</p>
       </div>
       <div class="step">
         <strong>Configure in Open Historia</strong>
-        <p>Select <strong>OpenAI Compatible</strong>, set the endpoint to <code>http://localhost:1234/v1</code>. No API key needed.</p>
+        <p>Select <strong>OpenAI Compatible</strong>, set the endpoint to <code>http://localhost:1234/v1</code>, and enter the model name shown by LM Studio. No API key needed.</p>
       </div>
     </div>
 
-    <h4>llama.cpp (Maximum Performance)</h4>
+    <h4>llama.cpp (Maximum Control)</h4>
     <div class="card">
-      <p><a href="https://github.com/ggerganov/llama.cpp" target="_blank" rel="noopener">llama.cpp</a> is the most performant option for technical users. Runs GGUF-format models with minimal overhead.</p>
+      <p><a href="https://github.com/ggerganov/llama.cpp" target="_blank" rel="noopener">llama.cpp</a> runs GGUF-format models with minimal overhead and is the most configurable option for technical users.</p>
       <div class="step">
-        <strong>Build llama.cpp server</strong>
-        <p>Follow the <a href="https://github.com/ggerganov/llama.cpp" target="_blank" rel="noopener">build instructions</a> for your platform.</p>
-      </div>
-      <div class="step">
-        <strong>Download a GGUF model</strong>
-        <p>Get a GGUF model from Hugging Face (e.g., <code>Llama-3.2-3B-Instruct-Q4_K_M.gguf</code>).</p>
-      </div>
-      <div class="step">
-        <strong>Start the server</strong>
-        <p><code>./llama-server -m model.gguf --port 8080</code></p>
+        <strong>Start the server with a large context</strong>
+        <p><code>./llama-server -m model.gguf -c 32768 --port 8080</code></p>
       </div>
       <div class="step">
         <strong>Configure in Open Historia</strong>
-        <p>Select <strong>OpenAI Compatible</strong>, set the endpoint to <code>http://localhost:8080/v1</code>.</p>
+        <p>Select <strong>OpenAI Compatible</strong> and set the endpoint to <code>http://localhost:8080/v1</code>.</p>
       </div>
     </div>
 
     <h3>Other Cloud APIs (OpenAI-Compatible)</h3>
     <div class="card">
-      <p>Any cloud service that speaks the OpenAI chat completions protocol works through the <strong>OpenAI Compatible</strong> provider. Popular options:</p>
+      <p>Any cloud service that speaks the OpenAI chat completions protocol works through the <strong>OpenAI Compatible</strong> provider. Common endpoints:</p>
       <table class="comparison-table">
         <thead>
           <tr>
             <th>Service</th>
             <th>Endpoint URL</th>
-            <th>Notable</th>
+            <th>Notes</th>
           </tr>
         </thead>
         <tbody>
           <tr>
             <td><strong>Groq</strong></td>
             <td><code>https://api.groq.com/openai/v1</code></td>
-            <td>Fast inference, generous free tier</td>
-          </tr>
-          <tr>
-            <td><strong>Together.ai</strong></td>
-            <td><code>https://api.together.xyz/v1</code></td>
-            <td>Wide model selection, $1 free credit</td>
+            <td>Very fast inference of open-weight models</td>
           </tr>
           <tr>
             <td><strong>OpenRouter</strong></td>
             <td><code>https://openrouter.ai/api/v1</code></td>
-            <td>Access 300+ models through one API</td>
+            <td>Many providers' models behind one key; use the full model slug</td>
+          </tr>
+          <tr>
+            <td><strong>Together</strong></td>
+            <td><code>https://api.together.xyz/v1</code></td>
+            <td>Wide selection of open-weight models</td>
           </tr>
           <tr>
             <td><strong>DeepInfra</strong></td>
             <td><code>https://api.deepinfra.com/v1/openai</code></td>
-            <td>Open-source models, pay-per-token</td>
+            <td>Open-weight models, pay per token</td>
           </tr>
           <tr>
             <td><strong>Fireworks</strong></td>
             <td><code>https://api.fireworks.ai/inference/v1</code></td>
-            <td>Fast, serverless GPU inference</td>
+            <td>Fast serverless inference</td>
           </tr>
         </tbody>
       </table>
-      <p>For any of these, select <strong>OpenAI Compatible</strong>, paste the endpoint URL and your API key from that service, and set the model name. The relay handles CORS automatically.</p>
+      <p>For any of these, select <strong>OpenAI Compatible</strong>, paste the endpoint URL and the key from that service, and set the model name exactly as the service lists it.</p>
     </div>
 
     <h2>Choosing the Right Option</h2>
@@ -306,7 +278,6 @@
           <tr>
             <th>Provider</th>
             <th>Cost</th>
-            <th>Quality</th>
             <th>Privacy</th>
             <th>Best For</th>
           </tr>
@@ -314,145 +285,63 @@
         <tbody>
           <tr>
             <td>Gemini</td>
-            <td>Free tier available</td>
-            <td>Excellent</td>
+            <td>Free tier, then pay per token</td>
             <td>Cloud</td>
-            <td>Quickest setup, casual play</td>
+            <td>Quickest setup, the default</td>
           </tr>
           <tr>
             <td>OpenAI</td>
-            <td>Pay-per-token</td>
-            <td>Excellent</td>
+            <td>Pay per token</td>
             <td>Cloud</td>
-            <td>Best quality, heavy use</td>
+            <td>Strong all-round quality</td>
           </tr>
           <tr>
             <td>Anthropic Claude</td>
-            <td>Pay-per-token</td>
-            <td>Excellent</td>
+            <td>Pay per token</td>
             <td>Cloud</td>
-            <td>Rich narrative, diplomacy</td>
+            <td>Rich narrative and diplomacy</td>
           </tr>
           <tr>
             <td>DeepSeek</td>
-            <td>Very low cost</td>
-            <td>Very good</td>
-            <td>Cloud (China)</td>
+            <td>Low cost per token</td>
+            <td>Cloud</td>
             <td>Budget-friendly quality</td>
           </tr>
           <tr>
             <td>Ollama / LM Studio / llama.cpp</td>
             <td>Free</td>
-            <td>Varies by model</td>
             <td>Fully local</td>
-            <td>Privacy, offline play</td>
+            <td>Privacy and offline play; needs a capable machine</td>
           </tr>
           <tr>
             <td>Groq / Together / OpenRouter</td>
-            <td>Free tier / low cost</td>
-            <td>Very good</td>
+            <td>Varies by service and model</td>
             <td>Cloud</td>
-            <td>Fast cloud inference, many models</td>
+            <td>Fast inference, many models</td>
           </tr>
         </tbody>
       </table>
-    </div>
-
-    <h2>Model Recommendations</h2>
-    <div class="card">
-      <table class="comparison-table">
-        <thead>
-          <tr>
-            <th>Model</th>
-            <th>Provider</th>
-            <th>Best For</th>
-            <th>Notes</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td>Gemini 2.5 Flash</td>
-            <td>Google (native)</td>
-            <td>All features, great free tier</td>
-            <td>Default — excellent all-rounder</td>
-          </tr>
-          <tr>
-            <td>Gemini 2.5 Flash Lite</td>
-            <td>Google (native)</td>
-            <td>Budget / free tier</td>
-            <td>Fast, generous rate limits</td>
-          </tr>
-          <tr>
-            <td>GPT-4.1 Mini</td>
-            <td>OpenAI (native)</td>
-            <td>Fast, inexpensive</td>
-            <td>Good for diplomacy and events</td>
-          </tr>
-          <tr>
-            <td>GPT-4.1</td>
-            <td>OpenAI (native)</td>
-            <td>Complex strategy &amp; narrative</td>
-            <td>Top-tier quality, higher cost</td>
-          </tr>
-          <tr>
-            <td>o4-mini</td>
-            <td>OpenAI (native)</td>
-            <td>Strategic reasoning</td>
-            <td>Reasoning model, excels at planning</td>
-          </tr>
-          <tr>
-            <td>Claude Sonnet 4</td>
-            <td>Anthropic (native)</td>
-            <td>Nuanced diplomacy, rich narrative</td>
-            <td>Best writing quality</td>
-          </tr>
-          <tr>
-            <td>DeepSeek-Chat (V3)</td>
-            <td>DeepSeek (compatible)</td>
-            <td>Budget-friendly quality</td>
-            <td>Very low cost per token</td>
-          </tr>
-          <tr>
-            <td>Llama 3.2 3B</td>
-            <td>Local (Ollama / LM Studio)</td>
-            <td>Diplomacy chat, advisor</td>
-            <td>~4 GB RAM needed</td>
-          </tr>
-          <tr>
-            <td>Mistral 7B</td>
-            <td>Local (Ollama / LM Studio)</td>
-            <td>Events, diplomacy, advisor</td>
-            <td>~8 GB RAM needed</td>
-          </tr>
-          <tr>
-            <td>Qwen 2.5 7B</td>
-            <td>Local (Ollama / LM Studio)</td>
-            <td>Strong reasoning, all features</td>
-            <td>~8 GB RAM needed</td>
-          </tr>
-        </tbody>
-      </table>
-      <p>For local models: smaller models respond faster and use less RAM. Larger models generate richer events and better strategic advice. For cloud models: Gemini's free tier is the best starting point; DeepSeek offers the best quality-per-dollar.</p>
+      <p>Rule of thumb: the quality of your game is the quality of the model. A free Gemini key is the best starting point; move up when you want deeper reasoning and richer writing, or go local when privacy matters and your hardware can carry a mid-sized model with a large context.</p>
     </div>
 
     <h2>Troubleshooting</h2>
     <div class="card">
-      <h3>AI features are greyed out or unresponsive</h3>
-      <p>Make sure your provider is configured correctly. For cloud APIs, verify your API key is valid and has credits. For local backends, check that the server is running and the endpoint URL matches. The game checks connectivity on load — if the backend isn't reachable, AI features won't activate.</p>
+      <h3>A time skip fails immediately, or nobody answers in chat</h3>
+      <p>The provider is not set up or not reachable. Check that a provider is selected in Settings, that the key is valid and has credit, and — for local backends — that the server is running and the endpoint URL matches, including the <code>/v1</code> path.</p>
+      <h3>"Context window exceeded" or "request too long"</h3>
+      <p>The model's context is too small for the time-skip request. Run the local model with a larger context window (see above) or choose a model with more context; on cloud providers, pick a model with a larger window.</p>
       <h3>API key not working</h3>
-      <p>Double-check you've selected the correct provider in settings. A Gemini key won't work with the OpenAI provider, and vice versa. For OpenAI Compatible providers, ensure the endpoint URL includes the full base path (e.g., <code>https://api.deepseek.com/v1</code>, not just <code>https://api.deepseek.com</code>).</p>
-      <h3>AI responses are slow</h3>
-      <p>For local models: try a smaller model (3B parameters) or enable GPU acceleration. Ollama and LM Studio both support GPU offloading. For cloud APIs: slower models like GPT-4.1 or Claude Sonnet produce higher quality but take longer — try a faster model if latency is an issue. Groq is particularly fast for cloud inference.</p>
-      <h3>CORS errors when using a remote backend</h3>
-      <p>The game handles CORS automatically for OpenAI, OpenAI Compatible, and Anthropic Compatible providers via the relay endpoint. If you're seeing CORS errors, make sure you're using the correct provider type — Gemini and Anthropic work direct from the browser, everything else routes through <code>/api/ai/relay</code>.</p>
-      <h3>DeepSeek / OpenRouter returns errors</h3>
-      <p>These services use the OpenAI Compatible provider. Ensure the endpoint URL is correct and includes <code>/v1</code>. The model name must match exactly what the service expects (e.g., <code>deepseek-chat</code> for DeepSeek, or the full OpenRouter model slug like <code>openai/gpt-4.1</code>).</p>
+      <p>Check that the key matches the selected provider — a Gemini key does not work with the OpenAI provider and vice versa. For OpenAI-compatible services, the model name must be exactly what the service expects (for example <code>deepseek-chat</code> on DeepSeek, or the full slug such as <code>openai/gpt-4.1</code> on OpenRouter).</p>
+      <h3>Responses are slow</h3>
+      <p>A time skip is a long generation and takes a while even on fast cloud models. For local models, enable GPU offloading (Ollama and LM Studio both support it) or try a smaller model. Groq is particularly fast among cloud services.</p>
+      <h3>CORS or "failed to fetch" errors</h3>
+      <p>In the desktop app and on a self-hosted install, providers that refuse browser requests are relayed through the game server automatically. On openhistoria.com there is no relay: a local Ollama must be started with <code>OLLAMA_ORIGINS=https://openhistoria.com</code>, and servers that never send CORS headers (llama.cpp, LM Studio) cannot be used from the website at all — use the desktop app for those.</p>
     </div>
 
     <h2>Related Guides</h2>
     <ul>
-      <li><a href="/get-started/">Get Started — installation and setup for all platforms</a></li>
-      <li><a href="/self-hosting/">Self-Hosting Guide — run your own server</a></li>
+      <li><a href="/get-started/">Get Started — the desktop app, the Android app, the browser demo, and your first game</a></li>
+      <li><a href="/self-hosting/">Self-Hosting Guide — run the server yourself</a></li>
       <li><a href="/how-to-play/">How to Play — gameplay mechanics and controls</a></li>
     </ul>
 

--- a/public/get-started/index.html
+++ b/public/get-started/index.html
@@ -14,23 +14,23 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#0b1020" />
   <link rel="icon" type="image/jpeg" href="/logo.png" />
-  <title>Get Started with Open Historia — Play the Free Grand Strategy Game in Your Browser</title>
+  <title>Get Started with Open Historia — Desktop App, Android App, or Browser Demo</title>
   <link rel="canonical" href="https://openhistoria.com/get-started/" />
-  <meta name="description" content="Get started playing Open Historia in your browser — no download required. Play the free open-source grand strategy game instantly on the web. Guide to the main menu, creating games, and joining multiplayer sessions." />
+  <meta name="description" content="How to start playing Open Historia, the free open-source AI grand strategy game: download the desktop app for Windows, macOS or Linux, install the Android app, or try the browser demo. Then connect an AI provider and start your first game." />
 
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Open Historia" />
   <meta property="og:url" content="https://openhistoria.com/get-started/" />
-  <meta property="og:title" content="Get Started with Open Historia — Play the Free Grand Strategy Game in Your Browser" />
-  <meta property="og:description" content="Play Open Historia in your browser — no download required. Get started with the free open-source grand strategy game instantly. Guide to the main menu, creating games, and joining sessions." />
+  <meta property="og:title" content="Get Started with Open Historia — Desktop App, Android App, or Browser Demo" />
+  <meta property="og:description" content="Download the desktop app, install the Android app, or try the browser demo. Connect an AI provider and start your first game of the free open-source grand strategy game." />
   <meta property="og:image" content="https://raw.githubusercontent.com/Open-Historia/open-historia/main/public/loading_screen.jpg" />
   <meta property="og:image:type" content="image/jpeg" />
   <meta property="og:image:width" content="1280" />
   <meta property="og:image:height" content="720" />
 
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Get Started with Open Historia — Play the Free Grand Strategy Game in Your Browser" />
-  <meta name="twitter:description" content="Play Open Historia in your browser — no download required. Get started instantly with the free open-source grand strategy game." />
+  <meta name="twitter:title" content="Get Started with Open Historia — Desktop App, Android App, or Browser Demo" />
+  <meta name="twitter:description" content="Download the desktop app, install the Android app, or try the browser demo. Connect an AI provider and start your first game." />
   <meta name="twitter:image" content="https://raw.githubusercontent.com/Open-Historia/open-historia/main/public/loading_screen.jpg" />
 
   <link rel="stylesheet" href="/guides.css" />
@@ -39,26 +39,32 @@
   {
     "@context": "https://schema.org",
     "@type": "HowTo",
-    "name": "How to Play Open Historia in the Browser",
-    "description": "Step-by-step guide to get started playing Open Historia, the free open-source grand strategy game, directly in your web browser — no download needed.",
+    "name": "How to Start Playing Open Historia",
+    "description": "Step-by-step guide to get started with Open Historia, the free open-source AI grand strategy game: get the game, connect an AI provider, and start your first game.",
     "step": [
       {
         "@type": "HowToStep",
         "position": "1",
-        "name": "Visit openhistoria.com",
-        "text": "Navigate to https://openhistoria.com in any modern browser. The game loads immediately — no account or download required."
+        "name": "Get the game",
+        "text": "Download the desktop app for Windows, macOS or Linux from the GitHub releases (recommended), install the Android app, or try the browser demo at openhistoria.com."
       },
       {
         "@type": "HowToStep",
         "position": "2",
-        "name": "Choose how to play",
-        "text": "From the main menu, click 'New Game' to start a single-player session of the Modern Day scenario, or create a multiplayer game and share the link with friends."
+        "name": "Connect an AI provider",
+        "text": "Open a game, open Settings and choose an AI provider under AI. Gemini is the default; a Google AI Studio key is enough to start."
       },
       {
         "@type": "HowToStep",
         "position": "3",
-        "name": "Play the game",
-        "text": "Click any nation on the world map to select it. Use the nation panel to manage diplomacy, deploy troops, and respond to events. End your turn to progress."
+        "name": "Start a game",
+        "text": "In the Games tab click New Game, pick a scenario, choose the country you want to lead on the picker map, and set a difficulty."
+      },
+      {
+        "@type": "HowToStep",
+        "position": "4",
+        "name": "Play",
+        "text": "Click countries on the map to inspect them and chat with their leaders, type your nation's actions in plain language, then skip time from the date at the top to see how the world reacts."
       }
     ]
   }
@@ -93,71 +99,85 @@
     <img class="logo" src="/logo.png" alt="Open Historia logo" width="64" height="64" />
 
     <h1>Get Started with Open Historia</h1>
-    <p class="tagline">Play the free open-source grand strategy game directly in your browser — no download, install, or account required.</p>
+    <p class="tagline">Free and open source. The game runs on your own machine, with an AI provider you choose — here is how to get it running and play your first game.</p>
 
-    <h2>Play on the Web</h2>
-    <div class="card">
-      <p>The easiest way to play Open Historia is right here on the website. Just visit <a href="/"><strong>openhistoria.com</strong></a> — the game loads instantly in your browser and you can start commanding nations on the interactive world map.</p>
-      <p>There's nothing to download, no account to create, and no setup required. All your games and scenarios are stored locally in your browser.</p>
-    </div>
-
-    <h2>Quick Start Guide</h2>
+    <h2>Three Ways to Play</h2>
 
     <div class="step">
-      <strong>Step 1 — Go to openhistoria.com</strong>
-      <p>Open any modern browser (Chrome, Firefox, Edge, Safari) and navigate to <a href="/"><strong>openhistoria.com</strong></a>. The game's main menu appears immediately.</p>
-    </div>
-
-    <div class="step">
-      <strong>Step 2 — Choose how to play</strong>
-      <p>From the main menu you can:</p>
+      <strong>Desktop app — recommended</strong>
+      <p>The desktop app is how the game is meant to be played: the world map is served from your own machine, so it is fast and works offline. Get it from the <a href="https://github.com/Open-Historia/open-historia/releases/tag/desktop-stable" target="_blank" rel="noopener">desktop release</a>:</p>
       <ul>
-        <li><strong>New Game</strong> — start a single-player session of the Modern Day scenario</li>
-        <li><strong>Load Game</strong> — resume a saved game stored in your browser</li>
-        <li><strong>Community</strong> — browse and download scenarios from the Scenario Hub</li>
-        <li><strong>Multiplayer</strong> — create a lobby and share the link so others can join</li>
+        <li><strong>Windows 10 &amp; 11:</strong> run <code>Open-Historia-Setup.exe</code>. If SmartScreen warns, choose <em>More info → Run anyway</em> — the installer is not code-signed yet.</li>
+        <li><strong>macOS:</strong> download the Apple Silicon or Intel zip, unzip, and drag <strong>Open Historia</strong> to Applications. The first time, right-click it and choose <em>Open</em>.</li>
+        <li><strong>Linux:</strong> install the <code>.deb</code> on Debian, Ubuntu and derivatives, or make the AppImage executable and run it.</li>
       </ul>
+      <p>Nothing else needs installing. On first launch the app downloads the world map data once (about 275 MB, with a progress bar). Your games and scenarios are saved on your computer.</p>
     </div>
 
     <div class="step">
-      <strong>Step 3 — Select your nation</strong>
-      <p>Click any country on the world map to select it. A nation panel opens with options for diplomacy, troop deployment, economy, and more.</p>
+      <strong>In your browser — a demo</strong>
+      <p>Press <strong>Play</strong> on <a href="/">openhistoria.com</a> to try the game without installing anything. The browser version streams every map tile from the community content-node network, so expect noticeable lag when panning and zooming — it is there to try the game, not the best way to play it.</p>
+      <p>Your games are saved in that browser, on that device. Signing in with Google is optional; it syncs your games and scenarios between devices, encrypted before they leave your browser. Your AI key goes straight from your browser to your provider.</p>
     </div>
 
     <div class="step">
-      <strong>Step 4 — Play your turn</strong>
-      <p>Negotiate with AI nations through natural language chat, deploy armies, respond to dynamic events, and consult your AI advisor. When ready, end your turn to see how the world reacts.</p>
+      <strong>Android</strong>
+      <p>Download <code>open-historia.apk</code> from the <a href="https://github.com/Open-Historia/open-historia/releases/tag/android" target="_blank" rel="noopener">Android release</a> and open it to install (allow installs from your browser when Android asks). It is the browser version packaged as an app: it connects to a content node on its own and streams the world map from there, and your games are saved on the phone. There is no server to run and nothing to point it at.</p>
     </div>
 
-    <h2>Playing with Friends</h2>
+    <p>Prefer to build from source, or run the server on another machine? See the <a href="/self-hosting/">self-hosting guide</a>.</p>
+
+    <h2>You Need an AI Provider</h2>
     <div class="card">
-      <p>Multiplayer is built right in — no separate server setup needed when playing on the openhistoria.com instance:</p>
-      <ul>
-        <li><strong>Create a lobby:</strong> From the main menu, click <strong>Multiplayer</strong> and start a new game. A joinable link is generated.</li>
-        <li><strong>Share the link:</strong> Send it to friends — they open it in their browser and join immediately. No accounts needed.</li>
-        <li><strong>Play together:</strong> Each player controls their chosen nation. Turns are processed simultaneously and everyone sees the results together.</li>
-      </ul>
-      <p>For private games or offline play, check the <a href="/self-hosting/">self-hosting guide</a> to run your own server.</p>
+      <p>Open Historia has no scripted simulation: every time skip, every event, every border change and every leader's reply is generated by a language model. <strong>Without a connected AI provider the world cannot advance</strong> — you can look at the map and use the map editor, but not play.</p>
+      <p>Open a game, open <strong>Settings</strong>, and pick a provider under <strong>AI</strong>. Gemini is the default; a free key from <a href="https://aistudio.google.com/apikey" target="_blank" rel="noopener">Google AI Studio</a> is enough to start. OpenAI, Anthropic, and anything that speaks the OpenAI or Anthropic APIs — including local models through Ollama or LM Studio — work too. The key is stored in the app and sent only to the provider you chose. See the <a href="/ai-setup/">AI setup guide</a> for every option.</p>
     </div>
 
-    <h2>Browser Features</h2>
+    <h2>Your First Game</h2>
+
+    <div class="step">
+      <strong>Step 1 — The main menu</strong>
+      <p>The menu has three tabs: <strong>Games</strong> (your saves), <strong>Scenarios</strong> (the worlds you can start from, with their editor), and <strong>Community</strong> (the Scenario Hub).</p>
+    </div>
+
+    <div class="step">
+      <strong>Step 2 — New Game</strong>
+      <p>Click <strong>New Game</strong>. <strong>Modern Day</strong> (starting 1 January 2016) is the built-in scenario; others can be imported from the Community tab first. Click the country you want to lead on the picker map, then choose a difficulty from Very Easy to Impossible.</p>
+    </div>
+
+    <div class="step">
+      <strong>Step 3 — Look around</strong>
+      <p>Click any country on the world map. Its panel shows what the map-maker wrote about it, an AI intelligence briefing on request, and an <strong>Open Diplomacy</strong> button that starts a chat with its leader.</p>
+    </div>
+
+    <div class="step">
+      <strong>Step 4 — Act</strong>
+      <p>Type what your nation does in the <strong>Actions</strong> panel in plain language — mobilise, sign a treaty, fund a programme, move troops. Actions queue up and are resolved at the next time skip. Negotiate with other leaders in chat, ask the <strong>Advisor</strong> for a briefing or a plan, and deploy spies from the chat panel.</p>
+    </div>
+
+    <div class="step">
+      <strong>Step 5 — Skip time</strong>
+      <p>Click the date at the top of the screen and choose how far to jump — from 6 hours to 1 year. The AI resolves your queued actions, plays every other nation, writes the events of that period and moves borders and fronts. Read the events on the timeline, then act again.</p>
+    </div>
+
+    <h2>Good to Know</h2>
     <div class="card">
       <ul>
-        <li><strong>Works everywhere:</strong> Play on desktop, tablet, or phone — any device with a browser</li>
-        <li><strong>Auto-save:</strong> Your game is saved automatically in your browser's local storage</li>
-        <li><strong>Scenario Hub:</strong> Browse and import community scenarios directly from the in-game Community tab</li>
-        <li><strong>AI features:</strong> If you connect an AI backend, diplomacy, events, and the advisor work in-browser too</li>
+        <li><strong>Single-player:</strong> you lead one nation and the AI plays the rest. There is no multiplayer lobby. On a self-hosted server other devices on your network can open the same saves — see the <a href="/self-hosting/">self-hosting guide</a>.</li>
+        <li><strong>Saves:</strong> the game saves itself as you play — on your computer in the desktop app, on the phone in the Android app, and in the browser in the demo.</li>
+        <li><strong>Scenario Hub:</strong> browse and import community scenarios from the Community tab, and publish your own.</li>
+        <li><strong>Map editor:</strong> every scenario opens in a full vector map editor — redraw borders, paint owners, place cities, then <em>Apply &amp; Play</em>.</li>
       </ul>
     </div>
 
     <h2>Next Steps</h2>
     <ul>
-      <li><a href="/how-to-play/">How to Play — complete gameplay guide for new players</a></li>
-      <li><a href="/ai-setup/">Connect an AI Backend — enable AI diplomacy, events, and advisor</a></li>
-      <li><a href="/self-hosting/">Self-Hosting Guide — run your own server for friends or offline play</a></li>
+      <li><a href="/how-to-play/">How to Play — the map, diplomacy, actions, troops, spies, time skips, and the map editor</a></li>
+      <li><a href="/ai-setup/">Connect an AI provider — Gemini, OpenAI, Anthropic, local models, and OpenAI-compatible APIs</a></li>
+      <li><a href="/self-hosting/">Self-Hosting Guide — build from source, play from other devices, run as a service</a></li>
     </ul>
 
-    <a href="/" class="cta">Play Open Historia Now</a>
+    <a href="/" class="cta">Play Open Historia</a>
 
     <footer>
       <p>Open Historia — free, open-source grand strategy game. <a href="https://github.com/Open-Historia/open-historia" target="_blank" rel="noopener">GitHub</a> · <a href="https://discord.gg/QaqAK7fQAg" target="_blank" rel="noopener">Discord</a> · <a href="/sitemap.xml">Sitemap</a></p>

--- a/public/guides/index.html
+++ b/public/guides/index.html
@@ -14,15 +14,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#0b1020" />
   <link rel="icon" type="image/jpeg" href="/logo.png" />
-  <title>Guides — Open Historia | Get Started, Self-Hosting, AI Setup &amp; Gameplay</title>
+  <title>Guides — Open Historia | Get Started, How to Play, AI Setup &amp; Self-Hosting</title>
   <link rel="canonical" href="https://openhistoria.com/guides/" />
-  <meta name="description" content="Complete guides for Open Historia, the free open-source grand strategy game. Installation, self-hosting, AI backend setup, gameplay mechanics, and Pax Historia comparison." />
+  <meta name="description" content="Guides for Open Historia, the free open-source AI grand strategy game: getting the game, how to play, connecting an AI provider, self-hosting the server, and how it compares to Pax Historia." />
 
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Open Historia" />
   <meta property="og:url" content="https://openhistoria.com/guides/" />
   <meta property="og:title" content="Guides — Open Historia" />
-  <meta property="og:description" content="Complete guides: installation, self-hosting, AI backend setup, gameplay mechanics, and Pax Historia alternative comparison." />
+  <meta property="og:description" content="Getting the game, how to play, connecting an AI provider, self-hosting the server, and how Open Historia compares to Pax Historia." />
   <meta property="og:image" content="https://raw.githubusercontent.com/Open-Historia/open-historia/main/public/loading_screen.jpg" />
   <meta property="og:image:type" content="image/jpeg" />
   <meta property="og:image:width" content="1280" />
@@ -30,7 +30,7 @@
 
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Guides — Open Historia" />
-  <meta name="twitter:description" content="Complete guides: installation, self-hosting, AI backend setup, gameplay mechanics, and Pax Historia alternative comparison." />
+  <meta name="twitter:description" content="Getting the game, how to play, connecting an AI provider, self-hosting the server, and how Open Historia compares to Pax Historia." />
   <meta name="twitter:image" content="https://raw.githubusercontent.com/Open-Historia/open-historia/main/public/loading_screen.jpg" />
 
   <link rel="stylesheet" href="/guides.css" />
@@ -65,36 +65,37 @@
     <img class="logo" src="/logo.png" alt="Open Historia logo" width="64" height="64" />
 
     <h1>Open Historia Guides</h1>
-    <p class="tagline">Everything you need to install, host, play, and master Open Historia — the free open-source grand strategy game.</p>
+    <p class="tagline">Everything you need to get, set up, play, and host Open Historia — the free open-source AI grand strategy game.</p>
 
     <div class="card">
       <h3><a href="/get-started/">Get Started</a></h3>
-      <p>Download and install Open Historia on Windows, macOS, Linux, or Android. One-click launchers, manual setup, and prerequisites — get playing in minutes.</p>
+      <p>The three ways to play — the desktop app for Windows, macOS and Linux, the Android app, and the browser demo — why the game needs an AI provider, and a walkthrough of your first game: the main menu, New Game, the country picker, and your first time skip.</p>
     </div>
 
     <div class="card">
       <h3><a href="/how-to-play/">How to Play</a></h3>
-      <p>Learn the core mechanics: interactive world map, AI diplomacy via natural language chat, troop deployment and combat, AI-generated events, AI strategic advisor, the vector map editor, and the Scenario Hub. Tips for new players and a recommended gameplay loop.</p>
+      <p>The core mechanics: the interactive world map, chatting with AI leaders, plain-language actions, AI-generated events, the advisor, spies, troops and fronts, time skips, the vector map editor, and the Scenario Hub. Tips for new players and a recommended loop.</p>
     </div>
 
     <div class="card">
       <h3><a href="/ai-setup/">AI Setup Guide</a></h3>
-      <p>Connect a local large language model (LLM) to unlock AI-powered diplomacy, AI-generated historical events, and the AI strategic advisor. Covers Ollama, LM Studio, llama.cpp, and OpenAI-compatible cloud APIs. Includes model recommendations and troubleshooting.</p>
+      <p>Connect the AI that runs the world: Gemini (the default, with a free key), OpenAI, Anthropic, local models through Ollama, LM Studio or llama.cpp, and OpenAI-compatible cloud APIs such as DeepSeek, Groq and OpenRouter. What local models need, and troubleshooting.</p>
     </div>
 
     <div class="card">
       <h3><a href="/self-hosting/">Self-Hosting Guide</a></h3>
-      <p>Run your own Open Historia server — completely offline, on your LAN, or accessible to friends over the internet. Covers CORS configuration, running as a systemd/launchd service, port forwarding, and privacy benefits.</p>
+      <p>Build and run the server yourself, play your saves from other devices on your network, use it with a local model offline, the environment variables that control who can reach it, and running it as a service on Linux, Windows, and macOS.</p>
     </div>
 
     <div class="card">
       <h3><a href="/pax-historia-alternative/">Pax Historia Alternative</a></h3>
-      <p>How Open Historia compares to Pax Historia and Age of History 3. Full feature comparison table, pricing breakdown, platform support, and answers to common questions about switching from commercial grand strategy games.</p>
+      <p>How Open Historia compares to Pax Historia and to other strategy games: what the two share, what is different about a free, open-source, local-first game, and answers to common questions about switching.</p>
     </div>
 
     <h2>Quick Links</h2>
     <ul>
-      <li><a href="/">Play Open Historia in your browser</a></li>
+      <li><a href="/">Play Open Historia</a></li>
+      <li><a href="https://github.com/Open-Historia/open-historia/releases/tag/desktop-stable" target="_blank" rel="noopener">Desktop downloads</a></li>
       <li><a href="https://github.com/Open-Historia/open-historia" target="_blank" rel="noopener">GitHub Repository</a></li>
       <li><a href="https://discord.gg/QaqAK7fQAg" target="_blank" rel="noopener">Discord Community</a></li>
       <li><a href="/sitemap/">Sitemap</a></li>

--- a/public/how-to-play/index.html
+++ b/public/how-to-play/index.html
@@ -14,15 +14,15 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#0b1020" />
   <link rel="icon" type="image/jpeg" href="/logo.png" />
-  <title>How to Play Open Historia — Grand Strategy Game Guide | Map Editor, AI Diplomacy &amp; Combat</title>
+  <title>How to Play Open Historia — Grand Strategy Game Guide | Map, AI Diplomacy, Actions &amp; Time Skips</title>
   <link rel="canonical" href="https://openhistoria.com/how-to-play/" />
-  <meta name="description" content="Learn how to play Open Historia, the free open-source grand strategy game. Master the interactive world map, AI diplomacy, troop combat, map editor, scenario hub, and AI advisor. Complete beginner's guide." />
+  <meta name="description" content="Learn how to play Open Historia, the free open-source AI grand strategy game: the interactive world map, chatting with AI leaders, plain-language actions, AI-generated events, the advisor, spies, troops, time skips, the map editor, and the Scenario Hub." />
 
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Open Historia" />
   <meta property="og:url" content="https://openhistoria.com/how-to-play/" />
   <meta property="og:title" content="How to Play Open Historia — Grand Strategy Game Guide" />
-  <meta property="og:description" content="Learn how to play Open Historia, the free open-source grand strategy game. Master the world map, AI diplomacy, troop combat, map editor, scenario hub, and AI advisor." />
+  <meta property="og:description" content="Learn how to play Open Historia, the free open-source AI grand strategy game: the world map, AI diplomacy, actions, events, the advisor, spies, troops, time skips, the map editor, and the Scenario Hub." />
   <meta property="og:image" content="https://raw.githubusercontent.com/Open-Historia/open-historia/main/public/loading_screen.jpg" />
   <meta property="og:image:type" content="image/jpeg" />
   <meta property="og:image:width" content="1280" />
@@ -30,7 +30,7 @@
 
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="How to Play Open Historia — Grand Strategy Game Guide" />
-  <meta name="twitter:description" content="Learn how to play Open Historia, the free open-source grand strategy game. Master the world map, AI diplomacy, troop combat, map editor, scenario hub, and AI advisor." />
+  <meta name="twitter:description" content="Learn how to play Open Historia, the free open-source AI grand strategy game: the world map, AI diplomacy, actions, events, the advisor, spies, troops, time skips, the map editor, and the Scenario Hub." />
   <meta name="twitter:image" content="https://raw.githubusercontent.com/Open-Historia/open-historia/main/public/loading_screen.jpg" />
 
   <link rel="stylesheet" href="/guides.css" />
@@ -64,40 +64,60 @@
     <img class="logo" src="/logo.png" alt="Open Historia logo" width="64" height="64" />
 
     <h1>How to Play Open Historia</h1>
-    <p class="tagline">Master the free open-source grand strategy game — from your first turn on the interactive world map to commanding AI diplomacy, deploying troops, creating custom scenarios, and sharing them with a global community.</p>
+    <p class="tagline">From your first look at the interactive world map to negotiating with AI leaders, giving orders in plain language, skipping time, building custom worlds in the map editor, and sharing them with the community.</p>
 
     <h2>Overview: What Is Open Historia?</h2>
     <div class="card">
-      <p>Open Historia is a <span class="highlight">free, open-source grand strategy game</span> where you command nations on an interactive world map. You negotiate with AI-powered nations through natural language chat, deploy troops, respond to AI-generated historical events, and shape the world through war, diplomacy, and expansion.</p>
-      <p>It's built as a community-driven alternative to Pax Historia — with a full vector map editor, a scenario hub for sharing custom worlds, and cross-platform support on Windows, macOS, Linux, and Android.</p>
+      <p>Open Historia is a <span class="highlight">free, open-source grand strategy game</span> where you lead one nation on an interactive world map. You give orders in plain language, negotiate with AI-run nations through chat, deploy troops and spies, and then skip time — hours, days, months or a year — while an AI simulates how the rest of the world responds: events, wars, treaties, and borders that actually move.</p>
+      <p>It is built as a community alternative to Pax Historia, with a full vector map editor, a Scenario Hub for sharing custom worlds, a desktop app for Windows, macOS and Linux, an Android app, and a browser demo.</p>
+    </div>
+
+    <div class="card">
+      <h3>The AI Runs the World</h3>
+      <p>There is no scripted simulation underneath. Every time skip is written by a language model from the current state of the world: what happened, who gained or lost territory, how other nations reacted. You bring the model — Gemini, OpenAI, Anthropic, or a local one — and the game sends it your key directly. <strong>Without an AI provider connected the world cannot advance</strong>, so set one up first: see the <a href="/ai-setup/">AI setup guide</a>.</p>
     </div>
 
     <h2>Core Features &amp; Mechanics</h2>
 
     <div class="card">
       <h3>Interactive World Map</h3>
-      <p>The map is your primary interface. Click any nation to select it and open its detail panel. Watch as territory, borders, and nations shift as history unfolds. The map supports pan, zoom, and click-to-inspect — every region, city, and unit is interactive.</p>
+      <p>The map is your primary interface. Pan, zoom, and click any region, city or unit to inspect it. Click a nation to open its panel: the description its map-maker wrote, an AI intelligence briefing on request, and an <strong>Open Diplomacy</strong> button. Watch territory, borders, and nations shift as history unfolds after every time skip.</p>
     </div>
 
     <div class="card">
       <h3>AI Diplomacy</h3>
-      <p>Click any country and start chatting with it — literally. Open Historia's <span class="highlight">AI diplomacy system</span> lets you negotiate with AI-controlled nations through natural language. Declare war, propose alliances, demand territory, threaten, or broker peace — the AI responds dynamically based on your relationship, relative strength, and the current world situation.</p>
-      <p>You can also request an <strong>AI intelligence briefing</strong> on any nation to understand its military strength, economy, allies, and posture before engaging.</p>
+      <p>Open a chat with any nation's leader and talk to them — literally. Propose alliances, demand territory, threaten, broker peace, or just probe their intentions; the leader answers in character, shaped by your relationship, relative strength, and the state of the world. What is agreed in chat feeds into the next time skip.</p>
+      <p>Before engaging, ask for an <strong>AI intelligence briefing</strong> on any nation from its panel to understand its strength, economy, allies, and posture.</p>
+    </div>
+
+    <div class="card">
+      <h3>Actions in Plain Language</h3>
+      <p>The <span class="highlight">Actions</span> panel is where you govern. Type what your nation does — "mobilise the reserves along the northern border", "offer Kenya a trade agreement", "fund a nuclear programme" — and it joins the queue. Queued actions are resolved at the next time skip, when the AI works out what they achieve and how everyone else responds.</p>
     </div>
 
     <div class="card">
       <h3>AI-Generated Events</h3>
-      <p>As you play, the game generates <span class="highlight">dynamic historical events</span> shaped by your decisions and the evolving world state. A booming economy might attract immigration; an aggressive neighbor might provoke a border crisis; a neglected province might rebel. Each event presents choices with real consequences.</p>
+      <p>Each time skip produces <span class="highlight">dynamic events</span> shaped by your decisions and the evolving world: a booming economy attracts investment, an aggressive neighbour provokes a border crisis, a neglected province rebels. Events land on the timeline with dates and consequences; you respond to them with actions, diplomacy, and troops.</p>
     </div>
 
     <div class="card">
       <h3>AI Advisor</h3>
-      <p>Stuck on strategy? Consult your <span class="highlight">AI advisor</span> for strategic guidance, economic analysis, situation summaries, and war planning. The advisor analyzes the current game state and offers actionable recommendations — which nation to ally with, where to deploy troops, how to stabilize a crumbling economy.</p>
+      <p>Stuck on strategy? Consult your <span class="highlight">AI advisor</span> for situation summaries, economic analysis, and war planning. The advisor reads the current game state and offers concrete recommendations — which nation to court, where to position troops, how to steady a crumbling economy.</p>
     </div>
 
     <div class="card">
-      <h3>Troop Deployment &amp; Combat</h3>
-      <p>You deploy, move, and position armies on the map. Deployments are "pending" until the AI resolves them — meaning you set your orders and the AI computes the outcome based on troop strength, terrain, and strategy. Scenarios control which troop types exist in their era (infantry, cavalry, tanks, aircraft, etc.).</p>
+      <h3>Spies</h3>
+      <p>From the chat panel you can <strong>deploy spies</strong> to other nations. Agents in place intercept what their host is saying to other leaders and report back; foreign agents caught in your own country can be expelled or turned into double agents. Espionage carries risk — an exposed operation sours relations.</p>
+    </div>
+
+    <div class="card">
+      <h3>Troops &amp; Combat</h3>
+      <p>You deploy, move, and position armies on the map. Deployments stay <em>pending</em> until the AI resolves them at the next time skip — you set your orders, and the AI decides the outcome from the strength of the forces involved, your other actions, and the wider situation, moving fronts and borders accordingly. Scenarios control which troop types exist in their era (infantry, cavalry, tanks, aircraft, and so on).</p>
+    </div>
+
+    <div class="card">
+      <h3>Time Skips</h3>
+      <p>Click the date at the top of the screen and choose how far to jump: 6 hours, 1 day, 3 days, 1 week, 1 month, 3 months, 6 months, or 1 year. Short skips give fine control during a crisis; long ones let whole eras play out. The AI then resolves your queued actions, plays every other nation, and writes the period's events onto the timeline.</p>
     </div>
 
     <h2>Using the Map Editor</h2>
@@ -106,58 +126,59 @@
       <ul>
         <li><strong>Draw regions:</strong> Create new territories with freehand drawing tools</li>
         <li><strong>Split and merge borders:</strong> Redraw the political map however you want</li>
-        <li><strong>Paint owners:</strong> Assign regions to specific nations</li>
-        <li><strong>Place cities:</strong> Import from the 70k+ city database or place manually</li>
-        <li><strong>Sign your map:</strong> Add creator metadata to your custom worlds</li>
+        <li><strong>Paint owners:</strong> Assign regions to nations, with their colours and flags</li>
+        <li><strong>Place cities:</strong> Search and import from a database of around 70,000 world places, or place them by hand</li>
+        <li><strong>Credit your work:</strong> Name and author your map before you share it</li>
         <li><strong>Apply &amp; Play:</strong> Hit one button to switch from editing to playing on your new map</li>
       </ul>
-      <p>Open the map editor from any scenario by clicking <strong>Open Map Editor</strong>, or visit <code>/?editor=1</code> for the standalone editor.</p>
+      <p>Open the editor from any scenario in the library by clicking <strong>Open Map Editor</strong>, or visit <code>/?editor=1</code> for the standalone editor.</p>
     </div>
 
     <h2>Scenarios &amp; The Scenario Hub</h2>
     <div class="card">
-      <p><strong>Modern Day</strong> is the built-in default scenario. The <span class="highlight">Scenario Hub</span> (accessible from the in-game <strong>Community</strong> tab) hosts community-created scenarios including:</p>
+      <p><strong>Modern Day</strong>, starting on 1 January 2016, is the only built-in scenario. Everything else lives on the <span class="highlight">Scenario Hub</span>, reached from the in-game <strong>Community</strong> tab. The official presets there include:</p>
       <ul>
         <li>World War II — 1939 — global war from the German invasion of Poland</li>
         <li>Medieval — 1200 AD — feudal Europe, crusades, and medieval empires</li>
         <li>Rome — 117 AD — the Roman Empire at its greatest extent</li>
-        <li>Mongol World — 1300 AD — the Mongol Empire and its neighbors</li>
-        <li>New World — 1650 — colonial powers, the Discovery of America, and global trade</li>
+        <li>Mongol World — 1300 AD — the Mongol Empire and its neighbours</li>
+        <li>New World — 1650 — colonial powers and global trade</li>
         <li>Bronze Age — 1200 BC — the Late Bronze Age on the eve of the Collapse</li>
       </ul>
-      <p>Browse scenarios, vote on your favorites, import with one click, and publish your own creations. Each scenario includes its own map, starting conditions, troop types, and historical context.</p>
+      <p>Alongside them are community scenarios such as The Great War — 1911, The Cold War — 1946, Fault Lines — 2014, and the Second Punic War — 218 BC. Browse them sorted by imports, likes, or date, import any with one click, and publish your own from the same tab. Each scenario brings its own map, starting conditions, troop types, and historical context.</p>
     </div>
 
     <h2>Gameplay Loop</h2>
     <div class="card">
-      <p>A typical turn in Open Historia looks like this:</p>
+      <p>A typical round in Open Historia looks like this:</p>
       <ol>
-        <li><strong>Survey:</strong> Review your nation's status — economy, military, diplomacy, and any pending events or threats.</li>
-        <li><strong>Consult the Advisor:</strong> Ask the AI advisor for strategic recommendations based on the current situation.</li>
-        <li><strong>Diplomacy:</strong> Chat with neighboring nations — negotiate, threaten, ally, or gather intelligence.</li>
-        <li><strong>Deploy Troops:</strong> Position armies for defense, offense, or deterrence.</li>
-        <li><strong>Respond to Events:</strong> Make decisions on AI-generated events that arise during the turn.</li>
-        <li><strong>Advance:</strong> End your turn and watch the AI resolve combat, process economic changes, and generate new events.</li>
+        <li><strong>Survey:</strong> Read the latest events on the timeline and check your nation's situation — economy, military, relations.</li>
+        <li><strong>Consult the Advisor:</strong> Ask for a briefing or a plan based on the current situation.</li>
+        <li><strong>Diplomacy:</strong> Chat with the leaders that matter — negotiate, threaten, ally, or gather intelligence.</li>
+        <li><strong>Act:</strong> Queue your nation's actions in plain language and position your troops.</li>
+        <li><strong>Skip time:</strong> Choose how far to jump. The AI resolves your actions, plays the other nations, and writes the events of that period.</li>
+        <li><strong>Repeat:</strong> React to what happened and plan the next move.</li>
       </ol>
     </div>
 
     <h2>Tips for New Players</h2>
     <div class="card">
       <ul>
-        <li><strong>Start with Modern Day:</strong> The default scenario is the most polished and easiest to learn on.</li>
-        <li><strong>Use the AI advisor often:</strong> It's like having a co-pilot that understands the game state.</li>
-        <li><strong>Diplomacy is powerful:</strong> A well-timed alliance can be more valuable than an expensive war.</li>
-        <li><strong>Experiment with scenarios:</strong> Each era has different troop types, economies, and diplomatic dynamics.</li>
-        <li><strong>Try the map editor:</strong> Even if you don't publish, editing maps helps you understand territory and borders.</li>
-        <li><strong>Read AI intelligence briefings:</strong> Before engaging any nation, get a briefing to understand its strength.</li>
+        <li><strong>Start with Modern Day:</strong> The built-in scenario is the most polished and the easiest to learn on.</li>
+        <li><strong>Use a capable model:</strong> The quality of events, diplomacy, and advice is the quality of the model you connect. Small local models struggle with the large answer a time skip needs.</li>
+        <li><strong>Skip short at first:</strong> A few days at a time shows you how the world responds to each action before you commit to a year.</li>
+        <li><strong>Use the AI advisor often:</strong> It reads the whole game state and is the fastest way to understand your position.</li>
+        <li><strong>Diplomacy is powerful:</strong> A well-timed alliance can be worth more than an expensive war.</li>
+        <li><strong>Read the briefings:</strong> Before engaging any nation, get an intelligence briefing to understand its strength.</li>
+        <li><strong>Try the map editor:</strong> Even if you never publish, editing a map teaches you how territory and borders work.</li>
       </ul>
     </div>
 
     <h2>Related Guides</h2>
     <ul>
-      <li><a href="/get-started/">Get Started — installation and setup</a></li>
-      <li><a href="/ai-setup/">Connect an AI Backend — enable AI features</a></li>
-      <li><a href="/self-hosting/">Self-Hosting Guide — run your own server</a></li>
+      <li><a href="/get-started/">Get Started — the desktop app, the Android app, the browser demo, and your first game</a></li>
+      <li><a href="/ai-setup/">Connect an AI provider — the model that runs the world</a></li>
+      <li><a href="/self-hosting/">Self-Hosting Guide — run the server yourself</a></li>
       <li><a href="/pax-historia-alternative/">Pax Historia Alternative — how Open Historia compares</a></li>
     </ul>
 

--- a/public/pax-historia-alternative/index.html
+++ b/public/pax-historia-alternative/index.html
@@ -14,49 +14,27 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#0b1020" />
   <link rel="icon" type="image/jpeg" href="/logo.png" />
-  <title>Open Historia — The Best Free Pax Historia Alternative | Open-Source Grand Strategy Game</title>
+  <title>Open Historia vs Pax Historia — The Free, Open-Source Alternative</title>
   <link rel="canonical" href="https://openhistoria.com/pax-historia-alternative/" />
-  <meta name="description" content="Open Historia is the best free, open-source alternative to Pax Historia. Feature comparison: AI diplomacy, map editor, custom scenarios, troop combat, self-hosting, and cross-platform play — all free under the MIT license." />
+  <meta name="description" content="How Open Historia compares to Pax Historia: both are AI-driven alternate-history sandboxes, but Open Historia is free, open source, runs on your own machine with your own AI, and has a built-in vector map editor. Also compared with Age of History 3 and other strategy games." />
 
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Open Historia" />
   <meta property="og:url" content="https://openhistoria.com/pax-historia-alternative/" />
-  <meta property="og:title" content="Open Historia — The Best Free Pax Historia Alternative | Open-Source Grand Strategy Game" />
-  <meta property="og:description" content="The best free, open-source alternative to Pax Historia. AI diplomacy, map editor, custom scenarios, troop combat, self-hosting, cross-platform — all free under MIT license." />
+  <meta property="og:title" content="Open Historia vs Pax Historia — The Free, Open-Source Alternative" />
+  <meta property="og:description" content="Both are AI-driven alternate-history sandboxes. Open Historia is free, open source, runs on your own machine with your own AI, and has a built-in vector map editor." />
   <meta property="og:image" content="https://raw.githubusercontent.com/Open-Historia/open-historia/main/public/loading_screen.jpg" />
   <meta property="og:image:type" content="image/jpeg" />
   <meta property="og:image:width" content="1280" />
   <meta property="og:image:height" content="720" />
 
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Open Historia — The Best Free Pax Historia Alternative" />
-  <meta name="twitter:description" content="The best free, open-source alternative to Pax Historia. AI diplomacy, map editor, custom scenarios, troop combat — all free under MIT license." />
+  <meta name="twitter:title" content="Open Historia vs Pax Historia — The Free, Open-Source Alternative" />
+  <meta name="twitter:description" content="Both are AI-driven alternate-history sandboxes. Open Historia is free, open source, runs on your own machine with your own AI, and has a built-in vector map editor." />
   <meta name="twitter:image" content="https://raw.githubusercontent.com/Open-Historia/open-historia/main/public/loading_screen.jpg" />
 
   <link rel="stylesheet" href="/guides.css" />
 
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "SoftwareApplication",
-    "name": "Open Historia",
-    "applicationCategory": "GameApplication",
-    "operatingSystem": "Windows, macOS, Linux, Android",
-    "description": "Open Historia is a free, open-source grand strategy game and community-driven alternative to Pax Historia. Features AI-powered diplomacy, a full vector map editor, custom scenarios, troop combat, and cross-platform play. Self-hostable under the MIT license.",
-    "url": "https://openhistoria.com/pax-historia-alternative/",
-    "offers": {
-      "@type": "Offer",
-      "price": "0",
-      "priceCurrency": "USD"
-    },
-    "author": {
-      "@type": "Organization",
-      "name": "Open Historia",
-      "url": "https://github.com/Open-Historia"
-    },
-    "license": "https://opensource.org/licenses/MIT"
-  }
-  </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
@@ -77,54 +55,6 @@
     ]
   }
   </script>
-  <script type="application/ld+json">
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "Is Open Historia really free?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes. Open Historia is completely free under the MIT license. No purchase, no microtransactions, no subscriptions, no ads. The source code is fully open on GitHub."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is Open Historia the same as Pax Historia?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "No. Open Historia is an independent project inspired by the grand strategy genre. It is not affiliated with Pax Historia Games. It is built from scratch as a community-driven, open-source alternative."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I play Open Historia offline?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes. Once installed, Open Historia runs entirely offline. If you connect a local LLM like Ollama or LM Studio, even AI features work without an internet connection."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Is there an Android version?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes. A thin client APK is available that connects to a running Open Historia server. Download it from the Android release page on GitHub. The game logic runs on the server; the APK is a remote display client."
-        }
-      },
-      {
-        "@type": "Question",
-        "name": "Can I create and share my own scenarios?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "Yes. Use the full vector map editor to draw regions, place cities, set owners, and define starting conditions. Publish your scenario to the Scenario Hub from the in-game Community tab and share it with players worldwide."
-        }
-      }
-    ]
-  }
-  </script>
 </head>
 <body>
   <div class="page">
@@ -134,28 +64,26 @@
 
     <img class="logo" src="/logo.png" alt="Open Historia logo" width="64" height="64" />
 
-    <h1>Open Historia — The Free Pax Historia Alternative</h1>
-    <p class="tagline">Open Historia is a free, open-source grand strategy game — a community-driven alternative to Pax Historia — with AI-powered diplomacy, a full vector map editor, custom scenarios, troop combat, and cross-platform play. No purchase, no subscriptions, no DRM — just download and play.</p>
+    <h1>Open Historia — The Free, Open-Source Pax Historia Alternative</h1>
+    <p class="tagline">Open Historia is a free, open-source AI grand strategy game built as a community alternative to Pax Historia. Same idea — lead a nation, act in plain language, let an AI simulate the world — but running on your own machine, with your own AI, under the MIT license. No purchase, no subscription, no metering.</p>
 
-    <h2>Why Switch from Pax Historia?</h2>
+    <h2>What the Two Games Share</h2>
     <div class="card">
-      <p><strong>Pax Historia</strong> is a popular commercial grand strategy game developed by Pax Historia Games. It offers a nation-commanding experience with a world map, but it requires payment to play and the development roadmap is controlled by a single company.</p>
-      <p>Open Historia was built by grand strategy fans who wanted:</p>
+      <p><strong>Pax Historia</strong> is a commercial alternate-history sandbox played in the browser, where an AI simulates how nations respond to the actions players type in natural language; players start diplomatic chats, jump forward in time, and publish custom maps and presets for others to play. Open Historia was started by fans of exactly that loop who wanted it to be:</p>
       <ul>
-        <li>A <strong>completely free</strong> alternative — no purchase, no microtransactions, no subscriptions</li>
-        <li><strong>Open-source transparency</strong> — the full codebase is on GitHub under the MIT license</li>
-        <li><strong>Community-driven development</strong> — features are shaped by players, not shareholders</li>
-        <li><strong>Self-hostable servers</strong> — run your own instance, play offline, control your data</li>
-        <li><strong>AI-powered diplomacy</strong> — negotiate with any nation through natural language, not fixed dialogue options</li>
-        <li><strong>A powerful map editor</strong> — create and share custom scenarios with full vector editing tools</li>
+        <li><strong>Free, with no metering</strong> — no tokens, no subscription, no daily limit on how long you play. The only cost is whatever your AI provider charges, and a free Gemini key or a local model costs nothing.</li>
+        <li><strong>Open source</strong> — the full codebase is on GitHub under the MIT license, and contributions shape the game.</li>
+        <li><strong>Yours to run</strong> — a desktop app, an Android app, and a server you can host yourself. Saves stay on your device; there is no account and no central game server.</li>
+        <li><strong>Bring-your-own AI</strong> — Gemini, OpenAI, Anthropic, or a local model through Ollama or LM Studio, sent your key directly. Play offline with a local model.</li>
+        <li><strong>A real map editor</strong> — a full vector editor to draw regions, redraw borders, paint owners, and place cities, with a Scenario Hub to share the result.</li>
       </ul>
     </div>
 
-    <h2>Open Historia vs Pax Historia — Feature Comparison</h2>
+    <h2>Open Historia vs Pax Historia — Comparison</h2>
     <table class="comparison-table">
       <thead>
         <tr>
-          <th>Feature</th>
+          <th>Aspect</th>
           <th>Open Historia</th>
           <th>Pax Historia</th>
         </tr>
@@ -163,98 +91,89 @@
       <tbody>
         <tr>
           <td>Price</td>
-          <td><span class="check">Free (MIT open-source)</span></td>
-          <td>Paid</td>
+          <td><span class="check">Free, no limits on play time</span></td>
+          <td>Commercial; free play is metered, longer sessions are paid</td>
         </tr>
         <tr>
           <td>Source code</td>
-          <td><span class="check">Fully open-source on GitHub</span></td>
-          <td><span class="cross">Closed-source</span></td>
+          <td><span class="check">Open source on GitHub (MIT)</span></td>
+          <td><span class="cross">Closed source</span></td>
         </tr>
         <tr>
-          <td>Interactive world map</td>
-          <td><span class="check">Shifting territory, borders, nations</span></td>
-          <td>Nation-based world map</td>
+          <td>Where it runs</td>
+          <td><span class="check">On your machine: desktop app, Android app, self-hosted server; browser demo</span></td>
+          <td>Hosted service in the browser</td>
         </tr>
         <tr>
-          <td>AI diplomacy</td>
-          <td><span class="check">Natural language chat with any nation</span></td>
-          <td>Fixed mechanics</td>
+          <td>The AI</td>
+          <td><span class="check">Your choice: Gemini, OpenAI, Anthropic, or a local model, with your own key</span></td>
+          <td>The developer's models, included in the service</td>
         </tr>
         <tr>
-          <td>AI intelligence briefings</td>
-          <td><span class="check">Full nation analysis on demand</span></td>
-          <td>Basic stats display</td>
+          <td>Plain-language actions and AI diplomacy chat</td>
+          <td><span class="check">Yes</span></td>
+          <td>Yes</td>
         </tr>
         <tr>
-          <td>AI-generated events</td>
-          <td><span class="check">Dynamic events based on world state</span></td>
-          <td>Preset events</td>
+          <td>Time skips with AI-written events</td>
+          <td><span class="check">6 hours to 1 year per skip</span></td>
+          <td>Yes</td>
         </tr>
         <tr>
-          <td>AI strategic advisor</td>
-          <td><span class="check">Real-time analysis and recommendations</span></td>
-          <td><span class="cross">Not available</span></td>
+          <td>AI advisor and intelligence briefings</td>
+          <td><span class="check">Built in</span></td>
+          <td>See their site</td>
         </tr>
         <tr>
-          <td>Vector map editor</td>
-          <td><span class="check">Full editor: draw, split, merge, paint</span></td>
-          <td>Limited or separate tool</td>
+          <td>Spies, troops and fronts on the map</td>
+          <td><span class="check">Built in</span></td>
+          <td>See their site</td>
         </tr>
         <tr>
-          <td>Scenario hub</td>
-          <td><span class="check">Browse, vote, import, publish scenarios</span></td>
-          <td><span class="cross">Not available</span></td>
+          <td>Map editor</td>
+          <td><span class="check">Full vector editor: draw, split, merge, paint owners, place cities</span></td>
+          <td>Custom maps and presets through its own tools</td>
         </tr>
         <tr>
-          <td>Custom scenario creation</td>
-          <td><span class="check">Full community scenario sharing</span></td>
-          <td>Limited</td>
+          <td>Sharing custom worlds</td>
+          <td><span class="check">Scenario Hub: browse, import, publish</span></td>
+          <td>Community presets on the service</td>
         </tr>
         <tr>
-          <td>Self-hosting</td>
-          <td><span class="check">Run your own server, fully offline</span></td>
-          <td><span class="cross">Client-server model</span></td>
-        </tr>
-        <tr>
-          <td>Platform support</td>
-          <td><span class="check">Windows, macOS, Linux, Android</span></td>
-          <td>Windows, macOS</td>
-        </tr>
-        <tr>
-          <td>Android app</td>
-          <td><span class="check">Thin client APK available</span></td>
-          <td><span class="cross">Not available</span></td>
-        </tr>
-        <tr>
-          <td>Modding</td>
-          <td><span class="check">Full source access, map editor, scenario system</span></td>
-          <td>Limited</td>
-        </tr>
-        <tr>
-          <td>Community governance</td>
-          <td><span class="check">Open-source, community-driven roadmap</span></td>
-          <td><span class="cross">Company-controlled</span></td>
+          <td>Your saves and data</td>
+          <td><span class="check">On your device; no account required</span></td>
+          <td>On the developer's servers, tied to your account</td>
         </tr>
         <tr>
           <td>Offline play</td>
-          <td><span class="check">Fully offline after installation</span></td>
-          <td>Requires connection</td>
+          <td><span class="check">Yes, with a local model</span></td>
+          <td><span class="cross">Requires their service</span></td>
+        </tr>
+        <tr>
+          <td>Platforms</td>
+          <td><span class="check">Windows, macOS, Linux, Android, browser demo</span></td>
+          <td>Browser</td>
+        </tr>
+        <tr>
+          <td>Modding</td>
+          <td><span class="check">Full source access, editable prompts, map editor, scenario system</span></td>
+          <td>Within the service's tools</td>
         </tr>
       </tbody>
     </table>
+    <p>Pax Historia's features and terms are the developer's to change; check <a href="https://www.paxhistoria.co/" target="_blank" rel="noopener">their site</a> for what is current. Open Historia is an independent project and is not affiliated with it.</p>
 
     <h2>Also a Free Alternative to Age of History 3</h2>
     <div class="card">
-      <p>Open Historia is also a great <span class="highlight">free alternative to Age of History 3</span> — another popular grand strategy title. Like Age of History, Open Historia features territory-based nation management, troop deployment, and historical scenarios. But it adds:</p>
+      <p>Open Historia is also a <span class="highlight">free alternative to Age of History 3</span>. Like Age of History, it features territory-based nation management, troop deployment, and historical scenarios. What it adds:</p>
       <ul>
-        <li>AI-powered diplomacy and natural language negotiation</li>
-        <li>An AI advisor that provides real-time strategic recommendations</li>
-        <li>A community scenario hub for sharing and discovering player-created worlds</li>
+        <li>AI-driven simulation: you act in plain language and the AI writes what happens next, instead of fixed mechanics</li>
+        <li>Natural-language negotiation with every nation's leader</li>
+        <li>An AI advisor for situation briefings and strategic advice</li>
+        <li>A community Scenario Hub for sharing and discovering player-made worlds</li>
         <li>Full vector map editing built directly into the game</li>
-        <li>Self-hosting — run your own server for multiplayer sessions</li>
       </ul>
-      <p>If you're looking for <strong>games like Age of History 3 but free</strong> or <strong>free games like Age of History</strong>, Open Historia is the top open-source option available.</p>
+      <p>If you are looking for <strong>games like Age of History 3 but free</strong>, Open Historia is the open-source option.</p>
     </div>
 
     <h2>Open Historia vs Other Grand Strategy Games</h2>
@@ -271,18 +190,18 @@
         <tbody>
           <tr>
             <td>Crusader Kings 3</td>
-            <td>Diplomacy, strategic advisor</td>
-            <td>CK3 is character-focused; Open Historia is nation-focused</td>
+            <td>Diplomacy, emergent stories</td>
+            <td>CK3 is character-focused with fixed mechanics; Open Historia is nation-focused and AI-narrated</td>
           </tr>
           <tr>
             <td>Europa Universalis 4</td>
             <td>Grand strategy, historical scope</td>
-            <td>Open Historia is free and open-source; EU4 requires purchase + DLC</td>
+            <td>Open Historia is free and open source; EU4 requires purchase plus DLC</td>
           </tr>
           <tr>
             <td>FreeCiv</td>
             <td>Open-source strategy game</td>
-            <td>FreeCiv is 4X/civilization-building; Open Historia is grand strategy with AI diplomacy</td>
+            <td>FreeCiv is 4X civilisation-building; Open Historia is grand strategy with AI diplomacy</td>
           </tr>
         </tbody>
       </table>
@@ -290,8 +209,8 @@
 
     <h2>Who Is Open Historia For?</h2>
     <div class="feature-grid">
-      <div class="feature-tag">Grand strategy enthusiasts looking for a free option</div>
-      <div class="feature-tag">Pax Historia players wanting more features without the price tag</div>
+      <div class="feature-tag">Grand strategy fans looking for a free option</div>
+      <div class="feature-tag">Pax Historia players who want unmetered play and their own AI</div>
       <div class="feature-tag">Modders and map creators who want full creative control</div>
       <div class="feature-tag">Self-hosters who want to run their own game server</div>
       <div class="feature-tag">Scenario creators and world-builders</div>
@@ -302,16 +221,16 @@
 
     <h2>How to Switch from Pax Historia</h2>
     <div class="step">
-      <strong>1. Download Open Historia for free</strong>
-      <p>No account, no payment, no registration. Just <a href="/get-started/">download and run the launcher</a> for your platform.</p>
+      <strong>1. Get Open Historia for free</strong>
+      <p>No account, no payment, no registration. <a href="/get-started/">Download the desktop app</a> for Windows, macOS or Linux, install the Android app, or try the browser demo.</p>
     </div>
     <div class="step">
-      <strong>2. Connect an AI backend (optional but recommended)</strong>
-      <p>Follow the <a href="/ai-setup/">AI setup guide</a> to enable AI diplomacy, events, and the strategic advisor. The game is playable without AI, but AI unlocks the full experience.</p>
+      <strong>2. Connect an AI provider</strong>
+      <p>Follow the <a href="/ai-setup/">AI setup guide</a>. The AI runs the world, so this is required — a free Gemini key is enough to start, and a local model keeps everything on your machine.</p>
     </div>
     <div class="step">
       <strong>3. Learn the mechanics</strong>
-      <p>Read the <a href="/how-to-play/">how to play guide</a> to get familiar with nation management, troop deployment, diplomacy, and the map editor.</p>
+      <p>Read the <a href="/how-to-play/">how to play guide</a>: the map, diplomacy, plain-language actions, troops, spies, time skips, and the map editor.</p>
     </div>
     <div class="step">
       <strong>4. Join the community</strong>
@@ -322,34 +241,34 @@
 
     <div class="card">
       <h3>Is Open Historia really free?</h3>
-      <p>Yes. Open Historia is <strong>completely free</strong> under the MIT license. No purchase, no microtransactions, no subscriptions, no ads. The source code is fully open on GitHub and always will be.</p>
+      <p>Yes. Open Historia is <strong>completely free</strong> under the MIT license: no purchase, no microtransactions, no subscription, no ads, no play-time limits. The one thing you supply is an AI provider — a free Gemini key or a local model costs nothing; paid providers charge you directly for what you use.</p>
     </div>
 
     <div class="card">
       <h3>Is Open Historia the same as Pax Historia?</h3>
-      <p>No. Open Historia is an <strong>independent project</strong> inspired by the grand strategy genre. It is not affiliated with Pax Historia Games. It's built from scratch as a community-driven, open-source alternative for players who want a free grand strategy experience with AI-powered diplomacy and a full map editor.</p>
+      <p>No. Open Historia is an <strong>independent, open-source project</strong> inspired by the same idea — AI-simulated alternate history — and is not affiliated with Pax Historia. It is built from scratch by its community for players who want that experience free, on their own machine, with their own AI, and with a full map editor.</p>
     </div>
 
     <div class="card">
       <h3>Can I play Open Historia offline?</h3>
-      <p>Yes. Once installed, Open Historia runs <strong>entirely offline</strong>. If you connect a local LLM (like Ollama or LM Studio), even AI features work without an internet connection. See the <a href="/self-hosting/">self-hosting guide</a>.</p>
+      <p>Yes. The desktop app runs the whole game on your machine, and with a local model (Ollama, LM Studio, or llama.cpp) even the AI runs without an internet connection. See the <a href="/ai-setup/">AI setup guide</a>.</p>
     </div>
 
     <div class="card">
       <h3>Is there an Android version?</h3>
-      <p>Yes. A <strong>thin client APK</strong> is available that connects to a running Open Historia server. Download it from the <a href="https://github.com/Open-Historia/open-historia/releases/tag/android" target="_blank" rel="noopener">Android release page</a>. The game logic runs on the server; the APK is a remote display client.</p>
+      <p>Yes. Download <code>open-historia.apk</code> from the <a href="https://github.com/Open-Historia/open-historia/releases/tag/android" target="_blank" rel="noopener">Android release</a>. It is the browser version packaged as an app: your games are saved on the phone and the world map is streamed from the community content nodes, so there is no server to run.</p>
     </div>
 
     <div class="card">
       <h3>Can I create and share my own scenarios?</h3>
-      <p>Yes. Use the <strong>full vector map editor</strong> to draw regions, place cities, set owners, and define starting conditions. Publish your scenario to the Scenario Hub from the in-game Community tab and share it with players worldwide.</p>
+      <p>Yes. Use the <strong>full vector map editor</strong> to draw regions, place cities, set owners, and define starting conditions, then publish the scenario to the Scenario Hub from the in-game Community tab.</p>
     </div>
 
     <h2>Ready to Play?</h2>
-    <p>Open Historia is the best free alternative to Pax Historia — with AI-powered diplomacy, a full map editor, community scenarios, and cross-platform play. All free, all open-source, all community-driven.</p>
+    <p>Open Historia is the free, open-source alternative to Pax Historia — AI-driven diplomacy and events, a full map editor, community scenarios, and apps for desktop and Android. Yours to run, yours to change.</p>
 
-    <a href="/get-started/" class="cta">Download and Play Free</a>
-    <a href="/" class="cta cta-secondary" style="margin-left: 0.75rem;">Play in Browser</a>
+    <a href="/get-started/" class="cta">Get Started for Free</a>
+    <a href="/" class="cta cta-secondary" style="margin-left: 0.75rem;">Try the Browser Demo</a>
 
     <footer>
       <p>Open Historia — free, open-source grand strategy game. <a href="https://github.com/Open-Historia/open-historia" target="_blank" rel="noopener">GitHub</a> · <a href="https://discord.gg/QaqAK7fQAg" target="_blank" rel="noopener">Discord</a> · <a href="/sitemap.xml">Sitemap</a></p>

--- a/public/self-hosting/index.html
+++ b/public/self-hosting/index.html
@@ -14,23 +14,23 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <meta name="theme-color" content="#0b1020" />
   <link rel="icon" type="image/jpeg" href="/logo.png" />
-  <title>Self-Hosting Open Historia — Run Your Own Grand Strategy Game Server Offline</title>
+  <title>Self-Hosting Open Historia — Run the Game Server Yourself</title>
   <link rel="canonical" href="https://openhistoria.com/self-hosting/" />
-  <meta name="description" content="Self-host Open Historia on your own machine. Run a private grand strategy game server for LAN play with friends, or play entirely offline. Complete guide for Windows, macOS, and Linux." />
+  <meta name="description" content="Run Open Historia's server yourself: build from source, play your saves from other devices on your network, play offline with a local model, the environment variables that control who can reach it, and running it as a service on Linux, Windows, and macOS." />
 
   <meta property="og:type" content="website" />
   <meta property="og:site_name" content="Open Historia" />
   <meta property="og:url" content="https://openhistoria.com/self-hosting/" />
-  <meta property="og:title" content="Self-Hosting Open Historia — Run Your Own Grand Strategy Game Server" />
-  <meta property="og:description" content="Self-host Open Historia on your own machine. Run a private grand strategy game server for LAN play with friends, or play entirely offline. Complete guide." />
+  <meta property="og:title" content="Self-Hosting Open Historia — Run the Game Server Yourself" />
+  <meta property="og:description" content="Build from source, play your saves from other devices on your network, play offline with a local model, and run the server as a service." />
   <meta property="og:image" content="https://raw.githubusercontent.com/Open-Historia/open-historia/main/public/loading_screen.jpg" />
   <meta property="og:image:type" content="image/jpeg" />
   <meta property="og:image:width" content="1280" />
   <meta property="og:image:height" content="720" />
 
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Self-Hosting Open Historia — Run Your Own Grand Strategy Game Server" />
-  <meta name="twitter:description" content="Self-host Open Historia on your own machine. Run a private server for friends, or play entirely offline. Complete guide for Windows, macOS, and Linux." />
+  <meta name="twitter:title" content="Self-Hosting Open Historia — Run the Game Server Yourself" />
+  <meta name="twitter:description" content="Build from source, play your saves from other devices on your network, play offline with a local model, and run the server as a service." />
   <meta name="twitter:image" content="https://raw.githubusercontent.com/Open-Historia/open-historia/main/public/loading_screen.jpg" />
 
   <link rel="stylesheet" href="/guides.css" />
@@ -40,25 +40,25 @@
     "@context": "https://schema.org",
     "@type": "HowTo",
     "name": "How to Self-Host Open Historia",
-    "description": "Step-by-step guide to self-host Open Historia, the free open-source grand strategy game, on your own server for LAN parties, remote play with friends, or offline single-player.",
+    "description": "Step-by-step guide to run the Open Historia game server yourself from source, reach it from other devices on your network, and run it as a service.",
     "step": [
       {
         "@type": "HowToStep",
         "position": "1",
-        "name": "Install Open Historia",
-        "text": "Clone the repository from GitHub, install dependencies, and download the map data using the automated launcher or manual setup."
+        "name": "Install from source",
+        "text": "With Git and Node.js 22 installed, clone the repository, run node scripts/fetch-map-assets.mjs to download the map data, then npm install and npm run build."
       },
       {
         "@type": "HowToStep",
         "position": "2",
         "name": "Start the server",
-        "text": "Run 'node server/server.js' to start the Express server on port 3000 (configurable via PORT environment variable)."
+        "text": "Run node server/server.js. The server listens on port 3000 (change it with the PORT environment variable) and the game is at http://localhost:3000."
       },
       {
         "@type": "HowToStep",
         "position": "3",
-        "name": "Connect players",
-        "text": "Share your local IP address or set up a domain. Players connect from browsers or the Android APK client."
+        "name": "Reach it from other devices",
+        "text": "In the current stable release the server answers on every network interface; newer builds answer only the local machine until you turn on Settings → Network → Let other devices connect, or start the server with OH_HOST=0.0.0.0. Other devices then open http://<your-ip>:3000 in a browser."
       }
     ]
   }
@@ -93,70 +93,108 @@
     <img class="logo" src="/logo.png" alt="Open Historia logo" width="64" height="64" />
 
     <h1>Self-Hosting Open Historia</h1>
-    <p class="tagline">Run your own grand strategy game server — completely offline, on your LAN, or accessible to friends over the internet.</p>
+    <p class="tagline">Run the game server yourself — from source on any machine with Node.js, on your own network, or entirely offline with a local model.</p>
 
-    <h2>Why Self-Host?</h2>
+    <h2>Do You Need This?</h2>
     <div class="card">
-      <p>Open Historia is a <span class="highlight">self-hosted grand strategy game</span> built on Node.js. There are no central game servers, no accounts, and no cloud dependencies — everything runs on your own machine.</p>
+      <p>Probably not. The <a href="/get-started/">desktop app</a> already runs the whole game — server included — on your own machine, with nothing else to install. Self-hosting from source is for when you want to:</p>
       <ul>
-        <li><strong>Offline play:</strong> No internet required after setup — play single-player anywhere.</li>
-        <li><strong>LAN parties:</strong> Host a server on your local network and friends connect from their browsers.</li>
-        <li><strong>Remote multiplayer:</strong> Forward a port or use a domain to play with friends across the internet.</li>
-        <li><strong>Full control:</strong> You control saves, scenarios, AI configuration, and who can connect.</li>
-        <li><strong>Privacy:</strong> No telemetry, no analytics, no accounts. Your game data stays on your machine.</li>
+        <li><strong>Run it on a machine without a desktop:</strong> a home server, a NAS, a Raspberry Pi, or a phone with Termux.</li>
+        <li><strong>Play from other devices:</strong> open your saves from a laptop, tablet, or phone browser on the same network.</li>
+        <li><strong>Hack on it:</strong> the source is MIT-licensed; this is how you run your own changes.</li>
       </ul>
+      <p>Whichever way you run it, Open Historia is <span class="highlight">local-first</span>: there is no central game server and no account. Your saves and scenarios live in the server's data directory on your machine, and your AI key goes only to the provider you configured.</p>
     </div>
 
-    <h2>Quick Setup: Self-Hosting in 3 Steps</h2>
+    <h2>Install and Run from Source</h2>
 
     <div class="step">
-      <strong>Step 1 — Install Open Historia</strong>
-      <p>First, <a href="/get-started/">get the game installed</a> on the machine that will act as your server. Use the launcher script for your platform, or follow the manual setup. The server machine needs Node.js — client players only need a browser or the Android APK.</p>
-    </div>
-
-    <div class="step">
-      <strong>Step 2 — Start the server</strong>
-      <p>In the project directory, run the launcher script for your platform:</p>
-      <ul>
-        <li><strong>Windows:</strong> run <code>Open-Historia-Setup.exe</code></li>
-        <li><strong>macOS:</strong> unzip and drag <strong>Open Historia</strong> to Applications</li>
-        <li><strong>Linux:</strong> <code>./launch-open-historia.sh</code></li>
-      </ul>
-      <p>The server will start on port 3000.</p>
+      <strong>Step 1 — Prerequisites</strong>
+      <p><a href="https://git-scm.com/" target="_blank" rel="noopener">Git</a> and <a href="https://nodejs.org/" target="_blank" rel="noopener">Node.js</a> 22 LTS or newer (20.19 is the minimum for the server and the client build).</p>
     </div>
 
     <div class="step">
-      <strong>Step 3 — Connect players</strong>
-      <p>Players connect by opening a browser and navigating to the server's address:</p>
+      <strong>Step 2 — Clone, fetch the map data, build</strong>
+      <pre><code>git clone https://github.com/Open-Historia/open-historia.git
+cd open-historia
+node scripts/fetch-map-assets.mjs   # downloads the world map data (about 275 MB)
+npm install
+npm run build</code></pre>
+      <p>On a server-only box (Termux, a NAS, anything headless) use <code>npm install --omit=dev --omit=optional</code> instead of <code>npm install</code>: it skips Electron and the desktop build chain, which are not needed to run the server.</p>
+    </div>
+
+    <div class="step">
+      <strong>Step 3 — Start the server</strong>
+      <pre><code>node server/server.js</code></pre>
+      <p>Then open <code>http://localhost:3000</code> in a browser. Set <code>PORT</code> to use another port. All state — saves, scenarios, editor documents, uploaded flags and basemaps — is plain files under <code>server/data/</code> (or wherever <code>OH_DATA_DIR</code> points); back that directory up and you have backed up everything.</p>
+    </div>
+
+    <h2>Playing from Other Devices</h2>
+    <div class="card">
+      <p>Any device on your network can play by opening the server's address in a browser — <code>http://192.168.x.x:3000</code>, using the server machine's local IP. The game loads from the server itself, so no extra configuration is needed on the client side. Everyone who connects sees and plays the same library of saves; there is no multiplayer mode and no accounts.</p>
+      <p>Whether the server answers other devices at all depends on the build:</p>
       <ul>
-        <li><strong>On the same machine:</strong> <code>http://localhost:3000</code></li>
-        <li><strong>On the same LAN:</strong> <code>http://192.168.x.x:3000</code> (use the server's local IP)</li>
-        <li><strong>From Android:</strong> Open the APK and enter the server address — it's remembered between sessions</li>
+        <li><strong>Current stable release:</strong> the server listens on every network interface as soon as it starts, so other devices can connect right away.</li>
+        <li><strong>Newer builds (the beta, and the source on the beta branch):</strong> the server answers only the machine it runs on until you turn on <strong>Settings → Network → "Let other devices connect"</strong>. It takes effect immediately, is remembered, and shows you the exact address to type on the other device. On a headless box, set <code>OH_HOST=0.0.0.0</code> instead (or one interface's address); that overrides the switch.</li>
       </ul>
-      <p>For remote play over the internet, you'll need to either:</p>
-      <ul>
-        <li>Forward port 3000 on your router, or</li>
-        <li>Use a service like Tailscale, ZeroTier, or ngrok to create a secure tunnel</li>
-      </ul>
+      <p><strong>The game's API has no password.</strong> While the server is reachable from the network, anyone on it can read, change, and delete your games and scenarios — fine on a home network you control, a bad idea on café, hotel, dorm, or office Wi-Fi. For remote play across the internet, put the machines on a private network with a tool such as Tailscale or ZeroTier rather than forwarding the port on your router.</p>
+      <p>The Android app does not connect to a self-hosted server: it is the browser version packaged as an app, streaming the map from the community content nodes with its games on the phone. A phone plays your self-hosted saves through its browser instead.</p>
+    </div>
+
+    <h2>Environment Variables</h2>
+    <div class="card">
+      <table class="comparison-table">
+        <thead>
+          <tr>
+            <th>Variable</th>
+            <th>Default</th>
+            <th>What it does</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>PORT</code></td>
+            <td><code>3000</code></td>
+            <td>The port the server listens on.</td>
+          </tr>
+          <tr>
+            <td><code>OH_DATA_DIR</code></td>
+            <td><code>server/data</code></td>
+            <td>Where saves, scenarios, and everything else is stored.</td>
+          </tr>
+          <tr>
+            <td><code>OH_HOST</code></td>
+            <td>unset</td>
+            <td>Newer builds: which interface to listen on. <code>0.0.0.0</code> means every device on the network; an address means that interface only. Overrides and locks the Settings → Network switch.</td>
+          </tr>
+          <tr>
+            <td><code>OH_ALLOW_REMOTE_RELAY</code></td>
+            <td>off</td>
+            <td>Newer builds: lets other devices use this server's AI relay (the fallback for local AI backends without CORS headers). Off means the relay answers this machine only, so nobody else on the network can use it as a proxy.</td>
+          </tr>
+          <tr>
+            <td><code>OH_RATE_LIMIT</code></td>
+            <td><code>1200</code></td>
+            <td>Newer builds: requests per minute per network client (the local machine is exempt).</td>
+          </tr>
+          <tr>
+            <td><code>OH_ALLOW_CROSS_ORIGIN</code></td>
+            <td>off</td>
+            <td>Disables the cross-origin write guard. Only needed when the game's pages are served from a different origin than the API (for example a separate web server in front of it). Devices that load the game from this server itself never need it.</td>
+          </tr>
+        </tbody>
+      </table>
     </div>
 
     <h2>Going Offline</h2>
     <div class="card">
-      <p>Once installed and built, Open Historia runs <span class="highlight">entirely offline</span> — no internet connection needed. The game logic, map rendering, scenario data, and the entire UI are all local.</p>
-      <p>Connecting an AI backend for diplomacy and events requires a local LLM (see the <a href="/ai-setup/">AI setup guide</a>), but the game is fully playable without AI as a pure strategy sandbox with the map editor and scenario system.</p>
-    </div>
-
-    <h2>CORS Configuration</h2>
-    <div class="card">
-      <p>By default, the server only accepts write operations (save, create, delete) from the same origin. If you're connecting from a different device on the network, set the environment variable to allow cross-origin requests:</p>
-      <pre><code>OH_ALLOW_CROSS_ORIGIN=1 node server/server.js</code></pre>
-      <p>This is safe for LAN and private networks. For public internet hosting, consider putting the server behind a reverse proxy like nginx or Caddy.</p>
+      <p>Once the map data is downloaded, the server, the map, the scenarios, and the editor all run <span class="highlight">without an internet connection</span>. Playing offline additionally needs an AI that runs offline: a local model through Ollama, LM Studio, or llama.cpp (see the <a href="/ai-setup/">AI setup guide</a>). Without any AI provider the world cannot advance — you can build and edit maps, but not play a turn.</p>
     </div>
 
     <h2>Running as a Service</h2>
     <div class="card">
       <h3>Linux (systemd)</h3>
-      <p>Create a systemd service file at <code>/etc/systemd/system/open-historia.service</code>:</p>
+      <p>Create <code>/etc/systemd/system/open-historia.service</code>:</p>
       <pre><code>[Unit]
 Description=Open Historia Game Server
 After=network.target
@@ -168,22 +206,24 @@ WorkingDirectory=/path/to/open-historia
 ExecStart=/usr/bin/node server/server.js
 Restart=on-failure
 Environment=PORT=3000
+# Newer builds answer only the local machine unless told otherwise:
+Environment=OH_HOST=0.0.0.0
 
 [Install]
 WantedBy=multi-user.target</code></pre>
-      <p>Then enable and start: <code>sudo systemctl enable --now open-historia</code></p>
+      <p>Then enable and start it: <code>sudo systemctl enable --now open-historia</code></p>
 
       <h3>Windows (Task Scheduler)</h3>
-      <p>Use Task Scheduler to run <code>node server/server.js</code> at system startup with the "Run whether user is logged on or not" option.</p>
+      <p>Create a task that runs <code>node server\server.js</code> in the project directory at startup, with "Run whether user is logged on or not". Set any environment variables in the task's action, or in a small <code>.cmd</code> wrapper.</p>
 
       <h3>macOS (launchd)</h3>
-      <p>Create a plist file in <code>~/Library/LaunchAgents/</code> to run the server as a background daemon.</p>
+      <p>Create a plist in <code>~/Library/LaunchAgents/</code> whose program arguments run <code>node server/server.js</code> with the project directory as the working directory, and load it with <code>launchctl</code>.</p>
     </div>
 
     <h2>Related Guides</h2>
     <ul>
-      <li><a href="/get-started/">Get Started — installation and setup for all platforms</a></li>
-      <li><a href="/ai-setup/">Connect an AI Backend — enable AI-powered diplomacy and events</a></li>
+      <li><a href="/get-started/">Get Started — the desktop app, the Android app, the browser demo, and your first game</a></li>
+      <li><a href="/ai-setup/">Connect an AI provider — including local models for offline play</a></li>
       <li><a href="/how-to-play/">How to Play — gameplay mechanics and controls</a></li>
     </ul>
 

--- a/public/sitemap/index.html
+++ b/public/sitemap/index.html
@@ -33,22 +33,22 @@
 
     <h2>Main</h2>
     <ul>
-      <li><a href="/">Homepage</a> — Play Open Historia in your browser</li>
+      <li><a href="/">Homepage</a> — Downloads for Windows, macOS, Linux and Android, and the browser demo</li>
     </ul>
 
     <h2>Guides</h2>
     <ul>
-      <li><a href="/guides/">Guides Hub</a> — Overview of all guides: get started, gameplay, AI setup, self-hosting, and Pax Historia comparison</li>
-      <li><a href="/get-started/">Get Started</a> — Download and install on Windows, macOS, Linux, or Android</li>
-      <li><a href="/how-to-play/">How to Play</a> — Gameplay guide: map, diplomacy, combat, map editor, scenarios</li>
-      <li><a href="/self-hosting/">Self-Hosting Guide</a> — Run your own server for LAN, offline, or remote play</li>
-      <li><a href="/ai-setup/">AI Setup Guide</a> — Connect a local LLM for AI diplomacy, events, and advisor</li>
+      <li><a href="/guides/">Guides Hub</a> — Overview of all guides: get started, how to play, AI setup, self-hosting, and the Pax Historia comparison</li>
+      <li><a href="/get-started/">Get Started</a> — The desktop app, the Android app and the browser demo; connecting an AI provider; your first game</li>
+      <li><a href="/how-to-play/">How to Play</a> — The map, diplomacy, actions, events, advisor, spies, troops, time skips, the map editor, and the Scenario Hub</li>
+      <li><a href="/self-hosting/">Self-Hosting Guide</a> — Build from source, play from other devices on your network, run offline with a local model, run as a service</li>
+      <li><a href="/ai-setup/">AI Setup Guide</a> — Connect Gemini, OpenAI, Anthropic, a local model, or an OpenAI-compatible API</li>
     </ul>
 
 
     <h2>Comparisons</h2>
     <ul>
-      <li><a href="/pax-historia-alternative/">Pax Historia Alternative</a> — Feature comparison vs Pax Historia and Age of History 3</li>
+      <li><a href="/pax-historia-alternative/">Pax Historia Alternative</a> — How Open Historia compares to Pax Historia and other strategy games</li>
     </ul>
 
     <h2>For Crawlers</h2>


### PR DESCRIPTION
The Get Started page and the guides under `public/` (served at openhistoria.com/get-started/, /guides/, /how-to-play/, /ai-setup/, /self-hosting/, /pax-historia-alternative/ and /sitemap/, and shipped inside the desktop app) described a game that does not exist. Every page is rewritten against the code, the release workflows and the README. Same content as beta (merged there directly).

**What was wrong, and what the pages say now**

- **Get Started** claimed a browser-first game with a *Multiplayer* menu entry, joinable lobby links and "turns processed simultaneously", a *Load Game* button, and AI as an optional extra. Now: the three real ways to play (desktop installers under `desktop-stable`, the browser demo that streams the map from content nodes with its optional Google sign-in, and the Android APK, which is the web build packaged with Capacitor); the AI provider is required; the walkthrough follows the real flow (Games / Scenarios / Community tabs → New Game → country picker → difficulty → country panel → Actions → time skips of 6 hours to 1 year). Single-player, stated as such.
- **How to Play** said events "present choices", combat is resolved by "terrain", and the loop is "end your turn". Now: the Actions panel, spies and time skips are described; events, troops and the loop as they work; the map editor's entry points, the ~70k place database and the six official hub presets kept (all verified present on the hub), with the newer community scenarios beside them.
- **AI Setup** listed retired model names as defaults, claimed the game "checks connectivity on load", and said the relay "handles CORS automatically" everywhere. Now: the five provider types and defaults exactly as `providerConfig.js` has them (`gemini-3.5-flash-lite`, `claude-haiku-4-5`, OpenAI model discovery, `http://localhost:11434/v1`); the relay as it works — direct first, the game server's same-origin relay only when the page is served locally, never on openhistoria.com, where Ollama needs `OLLAMA_ORIGINS`; what a local model needs (a large context window, a mid-sized instruct model at least).
- **Self-Hosting** told people to run `./launch-open-historia.sh`, promised "LAN parties" and "remote multiplayer", said the game is "fully playable without AI as a pure strategy sandbox", and misdescribed `OH_ALLOW_CROSS_ORIGIN`. Now: the README's build-from-source steps; the stable release listens on every interface while newer builds are loopback-only until Settings → Network or `OH_HOST`; the API has no password; the cross-origin variable is only for a client served from another origin; offline play needs a local model; the Android app does not connect to a self-hosted server.
- **Pax Historia comparison** called the other game preset-driven with "fixed mechanics", no scenario sharing, and Windows/macOS only. It is an AI-driven natural-language sandbox in the browser with community presets, so the page now compares the two on what is actually different: free and unmetered, MIT open source, runs on your machine with your own AI or a local model, local saves, a vector map editor, desktop and Android apps.
- **Guides index** and **Sitemap** cards updated to match.

The site redeploys from `main` on merge (`deploy-site.yml`).
