### PR TITLE
Country picker on coarse geometry; hub proxy allows GitHub's attachment hosts, bounds and retries a hop

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -658,8 +658,38 @@ const HUB_DOWNLOAD_HOSTS = new Set([
   "objects.githubusercontent.com",
   "user-images.githubusercontent.com",
   "user-attachments.githubusercontent.com",
+  // GitHub serves issue attachments from these two after the github.com hop:
+  // private-user-images for signed-in previews, the S3 bucket for
+  // /user-attachments/assets/. Without them every flag image and pack "redirected
+  // off GitHub".
+  "private-user-images.githubusercontent.com",
+  "github-production-user-asset-6210df.s3.amazonaws.com",
 ]);
 const HUB_MAX_BUNDLE_BYTES = 200 * 1024 * 1024;
+
+// One hop of a hub download. fetch() has no timeout of its own, so a connection
+// that never opens — an IPv6 route that blackholes, a proxy that drops the SYN —
+// held the request until the OS gave up (ETIMEDOUT, twenty-odd seconds on
+// Windows) and the player saw "fetch failed (ETIMEDOUT)" for a pack that was
+// fine a minute earlier. Each hop is bounded generously (bundles run to tens of
+// megabytes on slow links) and a transport failure is retried once before it
+// is reported; an HTTP error is never retried.
+const HUB_HOP_TIMEOUT_MS = 120_000;
+const HUB_TRANSIENT_CODES = new Set([
+  "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "EAI_AGAIN", "EPIPE",
+  "UND_ERR_CONNECT_TIMEOUT", "UND_ERR_SOCKET", "TimeoutError",
+]);
+const fetchHubHop = async (url) => {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return await fetch(url, { redirect: "manual", signal: AbortSignal.timeout(HUB_HOP_TIMEOUT_MS) });
+    } catch (error) {
+      const code = error?.cause?.code || error?.code || error?.name || "";
+      if (attempt >= 1 || !HUB_TRANSIENT_CODES.has(code)) throw error;
+      await new Promise((resolve) => setTimeout(resolve, 750));
+    }
+  }
+};
 
 // This route echoes a file that ANY member of the public can attach to a hub
 // issue, and it serves it from the game's OWN origin. Without these two headers a
@@ -762,7 +792,7 @@ app.get("/api/hub/file", async (req, res) => {
       if (hop > 5) {
         return sendError(res, 502, new Error("Too many redirects fetching scenario file."));
       }
-      upstream = await fetch(current, { redirect: "manual" });
+      upstream = await fetchHubHop(current);
       if (upstream.status < 300 || upstream.status >= 400) break;
       const location = upstream.headers.get("location");
       if (!location) break;

--- a/src/Game/GameUI/CountryPickerMap.jsx
+++ b/src/Game/GameUI/CountryPickerMap.jsx
@@ -3,7 +3,7 @@ import Map from "ol/Map";
 import View from "ol/View";
 import TileLayer from "ol/layer/Tile";
 import XYZ from "ol/source/XYZ";
-import VectorLayer from "ol/layer/Vector";
+import VectorImageLayer from "ol/layer/VectorImage";
 import VectorSource from "ol/source/Vector";
 import Style from "ol/style/Style";
 import Fill from "ol/style/Fill";
@@ -11,8 +11,9 @@ import Stroke from "ol/style/Stroke";
 import GeoJSON from "ol/format/GeoJSON";
 import { fromLonLat } from "ol/proj";
 import { defaults as defaultControls } from "ol/control/defaults";
-import { loadSeedFeatures } from "../../Editor/regionImport.js";
 import { flagEmojiFromGid } from "../../runtime/countryFlags.js";
+import { loadRegionLabelGeometry } from "../../runtime/countryLabels.js";
+import { toCountryName } from "../../runtime/ownerNames.js";
 
 const codeToColor = (code) => {
   let h = 0;
@@ -51,7 +52,11 @@ const applyOwnerOverrides = (features, overrides) => {
   return features;
 };
 
-const parseGeoJSONFeatures = (geojson) => {
+// The picker never zooms past 8, where a pixel is ~600 m: geometry finer
+// than a couple of kilometres is invisible here and only costs the draw.
+const PICKER_SIMPLIFY_TOLERANCE_M = 2000;
+
+const parseGeoJSONFeatures = (geojson, { stock = false } = {}) => {
   const fmt = new GeoJSON();
   const features = fmt.readFeatures(geojson, {
     dataProjection: "EPSG:4326",
@@ -60,8 +65,13 @@ const parseGeoJSONFeatures = (geojson) => {
   for (const feature of features) {
     const props = feature.getProperties();
     if (props.id != null) feature.setId(String(props.id));
-    if (feature.get("owner") == null) feature.set("owner", props.gid0 || props.owner || null);
+    // The stock tile carries the modern country as `owner`; resolve it from the
+    // GADM code the way the seed did, so the playable set matches by name.
+    if (stock) feature.set("owner", toCountryName(props.gid0) || props.owner || null);
+    else if (feature.get("owner") == null) feature.set("owner", props.gid0 || props.owner || null);
     if (feature.get("typeId") == null) feature.set("typeId", "land");
+    const geometry = feature.getGeometry();
+    if (!stock && geometry?.simplify) feature.setGeometry(geometry.simplify(PICKER_SIMPLIFY_TOLERANCE_M));
   }
   return features;
 };
@@ -123,8 +133,20 @@ const CountryPickerMap = ({
 
   // One-time map + layer creation
   useEffect(() => {
-    const source = new VectorSource();
-    const layer = new VectorLayer({ source });
+    // wrapX:false, as the editor found the hard way (OlMap.jsx): the canvas
+    // renderer otherwise repeats the world sideways and redraws EVERY region for
+    // each copy, two or three times per frame at this zoom. VectorImage
+    // rasterises the regions once and re-blits while panning; a hover or a pick
+    // re-rasterises, which on the coarse geometry is cheap.
+    const source = new VectorSource({ wrapX: false });
+    const layer = new VectorImageLayer({
+      source,
+      imageRatio: 2,
+      wrapX: false,
+      renderBuffer: 128,
+      updateWhileInteracting: false,
+      updateWhileAnimating: false,
+    });
     layerRef.current = layer;
     sourceRef.current = source;
 
@@ -136,6 +158,7 @@ const CountryPickerMap = ({
           source: new XYZ({
             url: "https://server.arcgisonline.com/ArcGIS/rest/services/Canvas/World_Dark_Gray_Base/MapServer/tile/{z}/{y}/{x}",
             maxZoom: 16,
+            wrapX: false,
           }),
         }),
         layer,
@@ -263,17 +286,22 @@ const CountryPickerMap = ({
     }
   }, [regionsGeojson, ownerOverrides]);
 
-  // Load seed features on mount (after regionsGeojson is checked above)
+  // The stock world, from the z0 tile of the regions archive: ~15k vertices in
+  // a few hundred kilobytes, the same geometry the game's own labels use and
+  // already cached once they have. This used to fetch and parse the 55 MB
+  // full-resolution seed — tens of seconds, for a map the size of a card.
   useEffect(() => {
     const source = sourceRef.current;
     if (!source) return;
     if (regionsGeojson) return; // custom data already loaded above
     let cancelled = false;
-    loadSeedFeatures()
-      .then((features) => {
-        // The seed is the shared stock world, so overriding owners on it is what
-        // turns "present-day Earth" into this scenario's map.
-        if (!cancelled) source.addFeatures(applyOwnerOverrides(features, ownerOverrides));
+    loadRegionLabelGeometry()
+      .then((collection) => {
+        if (cancelled || !collection?.features?.length) return;
+        // The stock world is the shared modern one, so overriding owners on it
+        // is what turns "present-day Earth" into this scenario's map.
+        const features = parseGeoJSONFeatures(collection, { stock: true });
+        source.addFeatures(applyOwnerOverrides(features, ownerOverrides));
       })
       .catch(() => {});
     return () => { cancelled = true; };


### PR DESCRIPTION
Two fixes from the field reports, both already on `beta`.

**Country picker (new game, faction creator).** It fetched and parsed the 55 MB full-resolution seed and painted every vertex through a VectorLayer that also repeated the world sideways, for a map the size of a card. It now uses the z0 tile of the regions archive for the stock world (~15k vertices, already cached by the game's labels), simplifies a scenario's own geometry to two kilometres (a pixel is ~600 m at its deepest zoom), draws through a VectorImage layer that rasterises once and re-blits while panning, and turns off wrapX. Ported from beta, where it has been in use since 6 September; measured there on the 4,848-region hand-drawn world: no long tasks on open or during a hover sweep.

**Hub file proxy.** GitHub now serves issue attachments from an S3 bucket and signed-in previews from `private-user-images.githubusercontent.com` after the `github.com` hop; neither host was on the allowlist, so every community flag image and flag pack was refused as "redirected off GitHub". Both hosts are allowed now (beta already had them). Each hop is also bounded, and a transport failure such as ETIMEDOUT or ECONNRESET is retried once before it is reported; HTTP errors are never retried.

Tests: 249 pass; client builds.
