### PR TITLE
A busy provider or a slip in the model's answer no longer costs the player their turn

### DIFF
--- a/src/Game/AI/chatVisibility.js
+++ b/src/Game/AI/chatVisibility.js
@@ -61,6 +61,20 @@ export const chatParticipantMatches = (country, polity) => {
 };
 
 /**
+ * A chat's participants with the player taken out — the invariant above, applied
+ * to a list a model wrote.
+ *
+ * Models list the player among the countries of a note they address TO the
+ * player: a field report's jump opened "Russian Federation, Republic of India"
+ * for a Russian player. Beyond the odd header, that list no longer matched the
+ * India thread already open, so the note forked a second thread instead of
+ * landing in the first — and the player would count as a participant everywhere
+ * this module decides who was in the room. A blank `player` removes nothing.
+ */
+export const withoutPlayerParticipant = (countries, player) =>
+    (Array.isArray(countries) ? countries : []).filter((country) => !chatParticipantMatches(country, player));
+
+/**
  * May `polity` see this chat?
  *
  * A blank `polity` means "no restriction" — the narrator and advisor paths — and

--- a/src/Game/AI/chatVisibility.test.js
+++ b/src/Game/AI/chatVisibility.test.js
@@ -13,7 +13,28 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { chatParticipantMatches, filterChatsVisibleTo, isChatVisibleTo } from "./chatVisibility.js";
+import { chatParticipantMatches, filterChatsVisibleTo, isChatVisibleTo, withoutPlayerParticipant } from "./chatVisibility.js";
+
+// The field report's jump addressed a note to a Russian player as
+// "Russian Federation, Republic of India", which forked a second India thread.
+test("a generated note's participant list loses the player, by name or code", () => {
+  const listed = [
+    { code: "Russian Federation", name: "Russian Federation" },
+    { code: "Republic of India", name: "Republic of India" },
+  ];
+  assert.deepEqual(withoutPlayerParticipant(listed, "Russian Federation"), [listed[1]]);
+  assert.deepEqual(
+    withoutPlayerParticipant([{ code: "RUS", name: "Russia" }, { code: "IND", name: "India" }], "rus"),
+    [{ code: "IND", name: "India" }],
+  );
+});
+
+test("with no player named, or only the player listed, nothing is invented", () => {
+  const listed = [{ code: "IND", name: "India" }];
+  assert.deepEqual(withoutPlayerParticipant(listed, ""), listed, "a blank player removes nobody");
+  assert.deepEqual(withoutPlayerParticipant([{ name: "Russia" }], "Russia"), [], "a note to nobody but the player is no chat");
+  assert.deepEqual(withoutPlayerParticipant(undefined, "Russia"), []);
+});
 
 // Shaped like storage/chat.json: `countries` lists the NON-PLAYER participants.
 const algeriaChat = { id: "c1", title: "Algeria: Electricity Corridor Inquiry", countries: [{ code: "DZA", name: "Algeria" }] };

--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -46,6 +46,7 @@ import {
 import { UNIT_CONTRACT_MARKER, collapseRepeatedBlock, templateAlreadySays } from "./promptDedupe.js";
 import { buildJumpProjectsDirective } from "./projectsDirective.js";
 import { extractJsonPayload, unwrapMimickedToolCall } from "./jsonSalvage.js";
+import { withoutPlayerParticipant } from "./chatVisibility.js";
 import { decodeGameMasterTransportPayload, getGameplayTool, normalizeGameplayPayload, validateGameplayPayload } from "./gameplaySchemas.js";
 import { buildOwnerAliasMap, canonicalOwnerName, toCountryName } from "../../runtime/ownerNames.js";
 import {
@@ -2925,21 +2926,20 @@ const fallbackNextSpeaker = ({ chat, excludedSpeaker }) => {
 
 export const buildGeneratedChat = async (chatLike, linkEventId, world, { fallbackTitle = "", playerName = "" } = {}) => {
   const countriesInput = Array.isArray(chatLike?.countries) ? chatLike.countries : [];
-  const countries = await resolveInvitees(countriesInput, world);
+  // A chat's countries are the OTHER side; the player is implicit
+  // (chatVisibility.js). A note naming the player among them is a note to the
+  // player, and keeping them there forks a duplicate of the thread already open.
+  const countries = withoutPlayerParticipant(await resolveInvitees(countriesInput, world), playerName);
   if (countries.length === 0) return null;
 
-  // The initiating polity speaks first — and it is never the player. When the
-  // model names no speaker (or names the player), attribute the opener to the
-  // first non-player participant.
-  const playerKey = normalizeString(playerName).toUpperCase();
-  const matchesPlayer = (country) =>
-    playerKey && (normalizeString(country.name).toUpperCase() === playerKey || normalizeString(country.code).toUpperCase() === playerKey);
+  // The initiating polity speaks first — and it is never the player, who is no
+  // longer in the list. When the model names no speaker (or names the player, or
+  // someone who is not a participant), attribute the opener to the first one.
   const speakerKey = normalizeString(chatLike?.speaker).toUpperCase();
   const initiator =
     countries.find((country) =>
-      speakerKey && !matchesPlayer(country)
+      speakerKey
       && (normalizeString(country.name).toUpperCase() === speakerKey || normalizeString(country.code).toUpperCase() === speakerKey))
-    ?? countries.find((country) => !matchesPlayer(country))
     ?? countries[0];
 
   const entry = normalizeChatEntry({

--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -1308,6 +1308,24 @@ const computeSimulatedDays = (variables) => {
   return days === null ? null : Math.max(0, days);
 };
 
+// How long a task waits before re-asking a provider that refused its first
+// attempt as busy. The provider path has already retried once after 5s by then,
+// so this is the longer pause — the same 15s the providers use between their own
+// status-code retries.
+const BUSY_PROVIDER_TASK_PAUSE_MS = 15000;
+
+const abortableWait = (ms, signal) => new Promise((resolve, reject) => {
+  if (signal?.aborted) {
+    reject(signal.reason);
+    return;
+  }
+  const timer = setTimeout(resolve, ms);
+  signal?.addEventListener("abort", () => {
+    clearTimeout(timer);
+    reject(signal.reason);
+  }, { once: true });
+});
+
 const runJsonTask = async (taskKey, {
   fallback,
   signal,
@@ -1946,33 +1964,53 @@ This live instruction supersedes older frozen country-stat prompts and all earli
       // Telemetry: the record for THIS attempt comes back through the sink, so
       // the validation outcome below lands on the call that produced it.
       const attemptSink = {};
-      const response = await callAI(systemPrompt, history, {
-        // No output-token cap. A long/action-heavy turn's JSON must not be truncated
-        // mid-response — a cut-off response won't parse, so runJsonTask fell back to
-        // canned events that carry NO regionTransfers and NO diplomacy, which is why
-        // the map never changed and no chats opened. main.jsx now lets each provider
-        // use its own model maximum when no maxTokens is passed.
-        // The moment this task gives up if nothing more arrives — null while
-        // nothing has come back yet. The providers read it to decide whether a
-        // busy-retry wait still fits inside the window.
-        deadline: idle.deadline,
-        // Every network chunk of the answer restarts that window.
-        onActivity: idle.note,
-        signal: controller.signal,
-        tool,
-        // Names this call in the ai-call transport entries, so a task's own
-        // entries and the request/response pair underneath them line up.
-        logLabel: `task "${taskKey}"`,
-        // Which model answers is the task's business (Settings → Per-task models).
-        taskKey,
-        // Where the cacheable prefix of the system prompt ends — null once the
-        // prompt was rewritten past it. Anthropic pins it with an explicit
-        // cache_control block; OpenAI and Gemini cache identical prefixes on
-        // their own, so the layout alone helps them.
-        staticPrefixEnd: staticPrefixEndOf(systemPrompt, staticPromptPrefix),
-        __debug: { taskKey, attempt: outputAttempt, maxAttempts: 2, simulatedDays: computeSimulatedDays(variables) },
-        __debugSink: attemptSink,
-      });
+      let response;
+      try {
+        response = await callAI(systemPrompt, history, {
+          // No output-token cap. A long/action-heavy turn's JSON must not be truncated
+          // mid-response — a cut-off response won't parse, so runJsonTask fell back to
+          // canned events that carry NO regionTransfers and NO diplomacy, which is why
+          // the map never changed and no chats opened. main.jsx now lets each provider
+          // use its own model maximum when no maxTokens is passed.
+          // The moment this task gives up if nothing more arrives — null while
+          // nothing has come back yet. The providers read it to decide whether a
+          // busy-retry wait still fits inside the window.
+          deadline: idle.deadline,
+          // Every network chunk of the answer restarts that window.
+          onActivity: idle.note,
+          signal: controller.signal,
+          tool,
+          // Names this call in the ai-call transport entries, so a task's own
+          // entries and the request/response pair underneath them line up.
+          logLabel: `task "${taskKey}"`,
+          // Which model answers is the task's business (Settings → Per-task models).
+          taskKey,
+          // Where the cacheable prefix of the system prompt ends — null once the
+          // prompt was rewritten past it. Anthropic pins it with an explicit
+          // cache_control block; OpenAI and Gemini cache identical prefixes on
+          // their own, so the layout alone helps them.
+          staticPrefixEnd: staticPrefixEndOf(systemPrompt, staticPromptPrefix),
+          __debug: { taskKey, attempt: outputAttempt, maxAttempts: 2, simulatedDays: computeSimulatedDays(variables) },
+          __debugSink: attemptSink,
+        });
+      } catch (error) {
+        // The provider refused inside the stream and gave no answer at all
+        // (providerErrors.js toolStreamRefusalError). There is nothing to correct,
+        // so the second attempt is a plain re-ask — after a real pause when it
+        // said it was busy, since its own quick retry has already failed — and
+        // not the canned fallback. Anything else still ends the task as before.
+        if (outputAttempt !== 1 || !error?.providerRefusal || controller.signal.aborted) throw error;
+        idle.cancel();
+        failureReason = normalizeString(error.message) || failureReason;
+        const pauseMs = error.providerRefusal.busy ? BUSY_PROVIDER_TASK_PAUSE_MS : 0;
+        logDebugEvent("ai", `Task "${taskKey}" attempt 1 got no answer: the provider refused.`, {
+          provider: error.providerRefusal.detail || "(no message)",
+          busy: error.providerRefusal.busy,
+          retryInMs: pauseMs,
+        }, { verbose: true });
+        if (pauseMs) await abortableWait(pauseMs, controller.signal);
+        continue;
+      }
       // This attempt is answered: stop counting silence against it. Validation,
       // salvage and the retry's own prompt evaluation all happen with nothing on
       // the wire, and leaving the window armed across them would have attempt

--- a/src/Game/AI/gameplaySchemas.js
+++ b/src/Game/AI/gameplaySchemas.js
@@ -2862,6 +2862,24 @@ const normalizeMarkerOperationShape = (entry) => {
   return { ...entry, ...(op ? { op } : {}) };
 };
 
+// A spawned unit's `status` is a four-word enum, and its `posture` an eight-word
+// one, and models mix them up: a field report's DeepSeek jump spawned a carrier
+// with status "holding" — a posture — and that one word failed the whole month
+// to the canned fallback. A posture word written as a status moves across (when
+// no posture was given); any other unknown status is dropped, since the field is
+// optional and the engine assigns one anyway.
+const UNIT_STATUSES = new Set(unitSchema.properties.status.enum);
+const UNIT_POSTURES = new Set(unitSchema.properties.posture.enum);
+
+const normalizeUnitOperationShape = (entry) => {
+  if (!isPlainRecord(entry) || !isPlainRecord(entry.unit) || entry.unit.status === undefined) return entry;
+  const status = String(entry.unit.status ?? "").trim().toLowerCase();
+  if (UNIT_STATUSES.has(status)) return { ...entry, unit: { ...entry.unit, status } };
+  const { status: _status, ...unit } = entry.unit;
+  if (UNIT_POSTURES.has(status) && unit.posture === undefined) unit.posture = status;
+  return { ...entry, unit };
+};
+
 const PAYLOAD_IMPACT_ARRAYS = [
   "actionIds",
   "createdChats",
@@ -2930,12 +2948,29 @@ const normalizeEventShape = (entry) => {
     if (Array.isArray(impacts.markerOps)) {
       impacts.markerOps = impacts.markerOps.map(normalizeMarkerOperationShape);
     }
+    if (Array.isArray(impacts.unitOps)) {
+      impacts.unitOps = impacts.unitOps.map(normalizeUnitOperationShape);
+    }
     event.impacts = impacts;
   }
   return event;
 };
 
+// The between-rounds pulse. `chat` is an object or null, and some models say
+// "nobody writes" in words instead — "Quiet pulse — submitting no contact." — which
+// failed both attempts of the pulse on nothing but the spelling of silence. A
+// sentence there is never a usable note (it has no speaker and no countries), so
+// it reads as the null it means.
+const normalizeIdleDiplomacyShape = (value) => {
+  if (!isPlainRecord(value)) return value;
+  const candidate = { ...value };
+  if (typeof candidate.chat === "string") candidate.chat = null;
+  if (Array.isArray(candidate.unitOps)) candidate.unitOps = candidate.unitOps.map(normalizeUnitOperationShape);
+  return candidate;
+};
+
 export const normalizeGameplayPayload = (taskKey, value) => {
+  if (taskKey === "idleDiplomacy") return normalizeIdleDiplomacyShape(value);
   if (taskKey !== "jumpForward" && taskKey !== "autoJumpForward") return value;
   if (!isPlainRecord(value)) return value;
 

--- a/src/Game/AI/gameplaySchemas.js
+++ b/src/Game/AI/gameplaySchemas.js
@@ -2969,8 +2969,26 @@ const normalizeIdleDiplomacyShape = (value) => {
   return candidate;
 };
 
+// The board prompt lists every running effort as `Operation "Name" [id proj-1]`,
+// and a model reads that label as the field's name: a field report's DeepSeek
+// wrote `"id"` instead of `projectId`, which held the whole turn. The reducer has
+// always read `projectId || id` (gameState.js normalizeProjectOp); only the
+// schema refused it.
+const normalizeProjectsShape = (value) => {
+  if (!isPlainRecord(value) || !Array.isArray(value.projectOps)) return value;
+  return {
+    ...value,
+    projectOps: value.projectOps.map((entry) => {
+      if (!isPlainRecord(entry) || entry.id === undefined) return entry;
+      const { id, ...op } = entry;
+      return op.projectId === undefined ? { ...op, projectId: id } : op;
+    }),
+  };
+};
+
 export const normalizeGameplayPayload = (taskKey, value) => {
   if (taskKey === "idleDiplomacy") return normalizeIdleDiplomacyShape(value);
+  if (taskKey === "projects") return normalizeProjectsShape(value);
   if (taskKey !== "jumpForward" && taskKey !== "autoJumpForward") return value;
   if (!isPlainRecord(value)) return value;
 

--- a/src/Game/AI/jsonSalvage.js
+++ b/src/Game/AI/jsonSalvage.js
@@ -24,7 +24,46 @@ const lenientJsonParse = (value) => {
   const repaired = value
     .replace(/[“”]/g, '"')
     .replace(/,\s*([}\]])/g, "$1");
-  return maybeJsonParse(repaired);
+  return maybeJsonParse(repaired) ?? maybeJsonParse(escapeInnerQuotes(repaired));
+};
+
+// A quote copied into a string without its backslash. The board prompt titles
+// entries `Operation "Name"`, and a model copying that into its answer wrote
+// `"name":"Operation "Name""` — one unescaped pair, and the whole reply stopped
+// being JSON, which held the turn (a DeepSeek V4 Flash field report).
+//
+// Inside a string, a quote can only END it if what follows is a separator (`,`
+// `:` `}` `]`) or the end of the text; any other quote is content and gets its
+// backslash. Only reached after a strict parse AND the other repairs failed, so
+// well-formed output is never touched, and whatever this produces still has to
+// pass the schema.
+const escapeInnerQuotes = (text) => {
+  let out = "";
+  let inString = false;
+  let escaped = false;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text[i];
+    if (!inString) {
+      if (ch === '"') inString = true;
+      out += ch;
+      continue;
+    }
+    if (escaped) {
+      escaped = false;
+    } else if (ch === "\\") {
+      escaped = true;
+    } else if (ch === '"') {
+      const next = text.slice(i + 1).match(/^\s*(.?)/)[1];
+      if (next === "" || ",:}]".includes(next)) {
+        inString = false;
+      } else {
+        out += "\\\"";
+        continue;
+      }
+    }
+    out += ch;
+  }
+  return out;
 };
 
 const closersFor = (stack) => stack

--- a/src/Game/AI/jsonSalvage.test.js
+++ b/src/Game/AI/jsonSalvage.test.js
@@ -147,3 +147,25 @@ ${ANSWER_SENTINEL}
 test("the directive actually names the marker it asks for", () => {
   assert.ok(ANSWER_SENTINEL_DIRECTIVE.includes(ANSWER_SENTINEL));
 });
+
+// A DeepSeek V4 Flash field report: copying the board prompt's `Operation "Name"`
+// title into its answer left one unescaped pair of quotes, and the whole reply
+// stopped being JSON — which held the turn. Verbatim from the log.
+test("a quote copied into a string without its backslash no longer sinks the reply", () => {
+  const raw = '{"projectOps":[{"op":"update","projectId":"project-0-mtuaa589-l1rt3ud","name":"Operation "Саммит Нормандской четвёрки"","eventIndex":0,"progress":18,"lastUpdate":"Инициатива начала реализацию."}]}';
+  const parsed = extractJsonPayload(raw);
+  assert.equal(parsed?.projectOps?.[0]?.name, 'Operation "Саммит Нормандской четвёрки"');
+  assert.equal(parsed.projectOps[0].projectId, "project-0-mtuaa589-l1rt3ud");
+  assert.equal(parsed.projectOps[0].progress, 18);
+});
+
+test("a quote mid-string is content; only a quote before a separator closes the string", () => {
+  assert.deepEqual(
+    extractJsonPayload('{"note":"he called it "the plan" in public","ok":true}'),
+    { note: 'he called it "the plan" in public', ok: true },
+  );
+});
+
+test("quotes that were escaped properly are left exactly as they were", () => {
+  assert.deepEqual(extractJsonPayload('{"note":"a \\"b\\" c"}'), { note: 'a "b" c' });
+});

--- a/src/Game/AI/lenientPayloads.test.js
+++ b/src/Game/AI/lenientPayloads.test.js
@@ -1,0 +1,122 @@
+/*! Open Historia — lenient payload shape tests © 2026 Nicholas Krol, AGPL-3.0-or-later (see LICENSE). */
+// Run: node --test src/Game/AI/lenientPayloads.test.js
+//
+// One rejected field fails the WHOLE payload, and for a jump that means the
+// player's month goes to canned events. These pin the slips a real model made
+// (a DeepSeek V4 Flash field report) that normalizeGameplayPayload now absorbs,
+// and that the schema is still strict about everything else.
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeGameplayPayload, validateGameplayPayload } from "./gameplaySchemas.js";
+
+const spawnedCarrier = (unitFields = {}) => ({
+  op: "spawn",
+  unit: {
+    id: "unit-1-ru-admiral-kuznetsov",
+    name: "Адмирал Кузнецов",
+    type: "naval",
+    ownerCode: "Russian Federation",
+    strength: 85,
+    composition: "1 aircraft carrier, 2 destroyers, 3 frigates",
+    lng: 37.6176,
+    lat: 55.7558,
+    regionId: "",
+    ...unitFields,
+  },
+});
+
+const jumpWith = (unitOps) => ({
+  summary: "February 2016.",
+  stopDate: "2016-03-01",
+  clearActions: true,
+  events: [{
+    date: "2016-02-03",
+    title: "UN Security Council adopts new sanctions against North Korea.",
+    description: "Resolution 2270 bans coal exports.",
+    importance: "major",
+    kind: "world",
+    playerRelated: true,
+    notable: true,
+    tags: ["Politics", "Military"],
+    warId: "",
+    combatants: [],
+    impacts: {
+      actionIds: [],
+      regionTransfers: [],
+      polityChanges: [],
+      createdChats: [],
+      unitOps,
+      markerOps: [],
+      spyOps: [],
+      regionClaims: [],
+    },
+  }],
+  catalyst: null,
+  storylineUpdates: "",
+  warUpdates: "",
+  relationUpdates: "",
+  agreementUpdates: "",
+});
+
+const unitOf = (payload) => payload.events[0].impacts.unitOps[0].unit;
+
+test("the field-report jump: a posture written as a status no longer fails the month", () => {
+  // Exactly what the model sent: status "holding" beside posture "holding".
+  const raw = jumpWith([spawnedCarrier({ status: "holding", posture: "holding" })]);
+  assert.equal(validateGameplayPayload("jumpForward", raw).valid, false, "the raw payload is the one that failed");
+
+  const normalized = normalizeGameplayPayload("jumpForward", raw);
+  const result = validateGameplayPayload("jumpForward", normalized);
+  assert.equal(result.valid, true, result.error);
+  assert.equal("status" in unitOf(normalized), false);
+  assert.equal(unitOf(normalized).posture, "holding");
+});
+
+test("a posture word in status becomes the posture when none was given", () => {
+  const normalized = normalizeGameplayPayload("jumpForward", jumpWith([spawnedCarrier({ status: "Patrol" })]));
+  assert.equal(validateGameplayPayload("jumpForward", normalized).valid, true);
+  assert.equal(unitOf(normalized).posture, "patrol");
+});
+
+test("a posture the model did give is never overwritten by the status", () => {
+  const normalized = normalizeGameplayPayload("jumpForward", jumpWith([spawnedCarrier({ status: "transit", posture: "massing" })]));
+  assert.equal(unitOf(normalized).posture, "massing");
+  assert.equal("status" in unitOf(normalized), false);
+});
+
+test("an unknown status that is not a posture either is dropped, not guessed at", () => {
+  const normalized = normalizeGameplayPayload("jumpForward", jumpWith([spawnedCarrier({ status: "deployed" })]));
+  assert.equal(validateGameplayPayload("jumpForward", normalized).valid, true);
+  assert.equal("status" in unitOf(normalized), false);
+  assert.equal("posture" in unitOf(normalized), false);
+});
+
+test("a real status survives, only its case is tidied", () => {
+  const normalized = normalizeGameplayPayload("jumpForward", jumpWith([spawnedCarrier({ status: "Engaged" })]));
+  assert.equal(unitOf(normalized).status, "engaged");
+});
+
+test("the rest of the unit schema is as strict as before", () => {
+  const typo = normalizeGameplayPayload("jumpForward", jumpWith([spawnedCarrier({ strenght: 50 })]));
+  assert.equal(validateGameplayPayload("jumpForward", typo).valid, false, "a misspelled unit field must still be caught");
+});
+
+const pulse = (fields) => ({ chat: null, unitOps: [], sighting: null, ...fields });
+
+test("idle diplomacy: silence written as a sentence reads as silence", () => {
+  const raw = pulse({ chat: "Quiet pulse — submitting no contact." });
+  assert.equal(validateGameplayPayload("idleDiplomacy", raw).valid, false, "the raw payload is the one that failed");
+
+  const normalized = normalizeGameplayPayload("idleDiplomacy", raw);
+  assert.equal(validateGameplayPayload("idleDiplomacy", normalized).valid, true);
+  assert.equal(normalized.chat, null);
+});
+
+test("idle diplomacy: a real note is untouched, and its unit ops get the same leniency", () => {
+  const note = { speaker: "Japan", title: "A word", openingMessage: "Hello.", countries: [{ name: "Japan" }] };
+  const normalized = normalizeGameplayPayload("idleDiplomacy", pulse({ chat: note, unitOps: [spawnedCarrier({ status: "exercise" })] }));
+  assert.deepEqual(normalized.chat, note);
+  assert.equal(normalized.unitOps[0].unit.posture, "exercise");
+});

--- a/src/Game/AI/lenientPayloads.test.js
+++ b/src/Game/AI/lenientPayloads.test.js
@@ -103,6 +103,23 @@ test("the rest of the unit schema is as strict as before", () => {
   assert.equal(validateGameplayPayload("jumpForward", typo).valid, false, "a misspelled unit field must still be caught");
 });
 
+test("projects: the id the prompt shows as [id …] is accepted as projectId", () => {
+  // Verbatim shape from the field report, which held the turn.
+  const raw = { projectOps: [{ op: "update", id: "project-0-mtuaa589-l1rt3ud", name: "Саммит", eventIndex: 0, progress: 20, status: "active" }] };
+  assert.equal(validateGameplayPayload("projects", raw).valid, false, "the raw payload is the one that failed");
+
+  const normalized = normalizeGameplayPayload("projects", raw);
+  assert.equal(validateGameplayPayload("projects", normalized).valid, true);
+  assert.equal(normalized.projectOps[0].projectId, "project-0-mtuaa589-l1rt3ud");
+  assert.equal("id" in normalized.projectOps[0], false);
+});
+
+test("projects: an explicit projectId wins over a stray id", () => {
+  const normalized = normalizeGameplayPayload("projects", { projectOps: [{ op: "update", id: "wrong", projectId: "right", name: "X" }] });
+  assert.equal(normalized.projectOps[0].projectId, "right");
+  assert.equal(validateGameplayPayload("projects", normalized).valid, true);
+});
+
 const pulse = (fields) => ({ chat: null, unitOps: [], sighting: null, ...fields });
 
 test("idle diplomacy: silence written as a sentence reads as silence", () => {

--- a/src/Game/AI/main.jsx
+++ b/src/Game/AI/main.jsx
@@ -27,6 +27,7 @@ import { normalizePromptPack } from "./gameplayPrompts.js";
 import {
     busyProviderMessage,
     contextWindowMessage,
+    describeHtmlErrorPage,
     errorPayloadText,
     isBusyErrorPayload,
     isContextWindowErrorPayload,
@@ -127,11 +128,27 @@ async function readErrorPayload(response) {
 
 function extractErrorMessage(payload, fallback) {
     if (!payload) return fallback;
-    if (typeof payload === "string" && payload.trim()) return payload.trim();
+    if (typeof payload === "string" && payload.trim()) return describeHtmlErrorPage(payload, fallback) || payload.trim();
     if (payload.error?.message) return payload.error.message;
     if (payload.message) return payload.message;
-    if (typeof payload.rawText === "string" && payload.rawText.trim()) return payload.rawText.trim();
+    if (typeof payload.rawText === "string" && payload.rawText.trim()) {
+        return describeHtmlErrorPage(payload.rawText, fallback) || payload.rawText.trim();
+    }
     return fallback;
+}
+
+// The body of a reply that claimed success. A 200 carrying a web page (a gateway
+// landing page, a proxy's error screen) used to surface as JSON.parse's
+// "Unexpected token '<', "<!doctype "... is not valid JSON" — true, and no help.
+async function readJsonAnswer(response, providerLabel) {
+    const text = await response.text();
+    try {
+        return JSON.parse(text);
+    } catch (error) {
+        const page = describeHtmlErrorPage(text, `${providerLabel} request failed (${response.status})`);
+        if (page) throw new Error(page);
+        throw error;
+    }
 }
 
 // Settings (per provider): an escape hatch for request-body fields the built-in
@@ -903,7 +920,7 @@ async function callGemini(systemPrompt, history, {
         // keep working exactly as it did.
         const data = String(response.headers.get("content-type") || "").includes("text/event-stream")
             ? await readGeminiStreamedResponse(response, onActivity)
-            : await response.json();
+            : await readJsonAnswer(response, "Gemini");
         onUsage?.(data);
         if (tool) {
             const toolInput = extractGeminiToolInput(data, tool);
@@ -1229,7 +1246,7 @@ async function callOpenAIStyleChatCompletions({
         const responseType = String(response.headers.get("content-type") || "");
         const data = responseType.includes("text/event-stream")
             ? await readOpenAIStreamedResponse(response, onActivity)
-            : await response.json();
+            : await readJsonAnswer(response, providerLabel);
         onUsage?.(data);
         const text = extractOpenAIMessageText(data);
 
@@ -1612,7 +1629,7 @@ async function callAnthropic(systemPrompt, history, {
         // arrived, so an endpoint that ignored stream:true still works.
         const data = String(response.headers.get("content-type") || "").includes("text/event-stream")
             ? await readAnthropicStreamedResponse(response, onActivity)
-            : await response.json();
+            : await readJsonAnswer(response, "Anthropic");
         onUsage?.(data);
         if (tool) {
             const toolInput = extractAnthropicToolInput(data, tool);
@@ -1829,7 +1846,7 @@ async function callAnthropicCompatible(systemPrompt, history, {
         // arrived, so an endpoint that ignored stream:true still works.
         const data = String(response.headers.get("content-type") || "").includes("text/event-stream")
             ? await readAnthropicStreamedResponse(response, onActivity)
-            : await response.json();
+            : await readJsonAnswer(response, "Anthropic Compatible");
         onUsage?.(data);
         if (tool) {
             const toolInput = extractAnthropicToolInput(data, tool);

--- a/src/Game/AI/main.jsx
+++ b/src/Game/AI/main.jsx
@@ -38,6 +38,7 @@ import {
     providerErrorReplyMessage,
     retryDelayMsFromPayload,
     TOOL_CALL_INSISTENCE,
+    toolStreamRefusalError,
 } from "./providerErrors.js";
 import { ANSWER_SENTINEL_DIRECTIVE } from "./jsonSalvage.js";
 import { createModeObserver, nextStructuredMode, startingStructuredMode } from "./structuredMode.js";
@@ -923,6 +924,8 @@ async function callGemini(systemPrompt, history, {
                 await sleep(OVERLOADED_RETRY_DELAY, signal);
                 continue;
             }
+            // Still refusing: say so, rather than hand back an empty "answer".
+            if (!streamedText && streamedError) throw toolStreamRefusalError("Gemini", streamedError, retriedAfterOverload);
 
             return { rawText: streamedText, toolInput: null };
         }
@@ -1255,6 +1258,12 @@ async function callOpenAIStyleChatCompletions({
                 console.warn(`[ai] ${providerLabel} reported "${errorPayloadText(streamedError)}" mid-stream; retrying once in ${OVERLOADED_RETRY_DELAY / 1000}s`);
                 await sleep(OVERLOADED_RETRY_DELAY, signal);
                 continue;
+            }
+            // Still refusing after that retry (or no time left for one): say so,
+            // rather than hand the task an empty "answer" to spend an attempt on.
+            // A partial tool call is left to the salvage pass, as before.
+            if (!text && streamedError && !extractOpenAIToolRaw(data, tool)) {
+                throw toolStreamRefusalError(providerLabel, streamedError, retriedAfterOverload);
             }
 
             // The model talked itself out of answering: no tool call, and the text
@@ -1627,7 +1636,10 @@ async function callAnthropic(systemPrompt, history, {
                     partialChars: data.partialToolJson.length,
                 }, { verbose: true });
             }
-            return { rawText: extractAnthropicText(data), toolInput: null };
+            // Still refusing: say so, rather than hand back an empty "answer".
+            const anthropicToolText = extractAnthropicText(data);
+            if (!anthropicToolText && data?.error) throw toolStreamRefusalError("Anthropic", data.error, retriedAfterOverload);
+            return { rawText: anthropicToolText, toolInput: null };
         }
         const text = extractAnthropicText(data);
 
@@ -1843,6 +1855,8 @@ async function callAnthropicCompatible(systemPrompt, history, {
             }
 
             const anthropicText = extractAnthropicText(data);
+            // Still refusing: say so, rather than hand back an empty "answer".
+            if (!anthropicText && data?.error) throw toolStreamRefusalError("Anthropic Compatible", data.error, retriedAfterOverload);
             // No tool call, and what came back is a planning monologue rather
             // than anything a salvage pass could parse. The proxy accepted
             // tool_choice without enforcing it, so asking again more firmly

--- a/src/Game/AI/providerErrors.js
+++ b/src/Game/AI/providerErrors.js
@@ -219,6 +219,49 @@ export const toolStreamRefusalError = (providerLabel, error, retried) => {
     return refusal;
 };
 
+// A web page where an API reply should be. It means the endpoint address points
+// at a website rather than its API: a gateway's own 404 page, a login screen, a
+// proxy's error page, or — when the address has no http(s):// — the game's own
+// server answering "Cannot POST /inference.example.com/v1/chat/completions".
+//
+// The page used to become the error message verbatim. A field report's log
+// carried a 10 KB Next.js 404 page in every failed call, a dozen times over,
+// until the log had nearly spent its whole 1 MB budget on one misconfigured
+// endpoint — and the player saw a wall of markup rather than "check the address".
+//
+// Returns "" for anything that is not an HTML page, so callers fall back to
+// what they did before.
+const HTML_PAGE_START = /^\s*(?:<!--[\s\S]*?-->\s*)*<(?:!doctype\s+html|html|head|body)\b/i;
+
+const decodeBasicEntities = (text) => text
+    .replace(/&nbsp;/gi, " ")
+    .replace(/&amp;/gi, "&")
+    .replace(/&lt;/gi, "<")
+    .replace(/&gt;/gi, ">")
+    .replace(/&quot;/gi, '"')
+    .replace(/&#x27;|&#39;|&apos;/gi, "'");
+
+export const describeHtmlErrorPage = (text, fallback) => {
+    const body = String(text ?? "");
+    if (!HTML_PAGE_START.test(body)) return "";
+    // What a person would read on the page: no head (its title is usually the
+    // site's marketing line), no scripts or styles, no tags.
+    const visible = decodeBasicEntities(body
+        .replace(/<head\b[\s\S]*?<\/head>/gi, " ")
+        .replace(/<(script|style|noscript|template)\b[\s\S]*?<\/\1>/gi, " ")
+        .replace(/<[^>]+>/g, " "))
+        .replace(/\s+/g, " ")
+        .trim();
+    const title = decodeBasicEntities(body.match(/<title[^>]*>([\s\S]*?)<\/title>/i)?.[1] ?? "")
+        .replace(/\s+/g, " ")
+        .trim();
+    const quoted = (visible || title).slice(0, 160);
+    return `${fallback ? `${fallback}: ` : ""}the endpoint answered with a web page instead of an API reply`
+        + `${quoted ? ` ("${quoted}${(visible || title).length > 160 ? "…" : ""}")` : ""}. `
+        + "Check the endpoint address in Settings — it should be the provider's API base URL, "
+        + "starting with https:// and usually ending in /v1.";
+};
+
 // Did the provider reject the request because it was STREAMED (rather than for
 // anything about its content)? Tool calls stream so a long timeline jump keeps
 // the connection warm, but a few gateways refuse stream and tools together, and

--- a/src/Game/AI/providerErrors.js
+++ b/src/Game/AI/providerErrors.js
@@ -195,6 +195,30 @@ export const busyProviderMessage = (providerLabel, detail, retried) =>
 export const providerErrorReplyMessage = (providerLabel, detail) =>
     `${providerLabel} returned an error instead of a reply${detail ? `: ${detail}` : ""}.`;
 
+// A structured task asked for a tool call and got back nothing at all — no call,
+// no text — except the provider's own error inside the stream. The providers retry
+// a busy one once; if it is still refusing after that, THIS is what to throw.
+//
+// Every tool path used to return an empty answer here instead. The task runner
+// then logged the provider as having "answered" with 0 characters, told the model
+// its reply "did not contain parseable JSON", and re-sent the whole prompt at once
+// to a provider that had just said it was overloaded. A DeepSeek V4 Flash field
+// report lost two held turns and a jump to exactly that, each one following a
+// "reported ... mid-stream; retrying once" warning a few minutes earlier.
+//
+// `providerRefusal` is how the task runner tells this apart from a real failure:
+// there was no answer to correct, so it spends its second attempt re-asking — after
+// a proper pause when the provider said it was busy — rather than falling back.
+export const toolStreamRefusalError = (providerLabel, error, retried) => {
+    const detail = errorPayloadText(error);
+    const busy = isBusyErrorPayload(error);
+    const refusal = new Error(busy
+        ? busyProviderMessage(providerLabel, detail, retried)
+        : providerErrorReplyMessage(providerLabel, detail));
+    refusal.providerRefusal = { busy, detail };
+    return refusal;
+};
+
 // Did the provider reject the request because it was STREAMED (rather than for
 // anything about its content)? Tool calls stream so a long timeline jump keeps
 // the connection warm, but a few gateways refuse stream and tools together, and

--- a/src/Game/AI/providerErrors.test.js
+++ b/src/Game/AI/providerErrors.test.js
@@ -14,12 +14,49 @@ import {
   providerErrorReplyMessage,
   retryDelayMsFromPayload,
   toolStreamRefusalError,
+  describeHtmlErrorPage,
 } from "./providerErrors.js";
 import {
     contextWindowMessage,
     isContextWindowErrorPayload,
     isContextWindowErrorText,
 } from "./providerErrors.js";
+
+// Both pages are from the same field report's log, abridged. The first is a
+// gateway's own Next.js 404 (the base URL pointed at the website, not the API);
+// it went into the log verbatim, about 10 KB, on every failed call.
+const GATEWAY_404_PAGE = '<!DOCTYPE html><html lang="en" class="dark"><head><meta charSet="utf-8"/>'
+  + '<title>ModelRouter | Unified AI API and Model Catalog</title>'
+  + '<script type="application/ld+json">{"@context":"https://schema.org"}</script></head>'
+  + '<body><div class="min-h-screen"><a href="/"><span>ModelRouter</span></a><div class="text-center">'
+  + '<h1>404</h1><p>This page doesn&#x27;t exist.</p><a href="/models">Browse Models</a></div></div>'
+  + '<script>self.__next_f.push([1,"lots of framework state"])</script></body></html>';
+
+// The second: the endpoint typed without https://, so the request went to the
+// game's own server, which answered with Express's default error page.
+const MISSING_SCHEME_PAGE = '<!DOCTYPE html>\n<html lang="en">\n<head>\n<meta charset="utf-8">\n<title>Error</title>\n</head>\n'
+  + '<body>\n<pre>Cannot POST /inference.dahl.global/v1/chat/completions</pre>\n</body>\n</html>\n';
+
+test("a gateway's 404 page is summarised to what it says, with the fix, not pasted whole", () => {
+  const message = describeHtmlErrorPage(GATEWAY_404_PAGE, "OpenAI Compatible request failed (404)");
+  assert.match(message, /^OpenAI Compatible request failed \(404\): the endpoint answered with a web page/);
+  assert.match(message, /"ModelRouter 404 This page doesn't exist\. Browse Models"/);
+  assert.match(message, /Check the endpoint address in Settings/);
+  assert.doesNotMatch(message, /<|schema\.org|__next_f|Unified AI API/, "no markup, scripts or head in the message");
+  assert.ok(message.length < 400, `summary is ${message.length} chars`);
+});
+
+test("the page the game's own server sends back shows the bad address it was given", () => {
+  const message = describeHtmlErrorPage(MISSING_SCHEME_PAGE, "OpenAI Compatible request failed (404)");
+  assert.match(message, /"Cannot POST \/inference\.dahl\.global\/v1\/chat\/completions"/);
+});
+
+test("anything that is not an HTML page is left to the caller", () => {
+  assert.equal(describeHtmlErrorPage('{"error":{"message":"nope"}}', "x"), "");
+  assert.equal(describeHtmlErrorPage("Rate limit exceeded (10 RPM on free plan).", "x"), "");
+  assert.equal(describeHtmlErrorPage("", "x"), "");
+  assert.equal(describeHtmlErrorPage("error code: 502", "x"), "");
+});
 
 // A DeepSeek V4 Flash field report: a tool call refused mid-stream, retried once,
 // refused again — and the task was handed an empty "answer" that it then blamed

--- a/src/Game/AI/providerErrors.test.js
+++ b/src/Game/AI/providerErrors.test.js
@@ -13,12 +13,35 @@ import {
   looksLikeDeliberation,
   providerErrorReplyMessage,
   retryDelayMsFromPayload,
+  toolStreamRefusalError,
 } from "./providerErrors.js";
 import {
     contextWindowMessage,
     isContextWindowErrorPayload,
     isContextWindowErrorText,
 } from "./providerErrors.js";
+
+// A DeepSeek V4 Flash field report: a tool call refused mid-stream, retried once,
+// refused again — and the task was handed an empty "answer" that it then blamed
+// on the model. What the providers throw instead must say it was the provider,
+// and carry the flag the task runner reads to re-ask rather than fall back.
+test("a tool call the provider refused twice becomes a flagged busy error, not an empty answer", () => {
+  const error = toolStreamRefusalError(
+    "OpenAI Compatible",
+    { message: "An internal error occurred. Please try again later." },
+    true,
+  );
+  assert.equal(error.providerRefusal.busy, true);
+  assert.equal(error.providerRefusal.detail, "An internal error occurred. Please try again later.");
+  assert.equal(error.message, busyProviderMessage("OpenAI Compatible", "An internal error occurred. Please try again later.", true));
+  assert.match(error.message, /overloaded/);
+});
+
+test("a refusal that is not about load is quoted as the provider's error, still flagged", () => {
+  const error = toolStreamRefusalError("Gemini", { message: "Invalid argument in request." }, false);
+  assert.equal(error.providerRefusal.busy, false);
+  assert.equal(error.message, providerErrorReplyMessage("Gemini", "Invalid argument in request."));
+});
 
 // The frame that started this: an OpenAI-compatible gateway answering HTTP 200
 // and then refusing inside the stream. The advisor used to report it as "no

--- a/src/runtime/gameState.js
+++ b/src/runtime/gameState.js
@@ -1819,6 +1819,15 @@ const patchedAlias = (patch, field) => {
 // If the pre-scan that releases a completion's effects matched a different entry
 // than the applier that stamps the latch, the effects would fire for one project
 // and be marked spent on another — and the next restatement would fire them again.
+//
+// Last, the name as the prompt DISPLAYS it. The board prompt titles each entry
+// `Operation "Standing Watch"` (or `"Operation Standing Watch"` when the label is
+// already part of the name), and a model copies that whole title, label and
+// quotes — translated, even: a Russian game produced `Операция "…"`. Only tried
+// when nothing matched exactly, so a project whose real name carries quotes is
+// still found by that name first.
+const DISPLAYED_PROJECT_TITLE = /^(?:[^\s"«“„]+\s+)?["«“„](.+)["»”“]$/u;
+
 const findProjectIndexForOp = (list, op) => {
   if (op.projectId) {
     const byId = list.findIndex((project) => project.id === op.projectId);
@@ -1826,7 +1835,10 @@ const findProjectIndexForOp = (list, op) => {
   }
   if (!op.name) return -1;
   const wanted = op.name.toLowerCase();
-  return list.findIndex((project) => project.name.toLowerCase() === wanted);
+  const exact = list.findIndex((project) => project.name.toLowerCase() === wanted);
+  if (exact !== -1) return exact;
+  const bare = op.name.trim().match(DISPLAYED_PROJECT_TITLE)?.[1]?.trim().toLowerCase();
+  return bare ? list.findIndex((project) => project.name.toLowerCase() === bare) : -1;
 };
 
 // Fold a project op's owner name onto the polity it actually names, before the op

--- a/src/runtime/projectOps.test.js
+++ b/src/runtime/projectOps.test.js
@@ -78,6 +78,21 @@ test("an explicitly emptied list is still an instruction, not an omission", () =
   assert.deepEqual(applyProjectOps([before], [{ op: "create", name: before.name, tags: [] }], {})[0].tags, []);
 });
 
+// The board prompt titles entries `Operation "Name"`, and a model copies the whole
+// title — label, quotes, and in a Russian game a translated label. Without an id
+// that update used to match nothing and vanish.
+test("an op naming a project by its displayed title still finds it", () => {
+  const before = applyProjectOps([], [{ op: "create", name: "Standing Watch", kind: "operation", summary: "s" }], {})[0];
+  for (const name of ['Operation "Standing Watch"', 'Операция "Standing Watch"', 'Operation «Standing Watch»']) {
+    const after = applyProjectOps([before], [{ op: "update", name, progress: 70 }], {});
+    assert.equal(after.length, 1, name);
+    assert.equal(after[0].progress, 70, name);
+  }
+  // The label may already be part of the name, in which case the prompt quotes the whole thing.
+  const labelled = applyProjectOps([], [{ op: "create", name: "Operation Kingfisher", kind: "operation", summary: "s" }], {})[0];
+  assert.equal(applyProjectOps([labelled], [{ op: "update", name: '"Operation Kingfisher"', progress: 40 }], {})[0].progress, 40);
+});
+
 test("a genuinely new project still receives its defaults", () => {
   const fresh = applyProjectOps([], [{ op: "create", name: "Fresh", summary: "s" }], {})[0];
   assert.equal(fresh.status, "active");


### PR DESCRIPTION
## Why

A player on Modern Day (Russia, OpenAI-compatible endpoint, DeepSeek V4 Flash) sent a diagnostics log full of lost turns. Most of it was their free-tier gateway refusing requests, but in five places the game turned a provider hiccup or one wrong field into a lost or held turn when it didn't need to:

- A complete, sensible month went to canned events because **one** spawned unit had `status: "holding"`.
- The Projects & Operations step **held the turn twice**, both times because the model copied our own prompt's `Operation "Name" [id proj-1]` format literally.
- A provider that refused mid-stream was logged as having "answered with 0 characters", and the model was then told its (non-existent) answer "did not contain parseable JSON".
- A misconfigured endpoint pasted a 10 KB HTML 404 page into every error, nearly filling the log's 1 MB budget.
- A note addressed *to* the player listed the player as a participant, forking a second thread instead of landing in the one already open.

One commit per fix.

## What changed

**1. A posture written as a unit status no longer fails the whole jump** (`9cdde1e`)
`normalizeGameplayPayload` tidies spawned units before validation: a posture word in `status` moves to `posture` (if none was given), any other unknown status is dropped (the field is optional), and a real status only has its case normalised. The idle pulse's unit ops get the same treatment, and its `chat` sent as a sentence ("Quiet pulse — submitting no contact.") now reads as the `null` it means.

**2. The board no longer holds a turn over how the prompt titles a project** (`b10dbb1`)
- `id` is accepted as `projectId`. The reducer already read `projectId || id`; only the schema refused it.
- The JSON salvage pass escapes a quote inside a string unless a separator or the end of the text follows it, so `"name":"Operation "X""` parses. It only runs after a strict parse and the existing repairs have failed, and the result still has to pass the schema.
- An op naming a project by its displayed title (label and quotes, translated or not: `Операция "…"`) now finds it; the exact name is still tried first.

**3. A busy provider is reported as busy, not as a model that said nothing** (`59dd50c`)
All four tool paths (OpenAI-compatible, Gemini, Anthropic, Anthropic-compatible) returned an empty answer when the provider was still refusing after its one quick retry. They now throw `toolStreamRefusalError`, which carries the provider's own message and a `providerRefusal` flag. `runJsonTask` reads the flag on attempt 1 and re-asks without a correction message, after a 15s pause if the provider said it was busy. The task still gets its two attempts; anything else thrown ends the task exactly as before.

**4. A web page from a misconfigured endpoint is summarised, not pasted whole** (`8bf983f`)
`describeHtmlErrorPage` turns an HTML reply into one line: what the page says (visible text, capped at 160 chars) plus "check the endpoint address in Settings". It's used for error bodies (`extractErrorMessage`) and for 200 replies on all four providers (`readJsonAnswer`), which previously surfaced as `Unexpected token '<' … is not valid JSON`. Anything that isn't HTML is handled as before.

**5. A note addressed to the player no longer lists the player as a participant** (`d8e4101`)
`buildGeneratedChat`, which every generated note goes through, drops the player from the resolved participants (`withoutPlayerParticipant`, in `chatVisibility.js` next to the rule it enforces: a chat's `countries` are the other side, and the player is implicit).

## Testing

- New and extended unit tests: `lenientPayloads.test.js` (new), `jsonSalvage.test.js`, `projectOps.test.js`, `providerErrors.test.js`, `chatVisibility.test.js`. The field-report payloads are used verbatim where the log kept them.
- `npm test`: 1156 tests, 0 failures (1 skipped: the Windows network rebind test).
- `eslint` on every changed file: no errors (the only warnings are old ones on lines this PR doesn't touch).
- `vite build` succeeds.
- **Replayed through the real turn engine** with open-historia-harness, answering the game's provider calls with the report's actual failed answers (offline, no key). Every case fails on `beta` and passes here:

| Case (from the log) | `beta` | This branch |
|---|---|---|
| Jump with a unit `status: "holding"` | Month lost to canned events (same error as the log) | Month kept, carrier on the map |
| Board op using `id` | Turn held | Turn finishes, project progress updated |
| Board reply with unescaped quotes | Turn held | Turn finishes, project progress updated |
| Provider busy twice, then answers | Kept, but re-asked instantly with a false "no parseable JSON" correction | Kept; re-asked after 15s, no correction |
| Provider busy throughout | Fallback reason "did not contain parseable JSON" | Fallback reason "…is overloaded right now…" |
| Gateway 404 HTML page | Reason is 6,699 chars of markup | One 304-char line pointing at the endpoint setting |
| Same page on a 200 | `Unexpected token '<' …` | Same one-liner |
| Outreach listing the player | A second "Russian Federation + Republic of India" thread | Lands in the existing India thread |
| Idle pulse `chat` as a sentence | Rejected twice | Accepted first time |

A level-2 bug hunt on this branch and on `beta` (same seed) gives identical results.

## Not in this PR

- Batch jobs and the world breadth-repair pass validate jumps without running `normalizeGameplayPayload`, so fix 1 doesn't reach them. That was already the case before this branch.
- Everything in the report that was the player's gateway (rate limits, token allowances, card and geo refusals, free-tier concurrency) is not a game bug and isn't touched here.
