### PR TITLE
Say AGPL-3.0 where the site and the package still said MIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@
   </a>
   <!-- License -->
   <a href="LICENSE">
-    <img src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square"
-      alt="License: MIT" />
+    <img src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg?style=flat-square"
+      alt="License: AGPL-3.0" />
   </a>
   <!-- Status -->
   <a href="#">

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "appId": "io.github.arkniem.openhistoria",
     "productName": "Open Historia",
     "files": [
+      "LICENSE",
       "dist/**",
       "server/**",
       "electron/**",

--- a/site/index.html
+++ b/site/index.html
@@ -47,7 +47,7 @@
     "name": "Open Historia",
     "url": "https://github.com/Open-Historia"
   },
-  "license": "https://opensource.org/licenses/MIT"
+  "license": "https://www.gnu.org/licenses/agpl-3.0.html"
 }
 </script>
 <script type="application/ld+json">
@@ -411,7 +411,7 @@
       <div class="feat"><div class="fi">🌐</div><h4>Scenario hub</h4><p>Browse and import community scenarios in-game, or publish your own.</p></div>
       <div class="feat"><div class="fi">🦉</div><h4>Strategy advisor</h4><p>Consult an AI advisor for guidance, economic analysis, and situation briefings.</p></div>
       <div class="feat"><div class="fi">🔒</div><h4>Runs on your machine</h4><p>Self-hostable and local-first — it runs at localhost, with your own AI backend.</p></div>
-      <div class="feat"><div class="fi">⚖️</div><h4>Free &amp; open source</h4><p>MIT-licensed and community-built. Fork it, mod it, make it yours.</p></div>
+      <div class="feat"><div class="fi">⚖️</div><h4>Free &amp; open source</h4><p>AGPL-3.0 licensed and community-built. Fork it, mod it, ship it — as long as your changes stay open too.</p></div>
     </div>
   </section>
 
@@ -450,7 +450,7 @@
     <div class="rule"></div>
     <div class="faq">
       <details><summary>Do I need to install anything else?</summary><p>Just <b>Node.js</b>, and the launcher offers to install it for you if it's missing (via winget on Windows, Homebrew on macOS, or your package manager on Linux). Everything else — including all map data — ships inside the download.</p></details>
-      <details><summary>Is it really free?</summary><p>Yes. Open Historia is free and open source under the MIT license. The AI features connect to an AI backend you configure — see the <a href="https://github.com/Open-Historia/open-historia#readme" target="_blank" rel="noopener">README</a> or ask in <a href="https://discord.gg/QaqAK7fQAg" target="_blank" rel="noopener">Discord</a> for setup help.</p></details>
+      <details><summary>Is it really free?</summary><p>Yes. Open Historia is free and open source under the GNU AGPL v3. The AI features connect to an AI backend you configure — see the <a href="https://github.com/Open-Historia/open-historia#readme" target="_blank" rel="noopener">README</a> or ask in <a href="https://discord.gg/QaqAK7fQAg" target="_blank" rel="noopener">Discord</a> for setup help.</p></details>
       <details><summary>Where does it run — is my data uploaded?</summary><p>The game runs locally on your own machine and opens in your browser at <code>localhost:3000</code>. Your saves and scenarios stay on your computer.</p></details>
       <details><summary>How do I update later?</summary><p>Run the <b>Update Open Historia</b> script that comes with your install — it fetches the latest version while preserving your saves, scenarios, and map data. You can choose the Stable or Beta channel when updating.</p></details>
       <details><summary>What about mobile?</summary><p>Download the Android APK and open it — that is the whole setup. Your games live on the phone and the world map is kept there after it downloads the first time, so there is no server to run and nothing to point it at.</p></details>
@@ -472,7 +472,7 @@
 
 <footer>
   <div class="wrap foot">
-    <div><span class="globe">🏛️</span> <b>Open Historia</b> · MIT licensed · built by <a href="https://github.com/Open-Historia/open-historia/graphs/contributors" target="_blank" rel="noopener">contributors</a></div>
+    <div><span class="globe">🏛️</span> <b>Open Historia</b> · AGPL-3.0 licensed · built by <a href="https://github.com/Open-Historia/open-historia/graphs/contributors" target="_blank" rel="noopener">contributors</a></div>
     <div class="fnav">
       <a href="#download">Download</a>
       <a href="https://github.com/Open-Historia/open-historia-node" target="_blank" rel="noopener">Host a node</a>


### PR DESCRIPTION
`1c66fb5` replaced the root `LICENSE` with the GNU AGPL v3, but everything that **tells** anyone the licence still said MIT — so the site advertised one licence while the repository shipped another.

| | |
|---|---|
| `site/index.html` | schema.org `"license"` (what search engines index), the "Free & open source" card, the FAQ answer, the footer |
| `README.md` | the shields.io badge |
| `package.json` | `build.files` gains `LICENSE` |

The feature card is **reworded, not relabelled**. "Fork it, mod it, make it yours" was accurate under MIT and misleading under a copyleft licence; it now says changes stay open too.

### The app never shipped a licence at all

`LICENSE` was not in `build.files`, so every installed copy of the game went out with no licence text. The AGPL expects it to travel with the work, and the next desktop update is the first build that will carry it.

Verified rather than assumed — packed the app and read the asar header back:

```
top-level entries in app.asar: node_modules, LICENSE, dist, electron, package.json, public, scripts, server
LICENSE present: true
LICENSE size in asar: 34523 bytes
```

The same change is already on `beta` (`db8c074`), where `electron-builder.beta.yml` needed it too — that config *replaces* package.json's block rather than extending it, and `server/betaPackaging.test.js` asserts the two lists match, so they cannot drift apart.

### ⚠️ Deliberately not changed — needs your decision

**The repository currently states two different licences.**

- Root `LICENSE` → **AGPL-3.0**
- `src/Editor/LICENSE` → still the **MIT** text
- **146 source files** carry a header reading `MIT (see src/Editor/LICENSE)` — and that is the licence a reader reaches from almost any source file in the project, including `server/` and `src/Game/`, not just the editor

Rewriting those is a licensing decision, not a find-and-replace, so I stopped here. Two readings, and they need different work:

1. **Everything is AGPL** — `src/Editor/LICENSE` gets replaced too and all 146 headers are rewritten. One scripted pass; I can do it on both branches.
2. **The map editor stays MIT deliberately** (so it can be reused), and the AGPL covers the game — then the headers on non-editor files are simply wrong and need to point somewhere else, and the split should be stated in the README.

Also worth settling: `package.json` has no `license` field. I left it out rather than guess between `AGPL-3.0-only` and `AGPL-3.0-or-later` — the LICENSE text alone does not state a version policy.