### PR TITLE
Contributor License Agreement: contributions are assigned to Open Historia

### DIFF
--- a/.github/cla-metadata.json
+++ b/.github/cla-metadata.json
@@ -1,0 +1,38 @@
+{
+  "name": {
+    "title": "Full legal name",
+    "type": "string",
+    "githubKey": "name",
+    "required": true
+  },
+  "email": {
+    "title": "E-mail address",
+    "type": "string",
+    "githubKey": "email",
+    "required": true
+  },
+  "category": {
+    "title": "How are you signing?",
+    "type": {
+      "enum": [
+        "On my own behalf, as an individual.",
+        "On behalf of a legal entity (my employer or organization)."
+      ]
+    },
+    "required": true
+  },
+  "entity": {
+    "title": "Legal entity name",
+    "description": "Only if you are signing on behalf of an entity: its full legal name.",
+    "type": "string"
+  },
+  "authority": {
+    "title": "I am authorized to bind the entity named above to this Agreement (entity signers only).",
+    "type": "boolean"
+  },
+  "agreement": {
+    "title": "I have read the Open Historia Contributor License Agreement and agree to be bound by it, including the assignment of my Contributions to the Owner in Section 2.",
+    "type": "boolean",
+    "required": true
+  }
+}

--- a/CLA.md
+++ b/CLA.md
@@ -74,7 +74,7 @@ If You sign this Agreement on behalf of a legal entity, You represent that You a
 
 (e) If any provision of this Agreement is held to be unenforceable, it will be enforced to the maximum extent permitted, and the remaining provisions will stay in force.
 
-(f) This Agreement is governed by the laws of [GOVERNING JURISDICTION], without regard to its conflict-of-laws rules. The courts of [GOVERNING JURISDICTION] have exclusive jurisdiction over any dispute arising out of or relating to this Agreement, except that the Owner may seek injunctive or other equitable relief in any court of competent jurisdiction.
+(f) This Agreement is governed by the laws of the State of Ohio, United States of America, without regard to its conflict-of-laws rules. The state and federal courts located in the State of Ohio have exclusive jurisdiction over any dispute arising out of or relating to this Agreement, and You consent to their personal jurisdiction, except that the Owner may seek injunctive or other equitable relief in any court of competent jurisdiction.
 
 (g) Notices to the Owner may be sent through the contact details published for the Open-Historia GitHub organization at https://github.com/Open-Historia.
 

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,85 @@
+# Open Historia Contributor License Agreement
+
+Version 1.0, 10 September 2026
+
+Thank you for your interest in contributing to Open Historia (the "Project"). This Contributor License Agreement (the "Agreement") records the terms on which you contribute to the Project. It transfers ownership of your Contributions to the Project's owner, so that the Project can be licensed, relicensed, defended and maintained as one whole, and it gives you back a broad licence to your own work, so you lose nothing you wrote.
+
+Please read it carefully before signing. By signing it, including electronically through CLA Assistant, you accept and agree to the following terms for all Contributions you have submitted and will submit to the Project.
+
+## 1. Definitions
+
+"Open Historia" or the "Project" means the Open Historia software and everything published alongside it, including source code, documentation, scenarios, data, artwork, translations, build and deployment scripts and websites, in any repository of the Open-Historia GitHub organization (https://github.com/Open-Historia) or in any other repository that the Owner designates as part of the Project.
+
+"Owner" means Nicholas Krol, the owner of Open Historia, together with any person or entity to whom ownership of the Project is later transferred, and their respective successors and assigns. Where the Project is owned by more than one person or entity, "Owner" means all of them jointly.
+
+"You" (or "Your") means the individual or legal entity that signs this Agreement. For a legal entity, the entity signing and all other entities that control, are controlled by, or are under common control with that entity are treated as one contributor.
+
+"Contribution" means any original work of authorship, including source code, documentation, scenarios, data, artwork, translations, configuration, and any modification of or addition to an existing work, that You intentionally submit to the Owner for inclusion in the Project, whether submitted before or after You sign this Agreement. "Submit" means any form of communication sent to the Owner or its representatives for that purpose, including pull requests, patches, issues and messages on any channel managed by or on behalf of the Project, but excluding communication that You conspicuously mark in writing as "Not a Contribution".
+
+## 2. Assignment of copyright
+
+(a) You irrevocably assign to the Owner all of Your right, title and interest throughout the world in and to each Contribution, including all copyright and all rights of a similar nature (such as database rights and neighbouring rights), all registrations and applications for them, all rights to claim and recover damages for past, present and future infringement, and all rights to renew and extend them. For a Contribution submitted after You sign this Agreement, the assignment takes effect at the moment You submit it.
+
+(b) The Owner may use, reproduce, modify, distribute, display, perform, sublicense and otherwise exploit each Contribution in any way and under any terms it chooses, including under the Project's public licence, under other open-source licences and under proprietary or commercial licences, without any further obligation to You.
+
+(c) To the extent that any right in a Contribution cannot be assigned under applicable law, or the assignment in Section 2(a) is held to be ineffective for any reason, You grant the Owner an exclusive, perpetual, irrevocable, worldwide, royalty-free, fully paid-up, transferable and sublicensable (through multiple tiers) licence to exercise that right in every way permitted by law, for the full term of the right, and You agree not to exercise that right against the Owner or anyone claiming through it.
+
+(d) To the extent permitted by law, You waive, and agree never to assert against the Owner or anyone acting under its authority, any moral rights or similar rights You may hold in a Contribution, including rights of attribution and integrity. Where such rights cannot be waived, You consent to any act or omission by the Owner or its licensees that would otherwise infringe them.
+
+## 3. Patent licence
+
+You grant the Owner, and every recipient of software distributed by the Owner, a perpetual, worldwide, non-exclusive, royalty-free, fully paid-up and irrevocable (except as stated in this Section) licence under any patent claims that You own or control, now or in the future, and that are necessarily infringed by Your Contribution alone or by the combination of Your Contribution with the Project as it existed when the Contribution was submitted, to make, have made, use, offer to sell, sell, import and otherwise transfer the Contribution and those combinations. If You, or any entity You control, institute patent litigation (including a cross-claim or counterclaim) alleging that the Project, or a Contribution incorporated in it, constitutes direct or contributory patent infringement, every patent licence granted to You under this Agreement or under the Project's licences for that Contribution terminates on the date the litigation is filed.
+
+## 4. Licence back to You
+
+The Owner grants You a perpetual, worldwide, non-exclusive, royalty-free and irrevocable licence to reproduce, modify, distribute, display, perform and otherwise use each of Your Contributions, in the form in which You submitted it, for any purpose, and to sublicense those rights. This licence covers Your own Contributions only. The rest of the Project remains available to You under the Project's public licence.
+
+## 5. The Owner's undertaking
+
+The Owner will make each Contribution that it accepts into the Project available to the public under the Project's public licence in force at the time the Contribution is accepted (at the date of this version of the Agreement, the GNU Affero General Public License, version 3 or any later version). This does not limit the Owner's right under Section 2(b) to license the Contribution under other terms as well, and it does not oblige the Owner to accept any Contribution or to keep any Contribution in the Project.
+
+## 6. Your representations
+
+You represent and warrant that:
+
+(a) You are legally entitled to enter into this Agreement and to make the assignments, licences and waivers in it. If You are below the age of majority where You live, a parent or legal guardian must sign on Your behalf.
+
+(b) Each Contribution is Your own original work, and You have not copied any part of it from anyone else, except as disclosed under Section 6(d).
+
+(c) If Your employer, or any other person or entity, has rights in intellectual property that You create, for example because You created the Contribution in the course of employment or under a contract, then one of the following is true: that party has signed this Agreement as an entity and named You as an authorized contributor; or that party has given You written permission to make the Contribution on these terms and has waived any rights in it; or the Contribution was created outside the scope of that relationship and that party has no claim to it.
+
+(d) If any part of a Contribution is not Your original work, for example code, data, images or text from a third party, or material produced with substantial help from an AI tool that may reproduce third-party material, You will identify that part, its source and its licence when You submit the Contribution. You represent that You have the right to submit that part and that its licence permits the Owner's use of it under Section 2(b). Such third-party parts are excluded from the assignment in Section 2(a) and are instead made available to the Owner under their own licence terms.
+
+(e) To Your knowledge, no Contribution infringes any copyright, patent, trademark, trade secret or other right of any third party, and no Contribution is subject to any licence or obligation (including any copyleft obligation) that would apply to the Project as a whole as a result of its inclusion, other than the Project's own public licence.
+
+(f) You will promptly notify the Owner if You become aware of any fact or circumstance that would make any of these representations inaccurate.
+
+## 7. No obligation, no warranty
+
+Except for the representations in Section 6, You provide Your Contributions "AS IS", without warranty of any kind, express or implied, including any warranty of merchantability, fitness for a particular purpose, title or non-infringement. You are not expected to provide support for Your Contributions unless You choose to. Nothing in this Agreement obliges the Owner to include any Contribution in the Project, to attribute it to You, or to keep it in the Project once included, and nothing in this Agreement creates an employment, agency, partnership or joint-venture relationship between You and the Owner.
+
+## 8. Entities
+
+If You sign this Agreement on behalf of a legal entity, You represent that You are authorized to bind that entity, and the entity assumes all of Your obligations under this Agreement for Contributions made by the employees, contractors and other persons that it names as its authorized contributors (its "Schedule"). The entity must notify the Owner in writing when persons are added to or removed from its Schedule. Contributions made by a named person before the Owner receives notice of that person's removal remain covered by this Agreement.
+
+## 9. General
+
+(a) This Agreement covers all Contributions that You submitted to the Project before signing and all Contributions that You submit after signing, until You notify the Owner in writing that You will make no further Contributions. Ending the Agreement in that way does not affect any Contribution submitted before the notice or any right, licence or waiver granted in respect of it.
+
+(b) This Agreement is the entire agreement between You and the Owner about Your Contributions and replaces any earlier understanding about them. It may be changed only in a writing signed by both You and the Owner. The Owner may publish revised versions of this Agreement for future contributors and may ask You to sign a revised version. Until You do, this version continues to govern Your Contributions.
+
+(c) The Owner may assign this Agreement, and the rights it holds under it, to any successor owner of the Project. You may not assign this Agreement without the Owner's written consent.
+
+(d) At the Owner's request and expense, You will sign any further document and take any further step reasonably necessary to confirm, perfect or record the assignments, licences and waivers in this Agreement. If You do not do so within a reasonable time after being asked, You appoint the Owner as Your attorney-in-fact to do so on Your behalf.
+
+(e) If any provision of this Agreement is held to be unenforceable, it will be enforced to the maximum extent permitted, and the remaining provisions will stay in force.
+
+(f) This Agreement is governed by the laws of [GOVERNING JURISDICTION], without regard to its conflict-of-laws rules. The courts of [GOVERNING JURISDICTION] have exclusive jurisdiction over any dispute arising out of or relating to this Agreement, except that the Owner may seek injunctive or other equitable relief in any court of competent jurisdiction.
+
+(g) Notices to the Owner may be sent through the contact details published for the Open-Historia GitHub organization at https://github.com/Open-Historia.
+
+## 10. How to sign
+
+You sign this Agreement electronically through CLA Assistant. When You open a pull request to an Open Historia repository, the CLA Assistant bot posts a link to this Agreement on the pull request; You may also go directly to https://cla-assistant.io/Open-Historia/open-historia. You sign once for the whole Project.
+
+By signing, You confirm that You have read this Agreement, that the details You entered (Your name and e-mail address and, for an entity, the entity's name and Your authority to sign for it) are accurate, and that You agree to be bound by this Agreement. Your GitHub account name, the details You entered, and the date and version of the Agreement You signed are recorded as Your signature.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to Open Historia
+
+Thanks for helping build Open Historia. This page covers the one legal step every contributor takes once, and the practical shape of a good pull request.
+
+## The Contributor License Agreement
+
+Open Historia accepts contributions only under its [Contributor License Agreement](CLA.md). In short:
+
+- You assign the copyright in your contributions to Open Historia's owner, so the Project can be licensed, relicensed and defended as one whole. Where your local law does not allow an assignment, you grant an exclusive licence instead.
+- You get a perpetual licence back to your own contributions, so you can keep using what you wrote anywhere you like.
+- You confirm the work is yours to give, and you tell us about any third-party material in it.
+- Open Historia publishes what it accepts under the Project's public licence (currently AGPL-3.0-or-later), and may license it under other terms as well.
+
+Read the full text before you sign; the summary above does not replace it.
+
+### How signing works
+
+Signing is electronic and takes a minute:
+
+1. Open a pull request against any Open-Historia repository.
+2. The CLA Assistant bot comments on the pull request with a link, and the pull request's CLA status check stays pending until you sign. You can also go straight to [cla-assistant.io/Open-Historia/open-historia](https://cla-assistant.io/Open-Historia/open-historia).
+3. Sign in with GitHub, fill in your name and e-mail address, and confirm that you agree.
+
+You sign once, for the whole Project, and it covers pull requests you have already opened; the status check updates on its own once you have signed.
+
+If you contribute for an employer or another organization, that organization signs the Agreement itself (choose "On behalf of a legal entity" when signing, and make sure you are authorized to sign for it) and names its contributors. If you are unsure whether your employer holds rights in what you write, ask them before you open the pull request.
+
+The text at [CLA.md](CLA.md) is the canonical copy. The Gist that CLA Assistant shows you mirrors it; if the two ever differ, the version you signed governs your contributions.
+
+## Pull requests
+
+- Keep one change per pull request, with a title that says what changed and a body that says why.
+- Say where anything in the change came from if it is not your own work: a library, a dataset, a map, an image, a translation, or code produced with substantial help from an AI tool. Name the source and its licence.
+- Do not add third-party material under a licence that would apply to the whole Project. Anything under a copyleft licence other than the Project's own needs a discussion first.
+- Run `npm test` and `npx eslint .` before you push. A pull request that changes what the app does should say how you checked it.
+- Target `main` unless a maintainer has pointed you at another branch.
+
+## Reporting problems
+
+Bugs and feature requests go to the [issue tracker](https://github.com/Open-Historia/open-historia/issues). For anything sensitive, such as a security problem, use the contact details on the [Open-Historia organization page](https://github.com/Open-Historia) rather than a public issue.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,7 +25,7 @@ You sign once, for the whole Project, and it covers pull requests you have alrea
 
 If you contribute for an employer or another organization, that organization signs the Agreement itself (choose "On behalf of a legal entity" when signing, and make sure you are authorized to sign for it) and names its contributors. If you are unsure whether your employer holds rights in what you write, ask them before you open the pull request.
 
-The text at [CLA.md](CLA.md) is the canonical copy. The Gist that CLA Assistant shows you mirrors it; if the two ever differ, the version you signed governs your contributions.
+The text at [CLA.md](CLA.md) is the canonical copy. The [Gist that CLA Assistant shows you](https://gist.github.com/Arkniem/f872c1b70ee0e762d87f927c199e6c9d) mirrors it; if the two ever differ, the version you signed governs your contributions.
 
 ## Pull requests
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Copyright (C) 2026 Open Historia
 
 This project is licensed under the terms of the GNU Affero General Public License v3.0 or later (AGPL-3.0-or-later). See the [LICENSE](LICENSE) file for details.
 
+Contributions are accepted under the [Contributor License Agreement](CLA.md), which assigns them to Open Historia. CLA Assistant asks you to sign it on your first pull request; see [CONTRIBUTING.md](CONTRIBUTING.md).
+
 <!-- Open Historia — portions (install, Android app, hub & preset docs) © 2026 Nicholas Krol, AGPL-3.0-or-later (see LICENSE). -->
 <h1 align="center">Open Historia</h1>
 


### PR DESCRIPTION
Adds the project's Contributor License Agreement and wires the docs for CLA Assistant.

**`CLA.md`** is the agreement. Contributors assign the copyright in their contributions to the Project's owner (Nicholas Krol, and whoever owns Open Historia after him), with an exclusive licence as the fallback where local law does not allow an assignment and a waiver of moral rights to the extent permitted. It also carries a patent licence, a licence back to the contributor for their own work, the owner's undertaking to publish what it accepts under the Project's public licence (AGPL-3.0-or-later today) while staying free to license it under any other terms, the usual representations (original work, employer rights, third-party and AI-assisted material disclosed), entity signing, and coverage of past contributions once signed.

**CLA Assistant.** The hosted service serves the agreement from a GitHub Gist, so `CLA.md` is the canonical text to paste into that Gist, and `.github/cla-metadata.json` is the content of the Gist's `metadata` file (CLA Assistant's custom fields: name, e-mail, individual or entity, entity name and signing authority, and the agreement checkbox), written to its published custom-fields schema.

**`CONTRIBUTING.md`** explains the agreement in plain words and how signing works; the README's licence section links to both.

Before publishing the Gist: fill in the bracketed governing-law jurisdiction in section 9(f), and have counsel read the text. Contributions already merged are not covered until their authors sign.
