### PR TITLE
Move the workflows off the Node 20 action runtime

### DIFF
--- a/.github/workflows/android-apk-beta.yml
+++ b/.github/workflows/android-apk-beta.yml
@@ -19,15 +19,15 @@ jobs:
     steps:
       # Always build the node-server code, which lives on `alpha`, regardless of
       # which branch this workflow is dispatched from.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: alpha
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"
@@ -75,7 +75,7 @@ jobs:
       - name: Collect
         run: cp mobile/android/app/build/outputs/apk/debug/app-debug.apk pax-historia.apk
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: pax-historia-apk-beta
           path: pax-historia.apk

--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -23,13 +23,13 @@ jobs:
   apk:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: "21"
@@ -59,7 +59,7 @@ jobs:
       - name: Collect
         run: cp mobile/android/app/build/outputs/apk/debug/app-debug.apk open-historia.apk
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: open-historia.apk
           path: open-historia.apk

--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -39,9 +39,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 24
           cache: npm
@@ -68,7 +68,7 @@ jobs:
           echo "No oversized files. dist-site is $(du -sh dist-site | cut -f1)."
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/desktop-installer.yml
+++ b/.github/workflows/desktop-installer.yml
@@ -35,9 +35,9 @@ jobs:
             args: --linux
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: npm
@@ -89,7 +89,7 @@ jobs:
           CSC_IDENTITY_AUTO_DISCOVERY: false
 
       - name: Upload as a build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: open-historia-${{ matrix.os }}
           # Only the finished installers; release/ also holds the unpacked app tree.


### PR DESCRIPTION
GitHub forces actions that declare `node20` onto `node24` and warns about it; they stop running once node20 leaves the runners. Every workflow on `main` was on the old pins, which is why the deploy run's annotation named three at once.

**These versions are not a fresh choice** — `beta` already runs exactly these, so this is that toolchain fix reaching `main` early. Bumping only the pins, rather than taking beta's files wholesale, keeps the change to the 14 lines that matter and means these lines already agree when beta merges.

| | | |
|---|---|---|
| `actions/checkout` | v4 → **v5** | node24 |
| `actions/setup-node` | v4 → **v5** | node24 |
| `actions/setup-java` | v4 → **v5** | node24 |
| `actions/upload-artifact` | v4 → **v6** | node24 |
| `cloudflare/wrangler-action` | v3 → **v4** | node24 |

Diff is 14 lines, all version pins. No inputs changed.

### Risk, and how it was checked

`checkout@v5`, `setup-node@v5` and `upload-artifact@v6` already run green in this repo in `desktop-beta.yml`, so those carry no new risk.

**`wrangler-action@v4` is the one that does.** Its only breaking change is that it installs Wrangler v4 by default instead of v3. `pages deploy` is unchanged in v4, but the failure mode if it were not is nasty — a green run that quietly publishes a *preview* and leaves openhistoria.com on the old build. So it was verified against the live site from this branch before merging, not after:

- Dispatched `deploy-site.yml` from `site-actions-node24` (run [34277958134](https://github.com/Open-Historia/open-historia/actions/runs/34277958134)) — site content identical to `main`, only the pins differ.
- **Succeeded.** Node 24.20.0, `⛅️ wrangler 4.130.0`, command ran as `wrangler pages deploy dist-site --project-name=open-historia --branch=main` with the production flag intact, 109 files uploaded, `✨ Deployment complete!`
- **Annotations: none.** The previous run (`34277337678`) carries `warning: Node.js 20 is deprecated…`; this one carries nothing.
- openhistoria.com returns HTTP 200 and serves the expected page.

### Not covered here

`android-apk.yml` still requests `node-version: 20` for the build itself. That is the *job's* Node, a separate question from the action runtime, and it is already answered differently on `beta` — left alone so this stays a one-axis change.