### PR TITLE
Site: the Linux .deb download pointed at a name the build never produces

### DIFF
--- a/.github/workflows/desktop-installer.yml
+++ b/.github/workflows/desktop-installer.yml
@@ -130,7 +130,7 @@ jobs:
             "windows": "$B/Open-Historia-Setup.exe",
             "mac": "$B/Open-Historia-mac-arm64.zip",
             "linux": "$B/Open-Historia-x86_64.AppImage",
-            "linuxDeb": "$B/open-historia_amd64.deb"
+            "linuxDeb": "$B/Open-Historia-amd64.deb"
           }
           JSON
             files+=(latest.json)

--- a/site/index.html
+++ b/site/index.html
@@ -353,7 +353,7 @@
       </div>
       <div class="tab-body on" data-os="windows">Run <b>Open-Historia-Setup.exe</b> and follow the installer, then open <b>Open Historia</b> from the Start Menu. If Windows SmartScreen warns, choose <span class="kbd">More info → Run anyway</span> — the installer isn't code-signed yet.</div>
       <div class="tab-body" data-os="mac">Unzip the download and drag <b>Open Historia</b> into your Applications folder. The first time, right-click it and choose <span class="kbd">Open</span> — the app isn't code-signed yet, so macOS asks for confirmation once. If it says the app is <b>damaged</b> instead, macOS quarantined the download — clear it with <span class="kbd">xattr -dr com.apple.quarantine "/Applications/Open Historia.app"</span> and open it again.</div>
-      <div class="tab-body" data-os="linux">On Debian, Ubuntu and derivatives install the <b>.deb</b> (<span class="kbd">sudo apt install ./open-historia_amd64.deb</span>) — it lands in your applications menu like any other program. Otherwise use the AppImage: <span class="kbd">chmod +x Open-Historia-x86_64.AppImage</span> and run it, nothing installed system-wide.</div>
+      <div class="tab-body" data-os="linux">On Debian, Ubuntu and derivatives install the <b>.deb</b> (<span class="kbd">sudo apt install ./Open-Historia-amd64.deb</span>) — it lands in your applications menu like any other program. Otherwise use the AppImage: <span class="kbd">chmod +x Open-Historia-x86_64.AppImage</span> and run it, nothing installed system-wide.</div>
     </div>
   </section>
 
@@ -384,7 +384,7 @@
         <h3>Linux</h3>
         <div class="meta">.deb for Debian &amp; Ubuntu · x86_64 · AppImage for other distros</div>
         <p>One portable file that runs on essentially any distribution. Make it executable and launch it — nothing to install, no packages to add.</p>
-        <a class="btn btn-ghost" href="https://github.com/Open-Historia/open-historia/releases/download/desktop-stable/open-historia_amd64.deb">⬇ Download .deb</a>
+        <a class="btn btn-ghost" href="https://github.com/Open-Historia/open-historia/releases/download/desktop-stable/Open-Historia-amd64.deb">⬇ Download .deb</a>
         <a class="hero-note" style="display:block;margin-top:0.6rem;font-size:0.85rem" href="https://github.com/Open-Historia/open-historia/releases/download/desktop-stable/Open-Historia-x86_64.AppImage">Not on Debian or Ubuntu? Get the AppImage instead.</a>
       </div>
       <div class="card">
@@ -505,7 +505,7 @@
   var WIN = "https://github.com/Open-Historia/open-historia/releases/download/desktop-stable/Open-Historia-Setup.exe";
   // The .deb: it installs to /opt with a root-owned chrome-sandbox, so Chromium's
   // sandbox works instead of being switched off (the AppImage cannot, see #658).
-  var LINUX = "https://github.com/Open-Historia/open-historia/releases/download/desktop-stable/open-historia_amd64.deb";
+  var LINUX = "https://github.com/Open-Historia/open-historia/releases/download/desktop-stable/Open-Historia-amd64.deb";
   var href = (os === "android") ? APK
            : (os === "windows") ? WIN
            : (os === "linux") ? LINUX


### PR DESCRIPTION
The landing page's "Download .deb" button, the per-OS download script and the Linux tab's install line all named the asset `open-historia_amd64.deb` (electron-builder's default deb pattern), but `package.json` sets `artifactName` to `Open-Historia-${arch}.${ext}`, so the file on the `desktop-stable` release is `Open-Historia-amd64.deb` (`latest-linux.yml` on the release says the same). GitHub answered the link with a 404. The Windows and AppImage links kept working because release asset URLs are matched case-insensitively.

The stable installer workflow wrote the same wrong name into `latest.json`'s `linuxDeb` field; corrected there too. Same fix merged on `beta`.
