### PR TITLE
Prompts carry the simulation rules once, not twice

### DIFF
--- a/docs/ai-prompts.md
+++ b/docs/ai-prompts.md
@@ -402,6 +402,7 @@ Jump payloads also carry a top-level `diplomaticOutreach[]` (same shape as `crea
 ## 10. Gotchas
 
 - **`worldSummary` and `worldSummaryNoCity` are the same string** — the "no city" name is historical; city coordinates are a separate `citiesSummary`/`${CITY_COORDINATES}`.
+- **`worldSummary` embeds the briefing and the simulation rules**, so a prompt that also renders `${WORLD_BEFORE_ROUND_ONE_TEXT}` or `${HISTORICAL_PRESET_SIMULATION_RULES}` would send them twice. `collapseRepeatedWorldContext` (`promptDedupe.js`) keeps the first copy of each and swaps later copies for a pointer; `runJsonTask` applies it to every task and `main.jsx` to the advisor and leader prompts. Values under 400 characters are left alone. Don't strip them from the summary instead: `actions` and `idleDiplomacy` see the rules only there, and saves carry frozen prompts.
 - **Two output attempts per task**, then a deterministic fallback (or throw). `finalAttempt` comes from `runJsonTask`, never from counting validator calls — attempt-1 schema failures skip `validatePayload` entirely (`gameplay.js:464` comment).
 - **Reputation and military-feasibility reach only the task path** (`buildTemplateVariables`). Advisor/leader use `buildPromptContext` directly and never see them.
 - **`catalystSummary` contains stray embedded "Game Master" text** (§7.9) — the actual GM task is `gameMaster`.

--- a/src/Game/AI/gameplay.js
+++ b/src/Game/AI/gameplay.js
@@ -43,7 +43,7 @@ import {
   planJumpSegments,
   segmentEventRange,
 } from "./jumpSegments.js";
-import { UNIT_CONTRACT_MARKER, collapseRepeatedBlock, templateAlreadySays } from "./promptDedupe.js";
+import { UNIT_CONTRACT_MARKER, collapseRepeatedWorldContext, templateAlreadySays } from "./promptDedupe.js";
 import { buildJumpProjectsDirective } from "./projectsDirective.js";
 import { extractJsonPayload, unwrapMimickedToolCall } from "./jsonSalvage.js";
 import { withoutPlayerParticipant } from "./chatVisibility.js";
@@ -1869,17 +1869,14 @@ This live instruction supersedes older frozen country-stat prompts and all earli
     systemPrompt = `${systemPrompt}\n\n${buildSpyOrdersDirective(normalizeString(variables?.playerPolity) || "the player")}`;
   }
 
-  // The scenario briefing arrives twice on eight of the sixteen prompts: once
-  // from the task text's own placeholder and again inside the world summary.
-  // On a real campaign that is ~108k characters sent twice, about a third of a
-  // jump prompt. Collapsed here rather than in the templates because existing
-  // saves carry frozen copies, and two tasks reach the briefing ONLY through the
-  // world summary - removing it there would take it from them entirely.
-  systemPrompt = collapseRepeatedBlock(
-    systemPrompt,
-    variables?.worldBeforeRoundOne,
-    "(The pre-round-one briefing is reproduced in full earlier in this prompt.)",
-  );
+  // The scenario briefing and simulation rules each arrive twice on most
+  // prompts: once from the task text's own placeholder and again inside the
+  // world summary. On a real campaign the briefing alone is ~108k characters
+  // sent twice, about a third of a jump prompt. Collapsed here rather than in
+  // the templates because existing saves carry frozen copies, and some tasks
+  // reach them ONLY through the world summary - removing them there would take
+  // them from those tasks entirely.
+  systemPrompt = collapseRepeatedWorldContext(systemPrompt, variables);
 
   // Batch routing (see the parameter): a deferred task leaves here with no
   // answer and no attempt loop; its result arrives through pollPendingBatches.

--- a/src/Game/AI/main.jsx
+++ b/src/Game/AI/main.jsx
@@ -52,6 +52,7 @@ import {
     renderTemplate,
     resolveHelperValues,
 } from "./promptContext.js";
+import { collapseRepeatedWorldContext } from "./promptDedupe.js";
 import { filterChatsVisibleTo, isChatVisibleTo } from "./chatVisibility.js";
 import { foreignAgentBrief } from "../../runtime/spycraft.js";
 
@@ -2306,7 +2307,12 @@ async function buildAdvisorSystemPrompt() {
     });
     const helperValues = resolveHelperValues(promptPack.helpers, variables);
 
-    const rendered = renderTemplate(promptPack.advisor, { ...variables, ...helperValues });
+    // The briefing and the rules also ride inside the world summary; keep one
+    // copy of each, as runJsonTask does for the gameplay tasks.
+    const rendered = collapseRepeatedWorldContext(
+        renderTemplate(promptPack.advisor, { ...variables, ...helperValues }),
+        variables,
+    );
     // The forces directive is beta-only — promptContext leaves forcePosture empty
     // in the classic system rather than paying for the territory index, so the
     // heading would introduce a section with nothing under it.
@@ -2384,8 +2390,14 @@ export async function buildDiplomaticSystemPrompt(countries, playerCountry, spea
     const agent = foreignAgentBrief(worldData, speakingAs, { playerPolity: playerCountry || gameData?.country || "", material: stolen });
     const espionage = agent ? "\n\n[Your Intelligence]\n" + agent : "";
 
+    // One copy each of the briefing and the rules (see buildAdvisorSystemPrompt).
+    const rendered = collapseRepeatedWorldContext(
+        renderTemplate(promptPack.leader, { ...variables, ...helperValues }),
+        variables,
+    );
+
     // Leaders negotiate as softly or ruthlessly as the chosen difficulty.
-    return `${renderTemplate(promptPack.leader, { ...variables, ...helperValues })}${espionage}\n\n${difficultyDirective(gameData?.difficulty)}`;
+    return `${rendered}${espionage}\n\n${difficultyDirective(gameData?.difficulty)}`;
 }
 
 let advisorHistory = [];

--- a/src/Game/AI/promptDedupe.js
+++ b/src/Game/AI/promptDedupe.js
@@ -91,3 +91,24 @@ export const collapseRepeatedBlock = (prompt, block, pointer) => {
     const tail = text.slice(first + needle.length).split(needle).join(String(pointer ?? ""));
     return head + tail;
 };
+
+// The scenario's simulation rules take the same two routes: the task text
+// renders ${HISTORICAL_PRESET_SIMULATION_RULES}, and buildWorldSummary embeds
+// them on its "Simulation rules:" line. Eleven prompts render both, the advisor
+// and the diplomatic chat among them. Two tasks (actions, idleDiplomacy) reach
+// the rules ONLY through the world summary, so the same reasoning as the
+// briefing applies: collapse after assembly, never strip them from the summary.
+
+export const BRIEFING_POINTER = "(The pre-round-one briefing is reproduced in full earlier in this prompt.)";
+export const SIMULATION_RULES_POINTER = "(The scenario's simulation rules are reproduced in full earlier in this prompt.)";
+
+/**
+ * Collapse every repeat of the briefing and the simulation rules in an
+ * assembled prompt. `variables` is the prompt's template variables; a missing
+ * or short value leaves the prompt as it was.
+ */
+export const collapseRepeatedWorldContext = (prompt, variables) => collapseRepeatedBlock(
+    collapseRepeatedBlock(prompt, variables?.worldBeforeRoundOne, BRIEFING_POINTER),
+    variables?.simulationRules,
+    SIMULATION_RULES_POINTER,
+);

--- a/src/Game/AI/promptDedupe.test.js
+++ b/src/Game/AI/promptDedupe.test.js
@@ -14,7 +14,9 @@ import assert from "node:assert/strict";
 import {
   DEDUPE_MIN_BLOCK_CHARS,
   UNIT_CONTRACT_MARKER,
+  SIMULATION_RULES_POINTER,
   collapseRepeatedBlock,
+  collapseRepeatedWorldContext,
   templateAlreadySays,
 } from "./promptDedupe.js";
 import defaultPrompts from "./defaultPrompts.json" with { type: "json" };
@@ -129,4 +131,91 @@ test("a short repeated string is left alone", () => {
   assert.ok(placeholder.length < DEDUPE_MIN_BLOCK_CHARS);
   const prompt = `A ${placeholder} B ${placeholder} C`;
   assert.equal(collapseRepeatedBlock(prompt, placeholder, POINTER), prompt);
+});
+
+// ---------------------------------------------------------------------------
+// The briefing and the simulation rules, across every bundled prompt
+//
+// Field report: the Pre-Game History prompt pasted the simulation rules twice,
+// once under its own heading and again inside ${GRAND_MAP_DESCRIPTION_NO_CITY}.
+
+const RULES = `No nuclear weapons exist. ${"Colonial borders follow the 1914 settlement. ".repeat(12)}`;
+
+// Built the way buildWorldSummary (promptContext.js) embeds both.
+const worldSummary = [
+  "Player polity: France",
+  `World before round one: ${BRIEFING}`,
+  `Simulation rules: ${RULES}`,
+  "",
+  "Map ownership:",
+  "- France: Brittany, Normandy",
+].join("\n");
+
+const VARIABLES = {
+  playerPolity: "France",
+  simulationRules: RULES,
+  worldBeforeRoundOne: BRIEFING,
+  worldSummary,
+  worldSummaryNoCity: worldSummary,
+};
+
+// resolveHelperValues and renderTemplate, without promptContext.js's imports.
+const renderBundled = (template) => {
+  const fill = (text, values) => String(text).replace(/\$\{([^}]+)\}/g, (_match, key) => values[key] ?? "");
+  let helpers = {};
+  for (let pass = 0; pass < 2; pass += 1) {
+    helpers = Object.fromEntries(Object.entries(defaultPrompts.helpers)
+      .map(([key, text]) => [key, fill(text, { ...VARIABLES, ...helpers })]));
+  }
+  return fill(template, { ...VARIABLES, ...helpers });
+};
+
+const countOf = (text, block) => text.split(block.trim()).length - 1;
+
+const BUNDLED_PROMPTS = {
+  advisor: defaultPrompts.advisor,
+  leader: defaultPrompts.leader,
+  ...defaultPrompts.tasks,
+};
+
+test("the rules pasted under their own heading and in the world summary collapse to one", () => {
+  const prompt = `Simulation rules for this world:\n${RULES}\n\nThe current political map:\n${worldSummary}`;
+  const out = collapseRepeatedWorldContext(prompt, VARIABLES);
+  assert.equal(countOf(out, RULES), 1);
+  assert.equal(countOf(out, BRIEFING), 1);
+  assert.ok(out.includes(`Simulation rules: ${SIMULATION_RULES_POINTER}`));
+  // The copy under the prompt's own heading is the one that survives.
+  assert.ok(out.startsWith(`Simulation rules for this world:\n${RULES}`));
+});
+
+test("every bundled prompt carries the rules and the briefing at most once", () => {
+  for (const [key, template] of Object.entries(BUNDLED_PROMPTS)) {
+    const rendered = renderBundled(template);
+    const out = collapseRepeatedWorldContext(rendered, VARIABLES);
+    for (const [name, block] of [["rules", RULES], ["briefing", BRIEFING]]) {
+      // Collapsing may never take away the only copy a prompt had.
+      assert.equal(countOf(out, block), Math.min(countOf(rendered, block), 1), `${key}: ${name}`);
+    }
+  }
+});
+
+// The report's prompt, and the two tasks that see the rules only through the
+// world summary: the first must lose its repeat, the others must keep theirs.
+test("pre-game history loses the repeat, and the summary-only tasks keep their copy", () => {
+  const pregame = renderBundled(defaultPrompts.tasks.pregameHistory);
+  assert.equal(countOf(pregame, RULES), 2, "the bundled pre-game prompt no longer repeats the rules");
+  assert.equal(countOf(collapseRepeatedWorldContext(pregame, VARIABLES), RULES), 1);
+  for (const key of ["actions", "idleDiplomacy"]) {
+    const rendered = renderBundled(defaultPrompts.tasks[key]);
+    assert.equal(countOf(rendered, RULES), 1, `${key} now renders the rules on its own`);
+    assert.equal(collapseRepeatedWorldContext(rendered, VARIABLES), rendered);
+  }
+});
+
+// A lazily built task may not construct simulationRules at all; with nothing to
+// match, the prompt goes out as rendered.
+test("missing variables leave the prompt untouched", () => {
+  const prompt = `${RULES}\n${worldSummary}`;
+  assert.equal(collapseRepeatedWorldContext(prompt, {}), prompt);
+  assert.equal(collapseRepeatedWorldContext(prompt, null), prompt);
 });


### PR DESCRIPTION
Reported against the Pre-Game History prompt: the simulation rules appeared under their own heading and again inside `${GRAND_MAP_DESCRIPTION_NO_CITY}`.

## Why it happened

`buildWorldSummary` embeds both the scenario briefing (`World before round one:`) and the simulation rules (`Simulation rules:`). `GRAND_MAP_DESCRIPTION` and `GRAND_MAP_DESCRIPTION_NO_CITY` are that same string. So every prompt that renders the map text and also its own `${HISTORICAL_PRESET_SIMULATION_RULES}` section sent the rules twice. In the bundled pack that is eleven prompts.

`runJsonTask` already collapsed a repeated briefing: it keeps the first copy and replaces later ones with a short pointer. The rules never got the same treatment. The advisor and diplomatic chat prompts are built in `main.jsx` and never went through `runJsonTask`, so they sent **both** the rules and the full briefing twice.

## The fix

- `collapseRepeatedWorldContext` in `promptDedupe.js` collapses repeats of both the briefing and the rules.
- `runJsonTask` uses it in place of the briefing-only collapse.
- `buildAdvisorSystemPrompt` and `buildDiplomaticSystemPrompt` now use it too.
- The copy under the prompt's own heading is the one kept. The map text's line becomes `Simulation rules: (The scenario's simulation rules are reproduced in full earlier in this prompt.)`.

I didn't remove the rules from the world summary or edit the templates. `actions` and `idleDiplomacy` see the rules only through the world summary, and saves carry frozen prompt copies. Either change would have dropped the rules from some prompts or missed existing campaigns. Collapsing after the prompt is assembled fixes every save and can't remove a prompt's only copy. Values under 400 characters are still left alone, as before.

## Testing

- `npm test`: 0 failures, 1 skip (the usual network test on Windows). `npm run build` passes.
- New tests in `promptDedupe.test.js` render every bundled prompt with map text built the way `buildWorldSummary` builds it. Each prompt must carry the rules and the briefing exactly once if it had them, and `actions`/`idleDiplomacy` must keep their only copy.
- In the harness, I captured the real prompts the engine builds, with a stand-in provider that refuses every call. I used a save with a 107,870-character briefing plus a fresh game, and a 1,311-character rules text added to the sandbox copies:

| Prompt | Rules / briefing copies before | After |
|---|---|---|
| pregameHistory, descriptionToAction, gameMaster, jumpForward | 2 / 1 | 1 / 1 |
| advisor, leader | 2 / 2 | 1 / 1 |
| actions, idleDiplomacy | 1 / 1 | 1 / 1 |

Prompt size on that save:
- Advisor: 437,618 → 328,591 characters (−25%, roughly 27k fewer input tokens per message).
- Chat: 365,905 → 256,878 characters (−30%).
- Every other affected prompt shrinks by the length of the rules.

An offline level-1 harness hunt on the branch found nothing.
