### PR TITLE
The advisor drawer stops before it covers the HUD, moves the HUD with it, and sits under open panels

### DIFF
--- a/src/Game/GameUI/advisor.jsx
+++ b/src/Game/GameUI/advisor.jsx
@@ -1176,7 +1176,7 @@ const AdvisorPanel = ({ isAdvisorOpen, mapRef, onClose, width, onResize, onResiz
             // Full height now the in-game top bar is gone — it used to stop 64px
             // (the old BAR_HEIGHT) short of the top to clear it. Anchored bottom: 0
             // above, so height: 100vh reaches the top edge.
-            width: typeof width === "number" ? `${width}px` : ADVISOR_PANEL_WIDTH, height: "100vh",
+            width: width || ADVISOR_PANEL_WIDTH, height: "100vh",
             backgroundColor: "rgba(24, 24, 27, 0.95)", backdropFilter: "blur(8px)",
             // Above every HUD button/panel (toolbar 9999, forces 10000,
             // library panels 10031) so nothing covers the open drawer on

--- a/src/Game/GameUI/advisor.jsx
+++ b/src/Game/GameUI/advisor.jsx
@@ -805,7 +805,7 @@ const AdvisorMessageList = React.memo(({ messages, isLoading, chatDiffers, chatD
     </div>
 ));
 
-const AdvisorPanel = ({ isAdvisorOpen, mapRef, onClose, width, onResize, onOpenActions, onOpenProjects, requestedPrompt, onConsumeRequest }) => {
+const AdvisorPanel = ({ isAdvisorOpen, mapRef, onClose, width, onResize, onResizingChange, onOpenActions, onOpenProjects, requestedPrompt, onConsumeRequest }) => {
     const [messages, setMessages]   = useState([]);
     const [input, setInput]         = useState("");
     const [isLoading, setIsLoading] = useState(false);
@@ -838,17 +838,19 @@ const AdvisorPanel = ({ isAdvisorOpen, mapRef, onClose, width, onResize, onOpenA
 
     // Drag the drawer's left edge to resize it. The panel is docked right, so the
     // new width is simply (viewport width − pointer x); the parent (main.jsx) clamps
-    // and persists it. Pointer capture keeps the drag alive if the cursor leaves the
-    // 10px handle. Works for mouse, touch and pen.
+    // it, and persists it when told the drag is over. Pointer capture keeps the drag
+    // alive if the cursor leaves the 10px handle. Works for mouse, touch and pen.
     const handleResizeStart = React.useCallback((e) => {
         if (typeof onResize !== "function") return;
         e.preventDefault();
         const target = e.currentTarget;
         try { target.setPointerCapture(e.pointerId); } catch { /* not fatal */ }
         setIsResizing(true);
+        onResizingChange?.(true);
         const onMove = (ev) => onResize(window.innerWidth - ev.clientX);
         const onUp = () => {
             setIsResizing(false);
+            onResizingChange?.(false);
             target.removeEventListener("pointermove", onMove);
             target.removeEventListener("pointerup", onUp);
             target.removeEventListener("pointercancel", onUp);
@@ -856,7 +858,7 @@ const AdvisorPanel = ({ isAdvisorOpen, mapRef, onClose, width, onResize, onOpenA
         target.addEventListener("pointermove", onMove);
         target.addEventListener("pointerup", onUp);
         target.addEventListener("pointercancel", onUp);
-    }, [onResize]);
+    }, [onResize, onResizingChange]);
     // A reply already in the chat language must skip the UI translator, which
     // would render it back into the interface language.
     const chatDiffers = chatLanguageDiffersFromUi();

--- a/src/Game/GameUI/advisor.jsx
+++ b/src/Game/GameUI/advisor.jsx
@@ -6,6 +6,7 @@ import { requestDiplomaticChat } from "./chat.jsx";
 import { JSON_URLS, readJson, writeJson } from "../../runtime/assets.js";
 import { formatReportFields, logDebugEvent } from "../../runtime/debugLog.js";
 import { useFailureReportButton } from "../../runtime/saveDebugLog.js";
+import { useIsMobile } from "../../runtime/useIsMobile.js";
 import { chatLanguageDiffersFromUi, isRtlLanguage, resolveChatLanguage } from "../../runtime/i18n.js";
 import { applyProjectOpsToWorld, normalizeActionEntry, readActionsState, readWorldState, writeActionsState, writeWorldState } from "../../runtime/gameState.js";
 import { extractFencedJson, looksLikeProjectOps } from "./advisorBlocks.js";
@@ -835,6 +836,7 @@ const AdvisorPanel = ({ isAdvisorOpen, mapRef, onClose, width, onResize, onResiz
     const inputRef = useRef(null);
     const [isResizing, setIsResizing] = useState(false);
     const [handleHover, setHandleHover] = useState(false);
+    const isMobile = useIsMobile();
 
     // Drag the drawer's left edge to resize it. The panel is docked right, so the
     // new width is simply (viewport width − pointer x); the parent (main.jsx) clamps
@@ -1178,10 +1180,14 @@ const AdvisorPanel = ({ isAdvisorOpen, mapRef, onClose, width, onResize, onResiz
             // above, so height: 100vh reaches the top edge.
             width: width || ADVISOR_PANEL_WIDTH, height: "100vh",
             backgroundColor: "rgba(24, 24, 27, 0.95)", backdropFilter: "blur(8px)",
-            // Above every HUD button/panel (toolbar 9999, forces 10000,
-            // library panels 10031) so nothing covers the open drawer on
-            // phones; below the editor (10050) and server-down (10060) overlays.
-            zIndex: 10040, borderLeft: "1px solid rgba(255,255,255,0.1)",
+            // Phones: above every HUD button/panel (toolbar 9999, forces 10000,
+            // library panels 10031) so nothing covers the near-full-width
+            // drawer; below the editor (10050) and server-down (10060) overlays.
+            // Desktop: the drawer can be dragged wide, so it sits under every
+            // HUD button, panel and menu (9998 and up: Actions, Projects,
+            // diplomacy chat, timeline panels, settings) and over only the map
+            // and the session pill (9996).
+            zIndex: isMobile ? 10040 : 9997, borderLeft: "1px solid rgba(255,255,255,0.1)",
             boxShadow: "-4px 0 24px rgba(0,0,0,0.4)",
             transition: "transform 0.35s cubic-bezier(0.4, 0, 0.2, 1)",
             display: "flex", flexDirection: "column",

--- a/src/Game/GameUI/advisor.jsx
+++ b/src/Game/GameUI/advisor.jsx
@@ -11,6 +11,7 @@ import { chatLanguageDiffersFromUi, isRtlLanguage, resolveChatLanguage } from ".
 import { applyProjectOpsToWorld, normalizeActionEntry, readActionsState, readWorldState, writeActionsState, writeWorldState } from "../../runtime/gameState.js";
 import { extractFencedJson, looksLikeProjectOps } from "./advisorBlocks.js";
 import { buildMessageDrafts, splitAtBlockquotes } from "./advisorDrafts.js";
+import { ADVISOR_SLIDE } from "./advisorSlide.js";
 import Markdown, { MarkdownStyleInjector } from "./markdown.jsx";
 import StatsPane from "./stats.jsx";
 
@@ -806,7 +807,7 @@ const AdvisorMessageList = React.memo(({ messages, isLoading, chatDiffers, chatD
     </div>
 ));
 
-const AdvisorPanel = ({ isAdvisorOpen, mapRef, onClose, width, onResize, onResizingChange, onOpenActions, onOpenProjects, requestedPrompt, onConsumeRequest }) => {
+const AdvisorPanel = ({ isAdvisorOpen, mapRef, onClose, width, onResize, onResizeEnd, onOpenActions, onOpenProjects, requestedPrompt, onConsumeRequest }) => {
     const [messages, setMessages]   = useState([]);
     const [input, setInput]         = useState("");
     const [isLoading, setIsLoading] = useState(false);
@@ -848,11 +849,10 @@ const AdvisorPanel = ({ isAdvisorOpen, mapRef, onClose, width, onResize, onResiz
         const target = e.currentTarget;
         try { target.setPointerCapture(e.pointerId); } catch { /* not fatal */ }
         setIsResizing(true);
-        onResizingChange?.(true);
         const onMove = (ev) => onResize(window.innerWidth - ev.clientX);
         const onUp = () => {
             setIsResizing(false);
-            onResizingChange?.(false);
+            onResizeEnd?.();
             target.removeEventListener("pointermove", onMove);
             target.removeEventListener("pointerup", onUp);
             target.removeEventListener("pointercancel", onUp);
@@ -860,7 +860,7 @@ const AdvisorPanel = ({ isAdvisorOpen, mapRef, onClose, width, onResize, onResiz
         target.addEventListener("pointermove", onMove);
         target.addEventListener("pointerup", onUp);
         target.addEventListener("pointercancel", onUp);
-    }, [onResize, onResizingChange]);
+    }, [onResize, onResizeEnd]);
     // A reply already in the chat language must skip the UI translator, which
     // would render it back into the interface language.
     const chatDiffers = chatLanguageDiffersFromUi();
@@ -1174,7 +1174,10 @@ const AdvisorPanel = ({ isAdvisorOpen, mapRef, onClose, width, onResize, onResiz
             // Slide via transform: the old right: calc(-min(...) - 1rem) was
             // INVALID CSS (a min() can't be negated like that), so the closed
             // position was silently dropped and the drawer never slid away.
-            transform: isAdvisorOpen ? "translateX(0)" : "translateX(calc(100% + 2rem))",
+            // Closed, it sits exactly its own width off-screen: the HUD beside it
+            // slides that same distance (main.jsx), so they move as one. The
+            // shadow, which would show past the edge, fades out with it instead.
+            transform: isAdvisorOpen ? "translateX(0)" : "translateX(100%)",
             // Full height now the in-game top bar is gone — it used to stop 64px
             // (the old BAR_HEIGHT) short of the top to clear it. Anchored bottom: 0
             // above, so height: 100vh reaches the top edge.
@@ -1188,8 +1191,8 @@ const AdvisorPanel = ({ isAdvisorOpen, mapRef, onClose, width, onResize, onResiz
             // diplomacy chat, timeline panels, settings) and over only the map
             // and the session pill (9996).
             zIndex: isMobile ? 10040 : 9997, borderLeft: "1px solid rgba(255,255,255,0.1)",
-            boxShadow: "-4px 0 24px rgba(0,0,0,0.4)",
-            transition: "transform 0.35s cubic-bezier(0.4, 0, 0.2, 1)",
+            boxShadow: isAdvisorOpen ? "-4px 0 24px rgba(0,0,0,0.4)" : "none",
+            transition: `transform ${ADVISOR_SLIDE}, box-shadow ${ADVISOR_SLIDE}`,
             display: "flex", flexDirection: "column",
             color: "white", fontFamily: "sans-serif", overflow: "hidden",
         }}>

--- a/src/Game/GameUI/advisorSlide.js
+++ b/src/Game/GameUI/advisorSlide.js
@@ -1,0 +1,5 @@
+// How the advisor drawer slides open and shut. The HUD beside it (the date
+// widget, flag badge and advisor button, placed by main.jsx) slides with this
+// same duration and easing over the same distance, so the two move as one.
+// Its own module so main.jsx can share it without loading the lazy advisor chunk.
+export const ADVISOR_SLIDE = "0.35s cubic-bezier(0.4, 0, 0.2, 1)";

--- a/src/Game/GameUI/libraryBar.jsx
+++ b/src/Game/GameUI/libraryBar.jsx
@@ -2048,7 +2048,8 @@ const LibraryTopBar = () => {
           remains is a compact floating cluster beside the ⋮ settings button: a
           small sleek pill with the session summary, plus Exit Game.
           Below the settings menu and date widget (z 9998/9999) so opening
-          either covers it instead of the other way around. */}
+          either covers it instead of the other way around, and below the
+          desktop advisor drawer (9997) so a wide drawer covers it too. */}
       {!menuOpen && !isMobile && (
         <div
           style={{
@@ -2059,7 +2060,7 @@ const LibraryTopBar = () => {
             left: "5rem",
             position: "fixed",
             top: "0.5rem",
-            zIndex: 9997,
+            zIndex: 9996,
           }}
         >
           <div

--- a/src/Game/GameUI/main.jsx
+++ b/src/Game/GameUI/main.jsx
@@ -154,7 +154,7 @@ const AdvisorDockIcon = () => (
   </svg>
 );
 
-const AdvisorButton = ({ isAdvisorOpen, rightShift, onToggle }) => (
+const AdvisorButton = ({ isAdvisorOpen, rightShift, rightShiftTransition, onToggle }) => (
   <button
     type="button"
     title="Advisor"
@@ -168,7 +168,7 @@ const AdvisorButton = ({ isAdvisorOpen, rightShift, onToggle }) => (
       background: isAdvisorOpen
         ? "linear-gradient(180deg, rgba(91,155,255,0.22), rgba(59,130,246,0.12))"
         : "linear-gradient(180deg, rgba(53,53,58,0.58), rgba(17,17,19,0.48))",
-      transition: "right 0.35s cubic-bezier(0.4, 0, 0.2, 1), background 0.15s ease",
+      transition: `${rightShiftTransition}, background 0.15s ease`,
     }}
   >
     <AdvisorDockIcon />
@@ -192,6 +192,7 @@ const Main = ({
   const [shouldLoadDebugConsole, setShouldLoadDebugConsole] = useState(false);
   const [isAdvisorOpen, setIsAdvisorOpen] = useState(false);
   const [advisorWidth, setAdvisorWidth] = useState(readAdvisorWidth);
+  const [isAdvisorResizing, setIsAdvisorResizing] = useState(false);
   // A starter message queued for the advisor's input box — set when something
   // OUTSIDE the advisor panel (the Actions panel's "Help brainstorm actions"
   // button) opens it wanting to prime the conversation, rather than opening it
@@ -362,8 +363,14 @@ const Main = ({
 
   // Called on every pointermove while the user drags the advisor's edge.
   const handleAdvisorResize = useCallback((px) => {
-    setAdvisorWidth(() => {
-      const w = clampAdvisorWidth(px);
+    setAdvisorWidth(clampAdvisorWidth(px));
+  }, []);
+
+  // The width is saved once, when the drag ends, rather than on every move.
+  const handleAdvisorResizingChange = useCallback((resizing) => {
+    setIsAdvisorResizing(resizing);
+    if (resizing) return;
+    setAdvisorWidth((w) => {
       try { localStorage.setItem("oh-advisor-width", String(w)); } catch { /* ignore */ }
       return w;
     });
@@ -377,6 +384,10 @@ const Main = ({
   }, []);
 
   const rightShift = isAdvisorOpen ? `calc(${advisorWidth}px + 0.5rem)` : "0.5rem";
+  // The HUD beside the drawer eases along when it opens or closes, but follows
+  // a drag instantly: an eased follow restarts on every pointermove, so the
+  // widgets trail the pointer by the length of the animation.
+  const rightShiftTransition = `right ${isAdvisorResizing ? "0s" : "0.35s"} cubic-bezier(0.4, 0, 0.2, 1)`;
   const toggleBottomPanel = useCallback((panelName) => {
     setActiveBottomPanel((currentPanel) => (
       currentPanel === panelName ? null : panelName
@@ -393,6 +404,7 @@ const Main = ({
         onSetPanel={setActiveBottomPanel}
         onTogglePanel={toggleBottomPanel}
         rightShift={rightShift}
+        rightShiftTransition={rightShiftTransition}
         topOffset={TOP_BAR_OFFSET}
       />
       <Toolbar
@@ -401,7 +413,7 @@ const Main = ({
         onTogglePanel={toggleBottomPanel}
         mapRef={mapRef}
       />
-      <Other rightShift={rightShift} />
+      <Other rightShift={rightShift} rightShiftTransition={rightShiftTransition} />
       <Search mapRef={mapRef} />
       <ForcesPanel
         mapRef={mapRef}
@@ -412,6 +424,7 @@ const Main = ({
       <AdvisorButton
         isAdvisorOpen={isAdvisorOpen}
         rightShift={rightShift}
+        rightShiftTransition={rightShiftTransition}
         onToggle={() => setIsAdvisorOpen(!isAdvisorOpen)}
       />
       <Suspense fallback={null}>
@@ -422,6 +435,7 @@ const Main = ({
             onClose={() => setIsAdvisorOpen(false)}
             width={advisorWidth}
             onResize={handleAdvisorResize}
+            onResizingChange={handleAdvisorResizingChange}
             onOpenActions={() => setActiveBottomPanel("actions")}
             onOpenProjects={() => setActiveBottomPanel("projects")}
             requestedPrompt={pendingAdvisorPrompt}

--- a/src/Game/GameUI/main.jsx
+++ b/src/Game/GameUI/main.jsx
@@ -13,6 +13,7 @@ import { Other } from "./other";
 import { Toolbar } from "./chat";
 import { Search } from "./search";
 import { ForcesPanel } from "./forces";
+import { ADVISOR_SLIDE } from "./advisorSlide.js";
 import { logDebugEvent } from "../../runtime/debugLog.js";
 import {
   describeProviderSetupNeed,
@@ -155,7 +156,7 @@ const AdvisorDockIcon = () => (
   </svg>
 );
 
-const AdvisorButton = ({ isAdvisorOpen, rightShift, rightShiftTransition, onToggle }) => (
+const AdvisorButton = ({ isAdvisorOpen, dockStyle, onToggle }) => (
   <button
     type="button"
     title="Advisor"
@@ -163,7 +164,8 @@ const AdvisorButton = ({ isAdvisorOpen, rightShift, rightShiftTransition, onTogg
     onClick={onToggle}
     style={{
       ...baseStyle,
-      bottom: "0.5rem", right: rightShift,
+      ...dockStyle,
+      bottom: "0.5rem",
       // Rides beside the advisor drawer, so a wide drawer carries it over the
       // Actions/Projects/chat panels (9998); an open panel stays on top.
       zIndex: 9997,
@@ -172,7 +174,7 @@ const AdvisorButton = ({ isAdvisorOpen, rightShift, rightShiftTransition, onTogg
       background: isAdvisorOpen
         ? "linear-gradient(180deg, rgba(91,155,255,0.22), rgba(59,130,246,0.12))"
         : "linear-gradient(180deg, rgba(53,53,58,0.58), rgba(17,17,19,0.48))",
-      transition: `${rightShiftTransition}, background 0.15s ease`,
+      transition: `${dockStyle.transition}, background 0.15s ease`,
     }}
   >
     <AdvisorDockIcon />
@@ -196,7 +198,6 @@ const Main = ({
   const [shouldLoadDebugConsole, setShouldLoadDebugConsole] = useState(false);
   const [isAdvisorOpen, setIsAdvisorOpen] = useState(false);
   const [advisorWidth, setAdvisorWidth] = useState(readAdvisorWidth);
-  const [isAdvisorResizing, setIsAdvisorResizing] = useState(false);
   // A starter message queued for the advisor's input box — set when something
   // OUTSIDE the advisor panel (the Actions panel's "Help brainstorm actions"
   // button) opens it wanting to prime the conversation, rather than opening it
@@ -384,14 +385,12 @@ const Main = ({
     document.documentElement.style.setProperty(ADVISOR_WIDTH_VAR, `${w}px`);
   }, []);
 
-  // Committed and saved once, when the drag ends. The state lands in the same
-  // render that turns the HUD's easing back on, and the variable already holds
+  // Committed and saved once, when the drag ends. The variable already holds
   // it, so nothing moves on release.
-  const handleAdvisorResizingChange = useCallback((resizing) => {
-    setIsAdvisorResizing(resizing);
+  const handleAdvisorResizeEnd = useCallback(() => {
     const w = draggedAdvisorWidthRef.current;
     draggedAdvisorWidthRef.current = null;
-    if (resizing || w === null) return;
+    if (w === null) return;
     setAdvisorWidth(w);
     try { localStorage.setItem("oh-advisor-width", String(w)); } catch { /* ignore */ }
   }, []);
@@ -404,11 +403,19 @@ const Main = ({
   }, []);
 
   const advisorCssWidth = `var(${ADVISOR_WIDTH_VAR}, ${advisorWidth}px)`;
-  const rightShift = isAdvisorOpen ? `calc(${advisorCssWidth} + 0.5rem)` : "0.5rem";
-  // The HUD beside the drawer eases along when it opens or closes, but follows
-  // a drag instantly: an eased follow restarts on every pointermove, so the
-  // widgets trail the pointer by the length of the animation.
-  const rightShiftTransition = `right ${isAdvisorResizing ? "0s" : "0.35s"} cubic-bezier(0.4, 0, 0.2, 1)`;
+  // Where the HUD beside the drawer (date widget, flag, advisor button) sits.
+  // It is always placed at the drawer's edge, and pushed back to the screen
+  // edge while the drawer is shut by the same transform the drawer uses: the
+  // same distance (the drawer's width), duration and easing, started in the
+  // same frame and run by the compositor, so opening and closing move them as
+  // one. A drag changes only the width, which `right` follows with no
+  // transition at all. (Easing `right` instead made the HUD cover less
+  // distance than the drawer in the same time, on the busy main thread.)
+  const advisorDockStyle = useMemo(() => ({
+    right: `calc(${advisorCssWidth} + 0.5rem)`,
+    transform: isAdvisorOpen ? "none" : `translateX(${advisorCssWidth})`,
+    transition: `transform ${ADVISOR_SLIDE}`,
+  }), [advisorCssWidth, isAdvisorOpen]);
   const toggleBottomPanel = useCallback((panelName) => {
     setActiveBottomPanel((currentPanel) => (
       currentPanel === panelName ? null : panelName
@@ -424,8 +431,7 @@ const Main = ({
         mapRef={mapRef}
         onSetPanel={setActiveBottomPanel}
         onTogglePanel={toggleBottomPanel}
-        rightShift={rightShift}
-        rightShiftTransition={rightShiftTransition}
+        dockStyle={advisorDockStyle}
         topOffset={TOP_BAR_OFFSET}
       />
       <Toolbar
@@ -434,7 +440,7 @@ const Main = ({
         onTogglePanel={toggleBottomPanel}
         mapRef={mapRef}
       />
-      <Other rightShift={rightShift} rightShiftTransition={rightShiftTransition} />
+      <Other dockStyle={advisorDockStyle} />
       <Search mapRef={mapRef} />
       <ForcesPanel
         mapRef={mapRef}
@@ -444,8 +450,7 @@ const Main = ({
       />
       <AdvisorButton
         isAdvisorOpen={isAdvisorOpen}
-        rightShift={rightShift}
-        rightShiftTransition={rightShiftTransition}
+        dockStyle={advisorDockStyle}
         onToggle={() => setIsAdvisorOpen(!isAdvisorOpen)}
       />
       <Suspense fallback={null}>
@@ -456,7 +461,7 @@ const Main = ({
             onClose={() => setIsAdvisorOpen(false)}
             width={advisorCssWidth}
             onResize={handleAdvisorResize}
-            onResizingChange={handleAdvisorResizingChange}
+            onResizeEnd={handleAdvisorResizeEnd}
             onOpenActions={() => setActiveBottomPanel("actions")}
             onOpenProjects={() => setActiveBottomPanel("projects")}
             requestedPrompt={pendingAdvisorPrompt}

--- a/src/Game/GameUI/main.jsx
+++ b/src/Game/GameUI/main.jsx
@@ -1,5 +1,5 @@
 /*! Open Historia — portions (mobile HUD wiring + advisor/forces launchers) © 2026 Nicholas Krol, AGPL-3.0-or-later (see LICENSE). */
-import React, { Suspense, lazy, useCallback, useEffect, useMemo, useState } from "react";
+import React, { Suspense, lazy, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { GenerationRatingToast } from "./generationRatingToast.jsx";
 import { SettingsButton, SettingsMenu } from "./settings";
 import { Presence } from "./presence.jsx";
@@ -30,6 +30,7 @@ import {
 // Width is kept in px so the drag maps 1:1 to the pointer, persisted in
 // localStorage, and clamped to a readable min and a max that keeps the HUD
 // in view.
+const ADVISOR_WIDTH_VAR = "--oh-advisor-width";
 const ADVISOR_MIN_WIDTH = 280;
 const ADVISOR_DEFAULT_WIDTH = 320; // 20rem, the old fixed width
 // The drawer may cover the map but not the HUD on its left. The tightest fit is
@@ -361,19 +362,35 @@ const Main = ({
     if (typeof seedPrompt === "string" && seedPrompt) setPendingAdvisorPrompt(seedPrompt);
   }, []);
 
+  // The drawer's width and the offset of the HUD beside it both read one CSS
+  // variable, so they are always laid out from the same number in the same
+  // frame. React state holds the width at rest; a drag writes the variable
+  // directly and commits to state when it ends, so no pointermove re-renders
+  // the game UI.
+  useLayoutEffect(() => {
+    document.documentElement.style.setProperty(ADVISOR_WIDTH_VAR, `${advisorWidth}px`);
+  }, [advisorWidth]);
+
+  // The width the current drag has reached, committed when it ends.
+  const draggedAdvisorWidthRef = useRef(null);
+
   // Called on every pointermove while the user drags the advisor's edge.
   const handleAdvisorResize = useCallback((px) => {
-    setAdvisorWidth(clampAdvisorWidth(px));
+    const w = clampAdvisorWidth(px);
+    draggedAdvisorWidthRef.current = w;
+    document.documentElement.style.setProperty(ADVISOR_WIDTH_VAR, `${w}px`);
   }, []);
 
-  // The width is saved once, when the drag ends, rather than on every move.
+  // Committed and saved once, when the drag ends. The state lands in the same
+  // render that turns the HUD's easing back on, and the variable already holds
+  // it, so nothing moves on release.
   const handleAdvisorResizingChange = useCallback((resizing) => {
     setIsAdvisorResizing(resizing);
-    if (resizing) return;
-    setAdvisorWidth((w) => {
-      try { localStorage.setItem("oh-advisor-width", String(w)); } catch { /* ignore */ }
-      return w;
-    });
+    const w = draggedAdvisorWidthRef.current;
+    draggedAdvisorWidthRef.current = null;
+    if (resizing || w === null) return;
+    setAdvisorWidth(w);
+    try { localStorage.setItem("oh-advisor-width", String(w)); } catch { /* ignore */ }
   }, []);
 
   // Keep the saved width valid if the window shrinks below it.
@@ -383,7 +400,8 @@ const Main = ({
     return () => window.removeEventListener("resize", onResize);
   }, []);
 
-  const rightShift = isAdvisorOpen ? `calc(${advisorWidth}px + 0.5rem)` : "0.5rem";
+  const advisorCssWidth = `var(${ADVISOR_WIDTH_VAR}, ${advisorWidth}px)`;
+  const rightShift = isAdvisorOpen ? `calc(${advisorCssWidth} + 0.5rem)` : "0.5rem";
   // The HUD beside the drawer eases along when it opens or closes, but follows
   // a drag instantly: an eased follow restarts on every pointermove, so the
   // widgets trail the pointer by the length of the animation.
@@ -433,7 +451,7 @@ const Main = ({
             isAdvisorOpen={isAdvisorOpen}
             mapRef={mapRef}
             onClose={() => setIsAdvisorOpen(false)}
-            width={advisorWidth}
+            width={advisorCssWidth}
             onResize={handleAdvisorResize}
             onResizingChange={handleAdvisorResizingChange}
             onOpenActions={() => setActiveBottomPanel("actions")}

--- a/src/Game/GameUI/main.jsx
+++ b/src/Game/GameUI/main.jsx
@@ -28,11 +28,25 @@ import {
 
 // The advisor drawer is user-resizable — drag its left edge (see advisor.jsx).
 // Width is kept in px so the drag maps 1:1 to the pointer, persisted in
-// localStorage, and clamped to a readable min and the current viewport.
+// localStorage, and clamped to a readable min and a max that keeps the HUD
+// in view.
 const ADVISOR_MIN_WIDTH = 280;
 const ADVISOR_DEFAULT_WIDTH = 320; // 20rem, the old fixed width
+// The drawer may cover the map but not the HUD on its left. The tightest fit is
+// the top edge: the 18rem date widget moves left with the drawer and must stop
+// short of the 4rem game-menu button at 0.5rem. 0.5 + 4 + 0.5 gap + 18 + 0.5 =
+// 23.5rem, which also clears the bottom-left toolbar and search button.
+const ADVISOR_LEFT_CLEARANCE_REM = 23.5;
 const clampAdvisorWidth = (px) => {
-  const max = (typeof window !== "undefined" ? window.innerWidth : 1280) - 16;
+  const viewport = typeof window !== "undefined" ? window.innerWidth : 1280;
+  const rem = typeof document !== "undefined"
+    ? parseFloat(getComputedStyle(document.documentElement).fontSize) || 16
+    : 16;
+  // A window too narrow to leave that room (a phone) still gets the default width.
+  const max = Math.max(
+    viewport - ADVISOR_LEFT_CLEARANCE_REM * rem,
+    Math.min(ADVISOR_DEFAULT_WIDTH, viewport - 16),
+  );
   return Math.round(Math.min(Math.max(px, Math.min(ADVISOR_MIN_WIDTH, max)), max));
 };
 const readAdvisorWidth = () => {

--- a/src/Game/GameUI/main.jsx
+++ b/src/Game/GameUI/main.jsx
@@ -164,6 +164,9 @@ const AdvisorButton = ({ isAdvisorOpen, rightShift, rightShiftTransition, onTogg
     style={{
       ...baseStyle,
       bottom: "0.5rem", right: rightShift,
+      // Rides beside the advisor drawer, so a wide drawer carries it over the
+      // Actions/Projects/chat panels (9998); an open panel stays on top.
+      zIndex: 9997,
       height: "4rem", width: "4rem",
       cursor: "pointer", fontSize: "1.5rem",
       background: isAdvisorOpen

--- a/src/Game/GameUI/other.jsx
+++ b/src/Game/GameUI/other.jsx
@@ -49,11 +49,10 @@ const FallbackBadge = ({ label }) => (
     </div>
 );
 
-const Other = memo(function Other({
-    rightShift = "0.5rem",
-    rightShiftTransition = "right 0.35s cubic-bezier(0.4, 0, 0.2, 1)",
-    embedded = false,
-}) {
+// dockStyle places the standalone badge beside the advisor drawer (main.jsx).
+const DEFAULT_DOCK_STYLE = { right: "0.5rem" };
+
+const Other = memo(function Other({ dockStyle = DEFAULT_DOCK_STYLE, embedded = false }) {
     const { activeGame } = useLibraryState();
     const activeGameId = String(activeGame?.id || "");
     const activeGameCountry = String(activeGame?.country || "").trim();
@@ -175,8 +174,8 @@ const Other = memo(function Other({
             overflow: "hidden",
         } : {
             ...baseStyle,
+            ...dockStyle,
             bottom: "4.75rem",
-            right: rightShift,
             // Rides beside the advisor drawer, so a wide drawer carries it over
             // the Actions/Projects/chat panels (9998); an open panel stays on top.
             zIndex: 9997,
@@ -184,7 +183,6 @@ const Other = memo(function Other({
             width: "2.75rem",
             padding: "0.35rem",
             boxSizing: "border-box",
-            transition: rightShiftTransition,
             overflow: "hidden",
         }}
         >

--- a/src/Game/GameUI/other.jsx
+++ b/src/Game/GameUI/other.jsx
@@ -177,6 +177,9 @@ const Other = memo(function Other({
             ...baseStyle,
             bottom: "4.75rem",
             right: rightShift,
+            // Rides beside the advisor drawer, so a wide drawer carries it over
+            // the Actions/Projects/chat panels (9998); an open panel stays on top.
+            zIndex: 9997,
             height: "2.75rem",
             width: "2.75rem",
             padding: "0.35rem",

--- a/src/Game/GameUI/other.jsx
+++ b/src/Game/GameUI/other.jsx
@@ -49,7 +49,11 @@ const FallbackBadge = ({ label }) => (
     </div>
 );
 
-const Other = memo(function Other({ rightShift = "0.5rem", embedded = false }) {
+const Other = memo(function Other({
+    rightShift = "0.5rem",
+    rightShiftTransition = "right 0.35s cubic-bezier(0.4, 0, 0.2, 1)",
+    embedded = false,
+}) {
     const { activeGame } = useLibraryState();
     const activeGameId = String(activeGame?.id || "");
     const activeGameCountry = String(activeGame?.country || "").trim();
@@ -177,7 +181,7 @@ const Other = memo(function Other({ rightShift = "0.5rem", embedded = false }) {
             width: "2.75rem",
             padding: "0.35rem",
             boxSizing: "border-box",
-            transition: "right 0.35s cubic-bezier(0.4, 0, 0.2, 1)",
+            transition: rightShiftTransition,
             overflow: "hidden",
         }}
         >

--- a/src/Game/GameUI/time.jsx
+++ b/src/Game/GameUI/time.jsx
@@ -177,7 +177,6 @@ const widgetSurface = {
     justifyContent: "center",
     padding: "0 0.5rem",
     position: "fixed",
-    transition: "right 0.35s cubic-bezier(0.4, 0, 0.2, 1)",
     width: "min(18rem, calc(100vw - 0.9rem))",
     zIndex: 9999,
 };
@@ -1520,8 +1519,9 @@ const DateWidget = ({
     mapRef,
     onSetPanel = null,
     onTogglePanel = null,
-    rightShift,
-    rightShiftTransition = widgetSurface.transition,
+    // Places the widget beside the advisor drawer: right, transform and
+    // transition (main.jsx).
+    dockStyle = null,
     topOffset = "0.5rem",
 }) => {
     const [gameData, setGameData] = useState(null);
@@ -2383,8 +2383,7 @@ const DateWidget = ({
         <div
         style={{
             ...widgetSurface,
-            right: rightShift,
-            transition: rightShiftTransition,
+            ...dockStyle,
             top: topOffset,
             // The player's country sits beside the date. On phones the standalone
             // pill would cover the date, so stretch the widget; on desktop cap the

--- a/src/Game/GameUI/time.jsx
+++ b/src/Game/GameUI/time.jsx
@@ -1521,6 +1521,7 @@ const DateWidget = ({
     onSetPanel = null,
     onTogglePanel = null,
     rightShift,
+    rightShiftTransition = widgetSurface.transition,
     topOffset = "0.5rem",
 }) => {
     const [gameData, setGameData] = useState(null);
@@ -2383,6 +2384,7 @@ const DateWidget = ({
         style={{
             ...widgetSurface,
             right: rightShift,
+            transition: rightShiftTransition,
             top: topOffset,
             // The player's country sits beside the date. On phones the standalone
             // pill would cover the date, so stretch the widget; on desktop cap the


### PR DESCRIPTION
Three problems with the resizable advisor drawer, all visible once it is dragged wide.

### 1. It could be dragged over the HUD
The drawer could be dragged to 16px from the left edge of the window. The date widget and flag ride beside it, so a wide drawer pushed the date widget off-screen and covered the toolbar, the search button and the game-menu button.

It now stops with 23.5rem left on its left: the date widget stops just short of the game-menu button, and the bottom-left toolbar and search stay clear. A window too narrow for that (a phone) still gets the default 320px, and a width saved wider than the new limit is clamped on load.

At the widest setting the session pill and Exit Game are covered. They already sat under the date widget by design, and the game can still be left from the ☰ menu.

### 2. The profile button, flag and date widget trailed the drawer
- **While dragging:** each of them eased its `right` offset over 0.35s, so every pointermove restarted an ease and they trailed the pointer, sliding under the drawer. The drawer's width and their offset now read one CSS variable (`--oh-advisor-width`), written directly on each pointermove. So they are laid out from the same number in the same frame, and a drag no longer re-renders the game UI. The width goes into React state and localStorage once, on release.
- **Opening and closing:** the drawer slid its width plus 2rem with a GPU transform, while the HUD eased `right` over only the drawer's width, on the main thread, in the same 0.35s. So the HUD covered less distance in the same time and fell behind. The HUD now always sits at the drawer's edge and is pushed back to the screen edge by the same transform as the drawer: same distance, duration and easing (`ADVISOR_SLIDE`, shared by both). The drawer now slides exactly its own width, and its shadow fades out as it closes.

### 3. A wide drawer hid the panels
The drawer sat at z-index 10040, above everything, so it covers the screen on phones. On desktop that hid the Actions, Projects, diplomacy chat and timeline panels (9998) whenever they opened beside a wide drawer.
- On desktop the drawer now sits at 9997: under every HUD button, panel and menu, and over the map. Phones keep 10040.
- The session pill moves to 9996, so the drawer still covers it.
- The flag badge and the advisor button move from 9999 to 9997, so an open panel covers them too.
- Diplomatic notifications (10050) and the country panel (10042) were already above the drawer and are unchanged.

### Testing
- `npm test`: 1173 pass, 0 fail, 1 skip (the usual Windows baseline). `npm run build` passes, and lint shows only existing warnings.
- Driven in the web build in headless Edge, with painted frames recorded while the drawer was dragged both ways, opened and closed, at normal speed and with the CPU throttled 4×. The gap between the drawer's edge and the advisor button is the same in every frame, and the flag and date widget each stay exactly 8px from the edge on every frame of an open. Before the fix, a steady drag left the widgets 450–660px under the drawer, and the gap on opening ran from 28px down to 12px.
- Checked with the drawer at full width: Actions, Projects, Diplomacy/Spy and Timeline each open on top of it, and the menu button, date widget, toolbar, search, flag and advisor button all stay visible.
