### PR TITLE
Timeline buttons show the date the jump actually lands on (#718)

### DIFF
--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -7,6 +7,7 @@ import { toCountryName } from "../../runtime/ownerNames.js";
 import { activeSpies, espionageBrief, intelligenceOf, normalizeIntercepts, normalizeSpies, resolveEspionage } from "../../runtime/spycraft.js";
 import { echoesExistingMessage, renderOpenChatsForPrompt } from "../../runtime/chatEcho.js";
 import { isSeal, newSeal, openExchange, sealExchange } from "../../runtime/spySeal.js";
+import { addIsoDays, jumpDayStep, jumpTargetDate, parseIsoDate } from "../../runtime/jumpDates.js";
 import {
   buildActionHistoryText,
   buildChatSummaryText,
@@ -109,29 +110,7 @@ const cloneValue = (value) => {
 const normalizeString = (value) => String(value ?? "").trim();
 const normalizeArray = (value) => (Array.isArray(value) ? value : []);
 
-const parseIsoDate = (value) => {
-  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(normalizeString(value));
-  if (!match) return null;
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  const day = Number(match[3]);
-  if (year < 1 || month < 1 || month > 12) return null;
-  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
-  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-  return day >= 1 && day <= daysInMonth[month - 1] ? { day, month, year } : null;
-};
-
-const addIsoDays = (value, days) => {
-  const parsed = parseIsoDate(value);
-  if (!parsed) return "";
-  const date = new Date(0);
-  date.setUTCHours(0, 0, 0, 0);
-  date.setUTCFullYear(parsed.year, parsed.month - 1, parsed.day);
-  date.setUTCDate(date.getUTCDate() + days);
-  const year = date.getUTCFullYear();
-  if (!Number.isFinite(date.getTime()) || year < 1 || year > 9999) return "";
-  return `${String(year).padStart(4, "0")}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`;
-};
+// parseIsoDate and addIsoDays live in runtime/jumpDates.js (imported above), next to the rule for where a time skip lands.
 
 export const validateTimelineDates = ({ candidate, mode, originDate, targetDate, requireAdvance = false }) => {
   const stopDate = normalizeString(candidate?.stopDate);
@@ -2431,9 +2410,11 @@ export const simulateTimelineJump = async ({ days, mode = "jump", signal } = {})
   if (safeDays <= 0) {
     throw new Error("Choose a time-skip amount greater than zero.");
   }
-  const dateStep = Math.max(0, Math.round(safeDays));
+  // One rule for where a skip lands, shared with the timeline's button labels
+  // (runtime/jumpDates.js), so a button never promises a date the jump misses.
+  const dateStep = jumpDayStep(safeDays);
   const originDate = normalizeString(bundle.game.gameDate);
-  const targetDate = dateStep >= 1 ? (addIsoDays(originDate, dateStep) || originDate) : originDate;
+  const targetDate = jumpTargetDate(originDate, safeDays);
   if (dateStep >= 1 && parseIsoDate(originDate) && targetDate === originDate) {
     throw new Error("The requested jump exceeds the supported date range.");
   }

--- a/src/Game/GameUI/time.jsx
+++ b/src/Game/GameUI/time.jsx
@@ -11,6 +11,7 @@ import {
     loadRegionCatalog,
 } from "../../runtime/assets.js";
 import { loadRollbackSnapshots, maybeGeneratePregameHistory, rollBackToSnapshot, simulateAutoJump, simulateTimelineJump } from "../AI/gameplay.js";
+import { jumpTargetDate } from "../../runtime/jumpDates.js";
 import { isMainMenuOpen } from "./libraryBar";
 import {
     applyEventImpactsToWorld,
@@ -817,6 +818,11 @@ const PanelChrome = ({
     );
 };
 
+// The date a skip of `days` lands on, as the timeline buttons print it. Computed
+// with the jump's own rule (runtime/jumpDates.js); currentDate is always a
+// YYYY-MM-DD by the time it gets here, so dayjs only formats it.
+const jumpLandingLabel = (from, days) => dayjs(jumpTargetDate(from, days)).format("M/D/YYYY");
+
 const JumpNode = ({ isLoading, opt, onJump }) => {
     const [hovered, setHovered] = useState(false);
 
@@ -876,15 +882,24 @@ const TimelineSkipPanel = ({
         if (!Number.isFinite(amount) || amount <= 0 || isLoading) return;
         onJump(amount * (unitToDays[customUnit] ?? 1));
     };
+    // Where a custom jump would land, shown under the row the way every preset
+    // shows its date (#718): 31 days from 1 January is 2/1, which "1 month" (30
+    // days) is not. Seen before pressing Go, not after a turn is spent.
+    const customDays = Number(customValue) * (unitToDays[customUnit] ?? 1);
+    const customLanding = Number.isFinite(customDays) && customDays > 0
+        ? jumpLandingLabel(currentDate, customDays)
+        : "";
     const jumpOptions = [
-        { label: "6 hours", sublabel: dayjs(currentDate).format("M/D/YYYY"), days: 0.25 },
-        { label: "1 day", sublabel: dayjs(currentDate).add(1, "day").format("M/D/YYYY"), days: 1 },
-        { label: "3 days", sublabel: dayjs(currentDate).add(3, "day").format("M/D/YYYY"), days: 3 },
-        { label: "1 week", sublabel: dayjs(currentDate).add(7, "day").format("M/D/YYYY"), days: 7 },
-        { label: "1 month", sublabel: dayjs(currentDate).add(1, "month").format("M/D/YYYY"), days: 30 },
-        { label: "3 months", sublabel: dayjs(currentDate).add(3, "month").format("M/D/YYYY"), days: 90 },
-        { label: "6 months", sublabel: dayjs(currentDate).add(6, "month").format("M/D/YYYY"), days: 180 },
-        { label: "1 year", sublabel: dayjs(currentDate).add(1, "year").format("M/D/YYYY"), days: 365 },
+        // Each label is the date the jump actually lands on (#718). These used to be
+        // calendar arithmetic, so "1 month" read 2/1 while the jump went 30 days, to 1/31.
+        { label: "6 hours", sublabel: jumpLandingLabel(currentDate, 0.25), days: 0.25 },
+        { label: "1 day", sublabel: jumpLandingLabel(currentDate, 1), days: 1 },
+        { label: "3 days", sublabel: jumpLandingLabel(currentDate, 3), days: 3 },
+        { label: "1 week", sublabel: jumpLandingLabel(currentDate, 7), days: 7 },
+        { label: "1 month", sublabel: jumpLandingLabel(currentDate, 30), days: 30 },
+        { label: "3 months", sublabel: jumpLandingLabel(currentDate, 90), days: 90 },
+        { label: "6 months", sublabel: jumpLandingLabel(currentDate, 180), days: 180 },
+        { label: "1 year", sublabel: jumpLandingLabel(currentDate, 365), days: 365 },
     ];
 
     return (
@@ -1055,6 +1070,11 @@ const TimelineSkipPanel = ({
         Go
         </button>
         </div>
+        {customLanding && (
+            <div style={{ color: "rgba(255,255,255,0.55)", fontSize: "0.72rem", marginTop: "0.3rem", textAlign: "center", width: "12.5rem" }}>
+            Lands on {customLanding}
+            </div>
+        )}
         </div>
 
         {isLoading && (

--- a/src/runtime/jumpDates.js
+++ b/src/runtime/jumpDates.js
@@ -1,0 +1,52 @@
+/*! Open Historia — time-skip landing dates © 2026 Nicholas Krol, AGPL-3.0-or-later (see LICENSE). */
+// Where a time skip lands, in one place. The jump itself (simulateTimelineJump in
+// gameplay.js) and the date printed on every timeline button both come from
+// jumpTargetDate, so what a button promises is what the jump does.
+//
+// Issue #718: they used to disagree. The jump adds a whole number of days to the
+// ISO game date, while the buttons were labelled with calendar arithmetic —
+// dayjs(date).add(1, "month") — so "1 month" from 1 January said 2/1 and landed
+// on 1/31, "6 months" said 7/1 and landed on 6/30, and "1 year" from 1 January
+// of a leap year said the next New Year's Day and landed on 31 December.
+//
+// parseIsoDate and addIsoDays moved here from gameplay.js unchanged. Import-free,
+// so node --test can load it; gameplay.js cannot be.
+
+const normalizeString = (value) => String(value ?? "").trim();
+
+// A real Gregorian YYYY-MM-DD as { day, month, year }, or null.
+export const parseIsoDate = (value) => {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(normalizeString(value));
+  if (!match) return null;
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  if (year < 1 || month < 1 || month > 12) return null;
+  const leapYear = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leapYear ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+  return day >= 1 && day <= daysInMonth[month - 1] ? { day, month, year } : null;
+};
+
+export const addIsoDays = (value, days) => {
+  const parsed = parseIsoDate(value);
+  if (!parsed) return "";
+  const date = new Date(0);
+  date.setUTCHours(0, 0, 0, 0);
+  date.setUTCFullYear(parsed.year, parsed.month - 1, parsed.day);
+  date.setUTCDate(date.getUTCDate() + days);
+  const year = date.getUTCFullYear();
+  if (!Number.isFinite(date.getTime()) || year < 1 || year > 9999) return "";
+  return `${String(year).padStart(4, "0")}-${String(date.getUTCMonth() + 1).padStart(2, "0")}-${String(date.getUTCDate()).padStart(2, "0")}`;
+};
+
+// Whole days a skip of `days` advances the calendar. Sub-day skips are allowed
+// (6 hours = 0.25) and keep the same date; the rest round to the nearest day,
+// exactly as the jump always has — so 12 hours (0.5) advances one day.
+export const jumpDayStep = (days) => Math.max(0, Math.round(Math.max(0, Number(days) || 0)));
+
+// The date a skip of `days` from `originDate` lands on. An origin that is not a
+// real ISO date comes back unchanged — which is what the jump does with it too.
+export const jumpTargetDate = (originDate, days) => {
+  const step = jumpDayStep(days);
+  return step >= 1 ? (addIsoDays(originDate, step) || originDate) : originDate;
+};

--- a/src/runtime/jumpDates.test.js
+++ b/src/runtime/jumpDates.test.js
@@ -1,0 +1,61 @@
+/*! Open Historia — time-skip landing date tests © 2026 Nicholas Krol, AGPL-3.0-or-later (see LICENSE). */
+// Run: node --test src/runtime/jumpDates.test.js
+//
+// Issue #718. The timeline's buttons printed calendar arithmetic while the jump
+// added a fixed day count, so "1 month" promised 2/1 and delivered 1/31. Both
+// now come from jumpTargetDate. These pin the rule, and the last test pins that
+// both callers actually use it — the drift between them WAS the bug.
+
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import test from "node:test";
+
+import { addIsoDays, jumpDayStep, jumpTargetDate, parseIsoDate } from "./jumpDates.js";
+
+test("each preset lands where the jump goes, not where a calendar month ends", () => {
+  // The labels main printed before, for contrast: 2/1, 7/1, 1/1/2017 and 6/1.
+  assert.equal(jumpTargetDate("2015-01-01", 30), "2015-01-31"); // "1 month"
+  assert.equal(jumpTargetDate("2015-01-01", 180), "2015-06-30"); // "6 months"
+  assert.equal(jumpTargetDate("2016-01-01", 180), "2016-06-29"); // "6 months", leap year
+  assert.equal(jumpTargetDate("2016-01-01", 365), "2016-12-31"); // "1 year", leap year
+  assert.equal(jumpTargetDate("2015-01-01", 365), "2016-01-01");
+  assert.equal(jumpTargetDate("2015-03-01", 90), "2015-05-30"); // "3 months" from 1 March
+});
+
+test("the reporter's custom jump: 31 days from 1 January lands on 1 February", () => {
+  assert.equal(jumpTargetDate("2015-01-01", 31), "2015-02-01");
+});
+
+test("sub-day skips keep the date; the rest round the way the jump always has", () => {
+  assert.equal(jumpDayStep(0.25), 0);
+  assert.equal(jumpTargetDate("2015-01-01", 0.25), "2015-01-01"); // "6 hours"
+  assert.equal(jumpDayStep(0.5), 1, "12 hours rounds to a day — existing behaviour, pinned, not changed");
+  assert.equal(jumpTargetDate("2015-01-01", 1.4), "2015-01-02");
+  assert.equal(jumpDayStep(-3), 0);
+  assert.equal(jumpDayStep("abc"), 0);
+});
+
+test("an origin that is not a real date comes back unchanged, as the jump leaves it", () => {
+  assert.equal(jumpTargetDate("1200 BCE", 30), "1200 BCE");
+  assert.equal(jumpTargetDate("2015-02-30", 30), "2015-02-30");
+  assert.equal(parseIsoDate("2015-02-30"), null);
+  assert.equal(addIsoDays("2015-12-31", 1), "2016-01-01");
+  assert.equal(addIsoDays("9999-12-31", 1), "", "past the supported range");
+});
+
+test("the jump and the timeline buttons both use jumpTargetDate", () => {
+  // gameplay.js cannot be imported under node --test, so this reads the source.
+  const read = (relative) => fs.readFileSync(new URL(relative, import.meta.url), "utf8");
+  const gameplay = read("../Game/AI/gameplay.js");
+  const time = read("../Game/GameUI/time.jsx");
+
+  assert.match(gameplay, /const targetDate = jumpTargetDate\(originDate, safeDays\);/, "the jump computes its own target again");
+  assert.doesNotMatch(gameplay, /const addIsoDays = /, "a second copy of the day arithmetic is back in gameplay.js");
+
+  assert.match(time, /const jumpLandingLabel = \(from, days\) => dayjs\(jumpTargetDate\(from, days\)\)/);
+  const optionsAt = time.indexOf("const jumpOptions = [");
+  assert.notEqual(optionsAt, -1, "the timeline's preset list moved");
+  const options = time.slice(optionsAt, time.indexOf("];", optionsAt));
+  assert.match(options, /jumpLandingLabel\(currentDate, 30\)/);
+  assert.doesNotMatch(options, /\.add\(/, "a preset label is using its own calendar arithmetic again");
+});


### PR DESCRIPTION
Part of #718 — the half of it that applies to main. The issue stays open for its feature requests.

### The bug

A time jump moves the game date by a whole number of days (`simulateTimelineJump` rounds `days` and adds that many), but main's Timeline buttons labelled themselves with calendar arithmetic — `dayjs(date).add(1, "month")` and so on — so they promised dates the jump never reached. From 1 January 2016:

| Button | Label said | Jump landed on |
|---|---|---|
| 1 month | 2/1/2016 | 1/31/2016 |
| 3 months | 4/1/2016 | 3/31/2016 |
| 6 months | 7/1/2016 | 6/29/2016 |
| 1 year | 1/1/2017 | 12/31/2016 |

Beta already labels its buttons from the day count; this was main-only.

### The fix

- The jump's rule — round to whole days, a skip under half a day keeps the date — is now `jumpTargetDate` in `src/runtime/jumpDates.js`. `simulateTimelineJump` and every button label call it, so the two cannot drift apart again.
- `parseIsoDate` and `addIsoDays` moved there from `gameplay.js` unchanged apart from `export`; `gameplay.js` imports them back, so its other callers are untouched.
- The custom row shows where it would land, the way the presets show theirs: 31 days from 1/1/2016 reads "Lands on 2/1/2016".

The other bug in #718 — two configuration profiles both reading ACTIVE — does not apply here: the profile manager only exists on beta, where it is fixed (5395d73).

Beta computes these labels on top of `gameDates.js` (BC dates); when beta is merged into main, keep beta's side.

### Checked

- `npm test`: 249 pass, 0 fail, after merging current main (#727, #728) into the branch. 5 new tests in `src/runtime/jumpDates.test.js`: the dates above, the reporter's 31-day case, sub-day rounding, and a source check that the jump and the labels both call `jumpTargetDate` (`gameplay.js` cannot be imported under `node --test`).
- eslint clean on `jumpDates.js`, its test and `gameplay.js` (`time.jsx` is not matched by the lint config, on main or here).
- `npm run build` and `npm run build:web` clean.
- Main's web build, a game dated 2016-01-01: the buttons read 1/31, 3/31, 6/29 and 12/31/2016, none of the old dates appear, and a custom 31 days shows "Lands on 2/1/2016".
