### PR TITLE
Stats waits for the pregame backstory instead of racing it

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -834,6 +834,19 @@ const beginSimulation = () => { activeSimulations += 1; };
 const endSimulation = () => { activeSimulations = Math.max(0, activeSimulations - 1); };
 export const isSimulationBusy = () => activeSimulations > 0;
 
+// Out-of-turn writers wait for the simulation to go idle before they read the
+// world or call the model. A jump, or the pregame backstory, reads the world,
+// works for minutes and writes it back; anything computed alongside it either
+// describes a world that is about to change or races its write. Ported from
+// beta, where the intelligence and stat-sheet first readings already use it.
+const waitForSimulationIdle = async ({ timeoutMs = 10 * 60 * 1000 } = {}) => {
+  const startedAt = Date.now();
+  while (isSimulationBusy()) {
+    if (Date.now() - startedAt > timeoutMs) throw new Error("The simulation stayed busy.");
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+};
+
 const resolveInvitees = async (names, world, additionalCountries = []) => {
   const countryCatalog = [
     ...mergePolityCatalog(await loadCountryNames(), world),
@@ -2126,6 +2139,11 @@ export const refreshSpyIntercepts = async () => {
 // Structured national stat sheet for the Stats tab, grounded in the same
 // campaign context as the intelligence briefing.
 export const generateCountryStatSheet = async ({ code, name } = {}) => {
+  // Issue #724: wait out any running simulation before reading the world.
+  // The Stats pane calls this directly, so on a fresh game it used to run a
+  // second AI call beside the pregame backstory, and build the sheet from a
+  // world with no history in it yet.
+  await waitForSimulationIdle();
   const bundle = await readGameStateBundle({ force: true });
   const variables = await buildTemplateVariables(bundle);
   const target = name || code || "the polity";
@@ -2624,16 +2642,22 @@ const validatePregameEvents = (candidate, { startDate, strict }) => {
 // writes doubles as the done-marker, so it can never run twice.
 export const maybeGeneratePregameHistory = async () => {
   if (isSimulationBusy()) return null;
-  const bundle = await readGameStateBundle({ force: true });
-  const briefing = normalizeString(bundle.world.startingTimelineText);
-  if (!briefing) return null;
-  if (normalizeEvents(bundle.events).length > 0) return null;
-  if ((normalizeWorldState(bundle.world).simulationHistory ?? []).length > 0) return null;
-  const startDate = normalizeString(bundle.game.startDate || bundle.game.gameDate);
-  if (!startDate) return null;
-
+  // Issue #724: take the lock before the first read, not after it. It used to
+  // be taken only once the bundle had been read and checked, so for the length
+  // of that read the backstory was under way while the lock still said idle —
+  // and a Stats pane already open as a fresh game loaded started its own AI
+  // call in the gap. The "nothing to do" returns below all pass through the
+  // finally, which is what makes holding the lock across them safe.
   beginSimulation();
   try {
+    const bundle = await readGameStateBundle({ force: true });
+    const briefing = normalizeString(bundle.world.startingTimelineText);
+    if (!briefing) return null;
+    if (normalizeEvents(bundle.events).length > 0) return null;
+    if ((normalizeWorldState(bundle.world).simulationHistory ?? []).length > 0) return null;
+    const startDate = normalizeString(bundle.game.startDate || bundle.game.gameDate);
+    if (!startDate) return null;
+
     const variables = await buildTemplateVariables(bundle);
     const { payload } = await runJsonTask("pregameHistory", {
       timeoutMs: getMapSetting(MAP_SETTING_KEYS.limitAiGeneration) ? 300000 : 0,

--- a/src/Game/AI/pregameStatsOrdering.test.js
+++ b/src/Game/AI/pregameStatsOrdering.test.js
@@ -1,0 +1,95 @@
+/*! Open Historia — stats-after-pregame ordering tests © 2026 Nicholas Krol, AGPL-3.0-or-later (see LICENSE). */
+// Run: node --test src/Game/AI/pregameStatsOrdering.test.js
+//
+// Issue #724: opening the Stats pane on a fresh game while its pregame
+// backstory was still generating ran a second AI call alongside it — an error
+// for players whose provider refuses concurrent requests — and computed the
+// national baseline from a world with no history in it yet, which then
+// persisted as campaign canon.
+//
+// Two orderings fix it, and each is one misplaced line from coming undone, so
+// both are pinned here:
+//
+//   1. generateCountryStatSheet waits for the simulation to go idle before it
+//      reads the world or calls the model. The Stats pane calls it DIRECTLY,
+//      not through ensureCountryStatSheet, so the wait has to live inside it.
+//   2. maybeGeneratePregameHistory takes the lock before its first read. It
+//      used to check the lock, read a whole bundle, and only then take it — so
+//      anything that looked in between saw "idle" while the backstory was
+//      already under way.
+//
+// gameplay.js pulls in the whole JSX chain and cannot be imported by
+// `node --test`, so these read its source instead — the same trade
+// server/desktopPortProbe.test.js makes with electron/main.cjs.
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+const source = fs.readFileSync(new URL("./gameplay.js", import.meta.url), "utf8");
+
+// One top-level function's CODE: from its declaration to the next declaration
+// at column 0, with whole-line comments removed. Without that, the comment
+// explaining this very fix — which says "first await" — sat above
+// beginSimulation() and failed the ordering check it was describing.
+const bodyOf = (name) => {
+  const start = source.indexOf(`export const ${name} = async`);
+  assert.notEqual(start, -1, `${name} is no longer in gameplay.js`);
+  const rest = source.slice(start + 1);
+  const next = rest.search(/\n(?:export )?const [A-Za-z_$][\w$]* = /);
+  const text = next === -1 ? source.slice(start) : source.slice(start, start + 1 + next);
+  return text.split(/\r?\n/).filter((line) => !line.trim().startsWith("//")).join("\n");
+};
+
+test("the idle wait exists at all", () => {
+  // Main never had it; this is the port. Everything below relies on it.
+  assert.match(source, /const waitForSimulationIdle = async/);
+});
+
+test("a stat sheet waits for the simulation before reading or asking anything", () => {
+  const body = bodyOf("generateCountryStatSheet");
+  const wait = body.indexOf("await waitForSimulationIdle(");
+  assert.notEqual(wait, -1, "generateCountryStatSheet no longer waits for the simulation to go idle");
+
+  // The world it reads is the world the sheet is built from. Read before the
+  // wait and the sheet describes the game as it was before the backstory.
+  const firstRead = body.search(/await read[A-Za-z]+\(/);
+  assert.notEqual(firstRead, -1, "could not find the world read in generateCountryStatSheet");
+  assert.ok(wait < firstRead, "the world is read before the idle wait — the sheet would describe a stale world");
+
+  const ask = body.indexOf("runJsonTask(");
+  assert.notEqual(ask, -1, "could not find the model call in generateCountryStatSheet");
+  assert.ok(wait < ask, "the model is asked before the idle wait — two AI calls would run at once");
+
+  // Exactly once. Twice is harmless at runtime but means a patch was applied
+  // over itself, which is exactly how the first attempt at this fix went wrong.
+  assert.equal(body.split("await waitForSimulationIdle(").length - 1, 1, "the idle wait appears more than once");
+});
+
+test("pregame history takes the lock before its first await", () => {
+  const body = bodyOf("maybeGeneratePregameHistory");
+  const check = body.indexOf("if (isSimulationBusy()) return null;");
+  const take = body.indexOf("beginSimulation();");
+  const firstAwait = body.search(/\bawait\b/);
+  assert.notEqual(check, -1, "pregame no longer refuses to start while something else is running");
+  assert.notEqual(take, -1, "pregame no longer takes the simulation lock");
+  assert.notEqual(firstAwait, -1, "pregame no longer awaits anything — this test is out of date");
+
+  assert.ok(check < take, "the lock is taken before checking whether it is free");
+  assert.ok(take < firstAwait, "an await runs before the lock is taken — anything looking in that gap sees idle");
+});
+
+test("every way out of pregame history releases the lock", () => {
+  // Taking the lock earlier moved the "nothing to do" returns inside the try.
+  // They are only safe because the finally releases it; without one, the first
+  // game opened with no backstory to write would lock the simulation for good.
+  const body = bodyOf("maybeGeneratePregameHistory");
+  const take = body.indexOf("beginSimulation();");
+  const tryAt = body.indexOf("try {", take);
+  assert.notEqual(tryAt, -1, "no try follows beginSimulation()");
+  assert.ok(
+    body.slice(take, tryAt).trim() === "beginSimulation();",
+    "code runs between taking the lock and the try that guarantees its release",
+  );
+  assert.match(body.slice(tryAt), /finally\s*\{\s*endSimulation\(\);\s*\}/, "the lock is not released in a finally");
+});

--- a/src/Game/GameUI/stats.jsx
+++ b/src/Game/GameUI/stats.jsx
@@ -8,7 +8,7 @@ import { useCountryDisplayName } from "../../runtime/polityNames.js";
 import { flagImageUrlFromGid } from "../../runtime/countryFlags.js";
 import COUNTRY_NAMES from "../../runtime/generated/countryNames.js";
 import { setRegionClickObserver } from "../Selection/Regions.jsx";
-import { generateCountryStatSheet } from "../AI/gameplay.js";
+import { generateCountryStatSheet, isSimulationBusy } from "../AI/gameplay.js";
 import { validateGameplayPayload } from "../AI/gameplaySchemas.js";
 
 // Sheets are regenerated when the game date moves; within a date they persist
@@ -232,7 +232,10 @@ const StatsPane = ({ active }) => {
                 return;
             }
         }
-        setState({ status: "loading", sheet: null, error: "" });
+        // `waiting` says why the card may sit for minutes (issue #724): the sheet
+        // now holds off until the world is idle, and a spinner that gives no
+        // reason reads as broken.
+        setState({ status: "loading", sheet: null, error: "", waiting: isSimulationBusy() });
         try {
             const generated = await generateCountryStatSheet({ code, name: displayName || code });
             const validation = validateGameplayPayload("countryStatSheet", generated);
@@ -356,7 +359,7 @@ const StatsPane = ({ active }) => {
 
             {state.status === "loading" && (
                 <p style={{ color: "rgba(255,255,255,0.5)", fontSize: "0.82rem", marginTop: "1rem" }}>
-                Compiling the stat sheet…
+                {state.waiting ? "Waiting for the world to finish updating, then compiling the stat sheet…" : "Compiling the stat sheet…"}
                 </p>
             )}
 


### PR DESCRIPTION
Fixes #724.

Opening the Stats pane on a fresh game while its pregame history was still generating fired a **second AI call alongside it** — an error for players whose provider refuses concurrent requests — and built the stat sheet from a world with **no history in it yet**.

### Cause

Pregame history holds the simulation lock for the whole AI call. The Stats pane calls `generateCountryStatSheet` directly, and nothing on that path ever looked at the lock.

There was also a smaller window inside pregame itself: it checked the lock, read a whole bundle, and only *then* called `beginSimulation()`. For the length of that read the backstory was under way while the lock still said idle, so a Stats pane already open as a fresh game loaded could start in the gap.

### Fix

- `generateCountryStatSheet` waits for the simulation to go idle **before** it reads the world or calls the model. `waitForSimulationIdle` is ported from beta, where the other out-of-turn writers already use it — main never had it.
- Pregame takes the lock **before its first read**. Its early "nothing to do" returns now run inside the `try`, which is safe only because the `finally` releases the lock.
- The loading card says *"Waiting for the world to finish updating, then compiling the stat sheet…"* when it has to wait — a multi-minute spinner with no reason given reads as broken.

Opening an existing sheet is unaffected; only generating a *new* one waits.

### Verification

`src/Game/AI/pregameStatsOrdering.test.js` pins both orderings, plus the `finally` that makes the lock move safe. It was run **red first** against the unpatched source, where it failed for exactly these reasons, then green.

Full suite A/B on identical modules:

| | tests | pass | fail |
|---|---|---|---|
| unpatched | 238 | 235 | 3 — the new test's three red cases |
| patched | 238 | 238 | 0 |

Nothing fails only when patched. No new lint findings on the two touched files. The same fix is already on `beta`.

### Not covered

If a turn **starts** while a stat sheet is already mid-generation, the two can still overlap — the wait guards the start, not the whole call. That is a narrower, pre-existing case, not the one reported, and fixing it properly means touching the stats persist path; left for a separate change.