### PR TITLE
A remembered model file path now finds the model a router serves (#721)

### DIFF
--- a/src/Game/AI/main.jsx
+++ b/src/Game/AI/main.jsx
@@ -6,6 +6,7 @@ import {
     providerSupportsModelDiscovery,
     setProviderField,
 } from "./providerConfig.js";
+import { looksLikeModelFilePath, resolveServedModelId } from "./modelIds.js";
 import { JSON_URLS, readJson } from "../../runtime/assets.js";
 import { chatLanguageDirective, languageDirective } from "../../runtime/i18n.js";
 import { difficultyDirective } from "../../runtime/difficulty.js";
@@ -481,7 +482,8 @@ async function resolveModel(provider, { endpoint = "", headers = {}, fallbackMod
     const configuredModel = settings.model.trim();
 
     if (configuredModel) {
-        return provider === "gemini" ? normalizeGeminiModel(configuredModel) : configuredModel;
+        if (provider === "gemini") return normalizeGeminiModel(configuredModel);
+        return matchServedModel(provider, configuredModel, { endpoint, headers, providerLabel, signal });
     }
 
     if (fallbackModel) {
@@ -521,6 +523,64 @@ async function resolveModel(provider, { endpoint = "", headers = {}, fallbackMod
         console.warn(`Could not auto-detect model for ${providerLabel}:`, error);
         throw new Error(`Could not auto-detect a model for ${providerLabel}. Enter a model manually in **settings**.`);
     }
+}
+
+// Issue #721. A configured id that names a model FILE (see modelIds.js) is
+// checked against the server's own /models list before it is sent: classic
+// llama-server reports its -m path as the model id, the game remembers and
+// suggests that id, and the same server in router mode only answers to the
+// model's NAME. Exact matches win, so servers whose ids really are paths are
+// untouched; with no list, or no match, the configured id goes out unchanged —
+// exactly what happened before this existed. Every other id skips all of it.
+//
+// Cached per endpoint for a minute: one lookup covers a whole turn's worth of
+// task calls rather than one per call, and a model the player loads into the
+// router mid-session is picked up within the minute.
+const SERVED_MODELS_TTL_MS = 60 * 1000;
+const servedModelsCache = new Map(); // endpoint -> { at, ids }
+// A turn makes many task calls; say it once per model, not on every one of them.
+const warnedServedModels = new Set();
+const warnServedModelOnce = (key, message) => {
+    if (warnedServedModels.has(key)) return;
+    warnedServedModels.add(key);
+    console.warn(message);
+};
+
+async function listServedModelIds(endpoint, headers, signal) {
+    const cached = servedModelsCache.get(endpoint);
+    if (cached && Date.now() - cached.at < SERVED_MODELS_TTL_MS) return cached.ids;
+    const response = await providerFetch(`${endpoint}/models`, { method: "GET", headers, signal });
+    if (!response.ok) return null;
+    const data = await response.json();
+    const ids = (data?.data ?? [])
+        .map((entry) => entry?.id)
+        .filter((id) => typeof id === "string" && id.trim());
+    servedModelsCache.set(endpoint, { at: Date.now(), ids });
+    return ids;
+}
+
+async function matchServedModel(provider, configuredModel, { endpoint = "", headers = {}, providerLabel = provider, signal } = {}) {
+    if (!providerSupportsModelDiscovery(provider) || !looksLikeModelFilePath(configuredModel)) return configuredModel;
+    const normalizedEndpoint = normalizeEndpoint(endpoint);
+    if (!normalizedEndpoint) return configuredModel;
+
+    let served;
+    try {
+        served = await listServedModelIds(normalizedEndpoint, headers, signal);
+    } catch (error) {
+        if (signal?.aborted) throw signal.reason ?? error;
+        return configuredModel; // no list, no guess
+    }
+
+    const match = resolveServedModelId(configuredModel, served);
+    if (match && match !== configuredModel) {
+        warnServedModelOnce(`${normalizedEndpoint}|${configuredModel}|${match}`, `[ai] ${providerLabel} does not serve "${configuredModel}"; using "${match}", the same model by name.`);
+        return match;
+    }
+    if (!match && served?.length) {
+        warnServedModelOnce(`${normalizedEndpoint}|${configuredModel}|`, `[ai] ${providerLabel} does not serve "${configuredModel}". It offers: ${served.join(", ")}.`);
+    }
+    return configuredModel;
 }
 
 async function callGemini(systemPrompt, history, {

--- a/src/Game/AI/modelIds.js
+++ b/src/Game/AI/modelIds.js
@@ -1,0 +1,58 @@
+/*! Open Historia — model ids against what a local server actually serves © 2026 Nicholas Krol, AGPL-3.0-or-later (see LICENSE). */
+// Issue #721: a player routed the Projects & Operations task to
+// `F:\Models\LLM\gemma-4-31B-it-APEX-Quality.gguf` and every turn failed on
+// "model … not found", while their llama-server, in router mode, was serving
+// that exact model as `gemma-4-31B-it-APEX-Quality`.
+//
+// Where the path comes from: classic single-model llama-server reports the file
+// it was started with (-m) as its model id unless --alias is given. The game
+// auto-detects that id, keeps it as the default model, and offers it again as a
+// suggestion in every model field — the per-task ones included. The same server
+// in router mode serves models by NAME, so the remembered path stops resolving.
+//
+// Pure and import-free so it is testable under `node --test`; the network side
+// (fetching /models) stays in main.jsx.
+
+// A configured id that names a model FILE rather than a model. Only these are
+// worth a /models lookup; every other id is sent exactly as configured.
+export const looksLikeModelFilePath = (id) => {
+  const text = String(id ?? "").trim();
+  if (!text) return false;
+  return /\.gguf$/i.test(text) || text.includes("\\");
+};
+
+const baseName = (id) => String(id).trim().split(/[\\/]/).pop() || "";
+
+// Names a server might list the same file under, best first. The configured id
+// itself always comes first, so a server whose ids genuinely ARE paths — vLLM
+// serving a file without --served-model-name, LM Studio's org/repo/file.gguf —
+// keeps getting exactly what the player typed.
+export const modelFileCandidates = (id) => {
+  const exact = String(id ?? "").trim();
+  if (!exact) return [];
+  const file = baseName(exact);
+  const stem = file.replace(/\.gguf$/i, "");
+  // The first shard of a split model: model-00001-of-00003.gguf.
+  const unsharded = stem.replace(/-\d{5}-of-\d{5}$/i, "");
+  return [...new Set([exact, file, stem, unsharded].filter(Boolean))];
+};
+
+// The id to send: the first candidate the server actually serves, matched exactly
+// and then ignoring case. null when none is served — the caller then sends the
+// configured id unchanged, which is exactly the behaviour before this existed.
+export const resolveServedModelId = (configured, servedIds) => {
+  const served = (Array.isArray(servedIds) ? servedIds : [])
+    .filter((id) => typeof id === "string" && id.trim());
+  if (!served.length) return null;
+
+  const candidates = modelFileCandidates(configured);
+  for (const candidate of candidates) {
+    if (served.includes(candidate)) return candidate;
+  }
+  for (const candidate of candidates) {
+    const lower = candidate.toLowerCase();
+    const hit = served.find((id) => id.toLowerCase() === lower);
+    if (hit) return hit;
+  }
+  return null;
+};

--- a/src/Game/AI/modelIds.test.js
+++ b/src/Game/AI/modelIds.test.js
@@ -1,0 +1,71 @@
+/*! Open Historia — model-id matching tests © 2026 Nicholas Krol, AGPL-3.0-or-later (see LICENSE). */
+// Run: node --test src/Game/AI/modelIds.test.js
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { looksLikeModelFilePath, modelFileCandidates, resolveServedModelId } from "./modelIds.js";
+
+// Verbatim from issue #721: the id the game sent, and the four models the
+// player's llama-server listed at startup in router mode.
+const REPORTED_ID = "F:\\Models\\LLM\\gemma-4-31B-it-APEX-Quality.gguf";
+const ROUTER_MODELS = [
+  "ArliAI_GLM-4.5-Air-Derestricted-Q4_K_M",
+  "Hermes3.6-35B-A3B-Uncensored-Genesis-V7-MTP-APEX",
+  "RavenX-CyberAgent-35B-v5.1-Q4_K_M",
+  "gemma-4-31B-it-APEX-Quality",
+];
+
+test("issue #721: a remembered file path resolves to the name the router serves", () => {
+  assert.equal(resolveServedModelId(REPORTED_ID, ROUTER_MODELS), "gemma-4-31B-it-APEX-Quality");
+});
+
+test("only file-like ids pay for a /models lookup", () => {
+  assert.equal(looksLikeModelFilePath(REPORTED_ID), true);
+  assert.equal(looksLikeModelFilePath("F:\\Models\\LLM\\no-extension"), true, "a Windows path is never a model name");
+  assert.equal(looksLikeModelFilePath("/home/me/models/qwen.GGUF"), true);
+  // Everything else is sent exactly as configured, with no extra request.
+  for (const id of ["gemma-4-31B-it-APEX-Quality", "anthropic/claude-sonnet-4", "llama3:8b", "gpt-4o", "/models/llama", "", null, undefined]) {
+    assert.equal(looksLikeModelFilePath(id), false, JSON.stringify(id));
+  }
+});
+
+test("a server whose ids really are paths keeps the exact id", () => {
+  // vLLM serving a file without --served-model-name lists the path itself, and
+  // LM Studio lists org/repo/file.gguf — the configured id must win there.
+  const vllm = ["/srv/models/qwen2.5-7b.gguf"];
+  assert.equal(resolveServedModelId("/srv/models/qwen2.5-7b.gguf", vllm), "/srv/models/qwen2.5-7b.gguf");
+  const lmStudio = ["lmstudio-community/Qwen2.5-7B-GGUF/Qwen2.5-7B-Q4_K_M.gguf", "qwen2.5-7b"];
+  assert.equal(
+    resolveServedModelId("lmstudio-community/Qwen2.5-7B-GGUF/Qwen2.5-7B-Q4_K_M.gguf", lmStudio),
+    "lmstudio-community/Qwen2.5-7B-GGUF/Qwen2.5-7B-Q4_K_M.gguf",
+  );
+});
+
+test("candidates run from most to least specific", () => {
+  assert.deepEqual(modelFileCandidates(REPORTED_ID), [
+    REPORTED_ID,
+    "gemma-4-31B-it-APEX-Quality.gguf",
+    "gemma-4-31B-it-APEX-Quality",
+  ]);
+  assert.deepEqual(modelFileCandidates("C:\\m\\big-00001-of-00003.gguf"), [
+    "C:\\m\\big-00001-of-00003.gguf",
+    "big-00001-of-00003.gguf",
+    "big-00001-of-00003",
+    "big",
+  ]);
+  assert.deepEqual(modelFileCandidates(""), []);
+});
+
+test("a listing that keeps the extension, or differs only in case, still matches", () => {
+  assert.equal(resolveServedModelId(REPORTED_ID, ["gemma-4-31B-it-APEX-Quality.gguf"]), "gemma-4-31B-it-APEX-Quality.gguf");
+  assert.equal(resolveServedModelId(REPORTED_ID, ["Gemma-4-31B-IT-APEX-Quality"]), "Gemma-4-31B-IT-APEX-Quality");
+});
+
+test("no match, or no list, leaves the decision to the caller", () => {
+  // null means "send what the player configured" — never a guess at some other model.
+  assert.equal(resolveServedModelId(REPORTED_ID, ["qwen3-32b", "llama-3.3-70b"]), null);
+  assert.equal(resolveServedModelId(REPORTED_ID, []), null);
+  assert.equal(resolveServedModelId(REPORTED_ID, undefined), null);
+  assert.equal(resolveServedModelId(REPORTED_ID, [null, "", 7]), null);
+});


### PR DESCRIPTION
Fixes #721 — ports beta's fix (`263beef`, already on `beta` via `df17561`) to `main`.

### The bug

The reporter's llama-server, in **router mode**, serves models by name — `gemma-4-31B-it-APEX-Quality` — but the game sent `F:\Models\LLM\gemma-4-31B-it-APEX-Quality.gguf`, and every call failed with *"model … not found"*.

Classic single-model llama-server reports its `-m` file path as the model id unless `--alias` is set. The game auto-detects that id and keeps it, and `resolveModel` sent any configured id **verbatim** — `/models` was only consulted when nothing was configured. So a path remembered from a classic-mode setup breaks the moment the player switches to router mode.

The report was against beta, where it hit one per-task route (Projects & Operations). Main has no per-task routing, so here it would hit **every** call through the default model — but the branch that sends the id is identical.

### The fix

A configured id that names a model *file* (`.gguf`, or backslashes) is checked against the server's own `/models` list before it is sent:

- **exact match wins** — servers whose ids genuinely are paths keep working (vLLM without `--served-model-name`, LM Studio's `org/repo/file.gguf`);
- otherwise the file name, then the name without `.gguf`, exactly and then ignoring case;
- **no list or no match → the configured id goes out unchanged.** The old behaviour; never a guess at another model.

Every other id — bare names, `provider/model` ids, Ollama tags — skips all of it and costs no request. The lookup is cached per endpoint for a minute, and the warning explaining a substitution is written once per model.

### Same code as beta

`modelIds.js` and `modelIds.test.js` are **byte-identical** to beta's, and the `listServedModelIds` / `matchServedModel` block in `main.jsx` is lifted verbatim from `263beef` — both lines ship the same logic.

### Verified on this branch

- 6 unit tests, including the reporter's exact id against the four model names in their router log
- End-to-end against a mock router-mode llama-server driving this `main.jsx`: the raw path reproduces the reported error word for word, the resolved name succeeds, the cache holds across calls, a bare name triggers no lookup, an unknown path goes out untouched (with a warning listing what the server offers), and providers without `/models` discovery are unaffected
- Full suite **240 pass, 0 fail**; `vite build` succeeds

Note: `main.jsx` is not covered by main's ESLint config (`.jsx` files are ignored), so the build is what vouches for it. `modelIds.js` and its test lint clean.

**Merging closes #721.** The reporter is on beta, which has the fix in source but in no published installer yet — `desktop-beta` 0.0.17 was built before it merged.